### PR TITLE
Add XDK Dockerfile

### DIFF
--- a/xdk/Dockerfile
+++ b/xdk/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:17-slim as Builder
+
+RUN mkdir -p /tmp && mv ${JAVA_HOME} /tmp/jdk
+
+FROM node:18.17.1-slim
+
+ENV JAVA_HOME=/usr/local/jdk
+ENV ECSTASY_HOME=/xqiz.it
+ENV PATH $ECSTASY_HOME/bin:$JAVA_HOME/bin:$PATH
+
+COPY --from=builder /tmp/jdk ${JAVA_HOME}
+COPY build/xdk/ $ECSTASY_HOME/libexec/
+
+RUN mkdir -p $ECSTASY_HOME/bin \
+    && ln -s $ECSTASY_HOME/libexec/bin/linux_launcher $ECSTASY_HOME/bin/xec \
+    && ln -s $ECSTASY_HOME/libexec/bin/linux_launcher $ECSTASY_HOME/bin/xtc \
+    && ln -s $ECSTASY_HOME/libexec/bin/linux_launcher $ECSTASY_HOME/bin/xam
+
+

--- a/xdk/Dockerfile
+++ b/xdk/Dockerfile
@@ -16,4 +16,5 @@ RUN mkdir -p $ECSTASY_HOME/bin \
     && ln -s $ECSTASY_HOME/libexec/bin/linux_launcher $ECSTASY_HOME/bin/xtc \
     && ln -s $ECSTASY_HOME/libexec/bin/linux_launcher $ECSTASY_HOME/bin/xam
 
+CMD ["/bin/sh"]
 


### PR DESCRIPTION
Added a `Dockerfile` to run the xdk in a container. This is obviously work-in-progress while we decide exactly how we work in containers, but it is a starting point for anyone to try it out.

## To build the image

First build the XDK
```
grade clean build
```
The build the image
```
cd xdk
docker build -t ghcr.io/xtclang/xdk:latest .
```

## Run the XDK in a Container

To run the image
```
docker run -it --rm ghcr.io/xtclang/xdk:latest
```

This will run the image interactively and drop you into a shell. All the XDK executables are on the path, as is Java and Node. 
There was no point doing anything more as the default entry point, as there is nothing to run.

The XDK is installed under the `/xqiz.it` directory.


## Notes 
The image is currently fixed to use Java 17.0.2. It also install Node 18.17.1 as that is what the image from https://github.com/azzazzel/xtc_platform uses. Eventually all these would ideally be parameterised. 

I could have done the whole build of the XDK inside the first part of the Dockerfile too but most people right now will already be building locally and this way you get whatever you have just built in the image.