### PR TITLE
Add a random seed to Compiler to help with testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ prj/
 .idea/
 .gradle/
 !gradle-wrapper.jar
+TAGS

--- a/javatools/src/main/java/org/xvm/tool/Compiler.java
+++ b/javatools/src/main/java/org/xvm/tool/Compiler.java
@@ -77,6 +77,7 @@ import org.xvm.util.Severity;
  * <li>{@code -strict} - convert warnings to errors</li>
  * <li>{@code -nowarn} - suppress warnings</li>
  * <li>{@code -verbose} - provide information about the work being done by the compilation process</li>
+ * <li>{@code -seed=n} - set the random seed to n</li>
  * </ul>
  */
 public class Compiler
@@ -558,6 +559,7 @@ public class Compiler
             addOption("o",       Form.File,   false, "File or directory to write output to");
             addOption("qualify", Form.Name,   false, "Use full module name for the output file name");
             addOption("version", Form.String, false, "Use full module name for the output file name");
+            addOption("seed",    Form.Int,    false, "Set the internal compiler random seed for testing purposes");
             addOption(Trailing,  Form.File,   true , "Source file name(s) and/or module location(s) to"
                                                  + " compile");
             }

--- a/javatools/src/main/java/org/xvm/tool/Launcher.java
+++ b/javatools/src/main/java/org/xvm/tool/Launcher.java
@@ -662,6 +662,14 @@ public abstract class Launcher
             }
 
         /**
+          * @return the seed for psuedo-random
+          */
+        public int seed()
+            {
+              return values().get("seed") instanceof Integer i ? i : 0;
+            }
+
+        /**
          * Parse the command line arguments into
          *
          * @param asArgs  the command line arguments to parse
@@ -2229,6 +2237,13 @@ public abstract class Launcher
         {
         File[] aFile = dir.listFiles();
         Arrays.sort(aFile, Comparator.comparing(File::getName));
+        // Psuedo random shuffle files, in an effort to trigger bugs
+        int seed = options().seed();
+        if( seed!=0 ) System.err.println("Compiling with seed="+seed);
+        for( int i=0; i<aFile.length; i++ ) {
+          int j = (i+seed)%aFile.length;
+          File tmp = aFile[i];  aFile[i] = aFile[j];  aFile[j] = tmp; // Swap i and j
+        }
         return aFile;
         }
 

--- a/xdk/build.gradle.kts
+++ b/xdk/build.gradle.kts
@@ -48,6 +48,7 @@ val bridgeLib       = "$javaDir/javatools_bridge.xtc"
 
 val distDir         = "$buildDir/dist"
 
+val seed            = "" // -seed=N to change the random seed, or blank ("") for no seed
 val xdkVersion      = rootProject.version
 var distName        = xdkVersion
 val isCI            = System.getenv("CI")
@@ -105,7 +106,7 @@ val compileEcstasy = tasks.register<JavaExec>("compileEcstasy") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "$ecstasyMain/x/ecstasy.x",
          "$turtleMain/x/mack.x")
@@ -129,7 +130,7 @@ val compileAggregate = tasks.register<JavaExec>("compileAggregate") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -148,7 +149,7 @@ val compileCollections = tasks.register<JavaExec>("compileCollections") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -167,7 +168,7 @@ val compileCrypto = tasks.register<JavaExec>("compileCrypto") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -186,7 +187,7 @@ val compileNet  = tasks.register<JavaExec>("compileNet") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -206,7 +207,7 @@ val compileJson = tasks.register<JavaExec>("compileJson") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -225,7 +226,7 @@ val compileOODB = tasks.register<JavaExec>("compileOODB") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -244,7 +245,7 @@ val compileIMDB = tasks.register<JavaExec>("compileIMDB") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -264,7 +265,7 @@ val compileJsonDB = tasks.register<JavaExec>("compileJsonDB") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -284,7 +285,7 @@ val compileWeb  = tasks.register<JavaExec>("compileWeb") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -304,7 +305,7 @@ val compileWebauth = tasks.register<JavaExec>("compileWebauth") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -324,7 +325,7 @@ val compileXenia = tasks.register<JavaExec>("compileXenia") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",
@@ -344,7 +345,7 @@ val compileBridge = tasks.register<JavaExec>("compileBridge") {
     jvmArgs("-Xms1024m", "-Xmx1024m", "-ea")
 
     classpath(javatoolsJar)
-    args("-o", "$libDir",
+    args("-o", "$libDir", "$seed",
          "-version", "$xdkVersion",
          "-L", "$coreLib",
          "-L", "$turtleLib",


### PR DESCRIPTION
Currently only shuffles the file visitation order.
In the future, could shuffle any collection order where the final compiler results are invariant.
Added compiler option "-seed=N". Defaults to 0 seed and no shuffle if missing.
