### PR TITLE
Upgrade Gradle build action to v2.4.2 to avoid future situation were we are vulnerable to Github configuration cache security issue for automated builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,6 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
       - name: Execute Gradle build
         run: ./gradlew build --info


### PR DESCRIPTION
Upgrade Gradle build action to v2.4.2 to avoid future situation were we are vulnerable to Github configuration cache security issue for automated builds