### PR TITLE
Replaced raw Collections.EMPTY_LIST with preferred Collections.emptyList()

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ClassStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ClassStructure.java
@@ -679,7 +679,7 @@ public class ClassStructure
         {
         ListMap<StringConstant, TypeConstant> mapThis = m_mapParams;
         return mapThis == null
-                ? Collections.EMPTY_LIST
+                ? Collections.emptyList()
                 : mapThis.asList();
         }
 
@@ -1064,7 +1064,7 @@ public class ClassStructure
                     }
                 }
             }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
         }
 
 
@@ -2944,7 +2944,7 @@ public class ClassStructure
                         }
 
                     if (!typeRight.containsSubstitutableMethod(sig,
-                            accessRight, false, Collections.EMPTY_LIST))
+                            accessRight, false, Collections.emptyList()))
                         {
                         setMiss.add(sig);
                         }
@@ -2976,7 +2976,7 @@ public class ClassStructure
 
                         // funky interface scenario
                         if (!typeRight.containsSubstitutableMethod(sig,
-                                accessRight, true, Collections.EMPTY_LIST))
+                                accessRight, true, Collections.emptyList()))
                             {
                             setMiss.add(sig);
                             }
@@ -2993,7 +2993,7 @@ public class ClassStructure
                             }
 
                         if (!typeRight.containsSubstitutableMethod(sig,
-                                accessRight, false, Collections.EMPTY_LIST))
+                                accessRight, false, Collections.emptyList()))
                             {
                             setMiss.add(sig);
                             }
@@ -3150,7 +3150,7 @@ public class ClassStructure
                 typeContrib = contrib.resolveGenerics(pool, new SimpleTypeResolver(pool, listParams));
 
                 if (typeContrib.containsSubstitutableMethod(signature, access, fFunction,
-                        Collections.EMPTY_LIST))
+                        Collections.emptyList()))
                     {
                     return true;
                     }
@@ -3160,7 +3160,7 @@ public class ClassStructure
         // finally check for Object methods (since Object is always an implicit contribution)
         IdentityConstant idObject = pool.clzObject();
         return !idClass.equals(idObject) && ((ClassStructure) idObject.getComponent()).
-                containsSubstitutableMethod(pool, signature, access, fFunction, Collections.EMPTY_LIST);
+                containsSubstitutableMethod(pool, signature, access, fFunction, Collections.emptyList());
         }
 
 

--- a/javatools/src/main/java/org/xvm/asm/Component.java
+++ b/javatools/src/main/java/org/xvm/asm/Component.java
@@ -511,7 +511,7 @@ public abstract class Component
         List<Contribution> list = m_listContribs;
         if (list == null)
             {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
             }
         assert (list = Collections.unmodifiableList(m_listContribs)) != null;
         return list;
@@ -1790,7 +1790,7 @@ public abstract class Component
                 }
             }
 
-        return matches == null ? Collections.EMPTY_LIST : matches;
+        return matches == null ? Collections.emptyList() : matches;
         }
 
     protected boolean canBeSeen(Access access)

--- a/javatools/src/main/java/org/xvm/asm/Component.java
+++ b/javatools/src/main/java/org/xvm/asm/Component.java
@@ -799,7 +799,7 @@ public abstract class Component
         {
         ensureChildren();
         Map<String, Component> map = m_childByName;
-        return map == null ? Collections.EMPTY_MAP : map;
+        return map == null ? Collections.emptyMap() : map;
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -2502,7 +2502,7 @@ public class ConstantPool
                 typeObject(), 0, null, 0, true, Collections.EMPTY_MAP,
                 Annotation.NO_ANNOTATIONS, Annotation.NO_ANNOTATIONS,
                 typeObject(), null, typeObject(),
-                Collections.EMPTY_LIST, new ListMap<>(), new ListMap<>(),
+                Collections.emptyList(), new ListMap<>(), new ListMap<>(),
                 Collections.EMPTY_MAP, Collections.EMPTY_MAP,
                 Collections.EMPTY_MAP, Collections.EMPTY_MAP,
                 ListMap.EMPTY, null, Progress.Building)
@@ -3228,7 +3228,7 @@ public class ConstantPool
         List<TypeConstant> list = f_tlolistDeferred.get();
         if (list == null)
             {
-            list = Collections.EMPTY_LIST;
+            list = Collections.emptyList();
             }
         else
             {
@@ -3794,7 +3794,7 @@ public class ConstantPool
                 null,                   // typeExtends
                 null,                   // typeRebase
                 null,                   // typeInto
-                Collections.EMPTY_LIST, // listProcess,
+                Collections.emptyList(), // listProcess,
                 ListMap.EMPTY,          // listmapClassChain
                 ListMap.EMPTY,          // listmapDefaultChain
                 Collections.EMPTY_MAP,  // mapProps

--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -2499,12 +2499,12 @@ public class ConstantPool
         if (info == null)
             {
             m_infoPlaceholder = info = new TypeInfo(
-                typeObject(), 0, null, 0, true, Collections.EMPTY_MAP,
+                typeObject(), 0, null, 0, true, Collections.emptyMap(),
                 Annotation.NO_ANNOTATIONS, Annotation.NO_ANNOTATIONS,
                 typeObject(), null, typeObject(),
                 Collections.emptyList(), new ListMap<>(), new ListMap<>(),
-                Collections.EMPTY_MAP, Collections.EMPTY_MAP,
-                Collections.EMPTY_MAP, Collections.EMPTY_MAP,
+                Collections.emptyMap(), Collections.emptyMap(),
+                Collections.emptyMap(), Collections.emptyMap(),
                 ListMap.EMPTY, null, Progress.Building)
                     {
                     public String toString()
@@ -3797,9 +3797,9 @@ public class ConstantPool
                 Collections.emptyList(), // listProcess,
                 ListMap.EMPTY,          // listmapClassChain
                 ListMap.EMPTY,          // listmapDefaultChain
-                Collections.EMPTY_MAP,  // mapProps
+                Collections.emptyMap(),  // mapProps
                 mapMethods,
-                Collections.EMPTY_MAP,  // mapVirtProps
+                Collections.emptyMap(),  // mapVirtProps
                 mapVirtMethods,
                 ListMap.EMPTY,          // mapChildren
                 null, Progress.Complete

--- a/javatools/src/main/java/org/xvm/asm/FileRepository.java
+++ b/javatools/src/main/java/org/xvm/asm/FileRepository.java
@@ -69,7 +69,7 @@ public class FileRepository
     public Set<String> getModuleNames()
         {
         checkCache();
-        return file.exists() && name != null ? Collections.singleton(name) : Collections.EMPTY_SET;
+        return file.exists() && name != null ? Collections.singleton(name) : Collections.emptySet();
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/MultiMethodStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/MultiMethodStructure.java
@@ -403,7 +403,7 @@ public class MultiMethodStructure
         {
         ensureChildren();
         Map<MethodConstant, MethodStructure> map = m_methodByConstant;
-        return map == null ? Collections.EMPTY_MAP : map;
+        return map == null ? Collections.emptyMap() : map;
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/SimulatedLinkerContext.java
+++ b/javatools/src/main/java/org/xvm/asm/SimulatedLinkerContext.java
@@ -228,9 +228,9 @@ public class SimulatedLinkerContext
     public static final SimulatedLinkerContext EMPTY = new SimulatedLinkerContext(null);
 
     private final ConditionalConstant           cond;
-    private Map<ConditionalConstant, Influence> influences  = Collections.EMPTY_MAP;
-    private Set<String>                         names       = Collections.EMPTY_SET;
-    private Map<IdentityConstant, Boolean>      present     = Collections.EMPTY_MAP;
-    private Map<ModuleConstant, Version>        modules     = Collections.EMPTY_MAP;
+    private Map<ConditionalConstant, Influence> influences  = Collections.emptyMap();
+    private Set<String>                         names       = Collections.emptySet();
+    private Map<IdentityConstant, Boolean>      present     = Collections.emptyMap();
+    private Map<ModuleConstant, Version>        modules     = Collections.emptyMap();
     private Version                             version;
     }

--- a/javatools/src/main/java/org/xvm/asm/constants/AbstractDependantChildTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/AbstractDependantChildTypeConstant.java
@@ -179,7 +179,7 @@ public abstract class AbstractDependantChildTypeConstant
         if (typeParent.containsGenericParam(sName))
             {
             // the passed in list applies only to the child and should not be used by the parent
-            type = typeParent.getGenericParamType(sName, Collections.EMPTY_LIST);
+            type = typeParent.getGenericParamType(sName, Collections.emptyList());
             }
         else
             {

--- a/javatools/src/main/java/org/xvm/asm/constants/AllCondition.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/AllCondition.java
@@ -106,7 +106,7 @@ public class AllCondition
                 }
             }
 
-        return setVers == null ? Collections.EMPTY_SET : setVers;
+        return setVers == null ? Collections.emptySet() : setVers;
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/AnyCondition.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/AnyCondition.java
@@ -102,7 +102,7 @@ public class AnyCondition
                 }
             }
 
-        return setVers == null ? Collections.EMPTY_SET : setVers;
+        return setVers == null ? Collections.emptySet() : setVers;
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -308,7 +308,7 @@ public class DifferenceTypeConstant
         {
         if (info1 == null || info2 == null)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         Map<Object, ParamInfo> map1 = info1.getTypeParams();
@@ -353,7 +353,7 @@ public class DifferenceTypeConstant
         {
         if (info1 == null)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         if (info2 == null)
@@ -383,7 +383,7 @@ public class DifferenceTypeConstant
         {
         if (info1 == null)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         if (info2 == null)

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -178,7 +178,7 @@ public class ParameterizedTypeConstant
     public List<TypeConstant> getParamTypes()
         {
         return m_atypeParams.length == 0
-                ? Collections.EMPTY_LIST
+                ? Collections.emptyList()
                 : Arrays.asList(m_atypeParams);
         }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyClassTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyClassTypeConstant.java
@@ -231,7 +231,7 @@ public class PropertyClassTypeConstant
                 : null;
         return type == null
                 // the passed in list represents the "child" and should not be used by the parent
-                ? m_typeParent.getGenericParamType(sName, Collections.EMPTY_LIST)
+                ? m_typeParent.getGenericParamType(sName, Collections.emptyList())
                 : type.containsGenericType(true)
                     ? type.resolveGenerics(getConstantPool(), m_typeParent)
                     : type;
@@ -418,7 +418,7 @@ public class PropertyClassTypeConstant
         return new TypeInfo(this, cInvals, infoBase.getClassStructure(),
                 idBase.getNestedDepth() + 1, false, mapTypeParams,
                 Annotation.NO_ANNOTATIONS, infoBase.getMixinAnnotations(), typeBase, null, null,
-                Collections.EMPTY_LIST, ListMap.EMPTY, ListMap.EMPTY,
+                Collections.emptyList(), ListMap.EMPTY, ListMap.EMPTY,
                 mapProps, mapMethods, mapVirtProps, mapVirtMethods, mapChildren,
                 null, TypeInfo.Progress.Complete);
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
@@ -577,7 +577,7 @@ public abstract class RelationalTypeConstant
                             null,                   // typeExtends
                             null,                   // typeRebase
                             null,                   // typeInto
-                            Collections.EMPTY_LIST, // listProcess,
+                            Collections.emptyList(), // listProcess,
                             ListMap.EMPTY,          // listmapClassChain
                             ListMap.EMPTY,          // listmapDefaultChain
                             mergeProperties(info1, info2, errs),

--- a/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
@@ -582,8 +582,8 @@ public abstract class RelationalTypeConstant
                             ListMap.EMPTY,          // listmapDefaultChain
                             mergeProperties(info1, info2, errs),
                             mergeMethods(info1, info2, errs),
-                            Collections.EMPTY_MAP,  // mapVirtProps
-                            Collections.EMPTY_MAP,  // mapVirtMethods
+                            Collections.emptyMap(),  // mapVirtProps
+                            Collections.emptyMap(),  // mapVirtMethods
                             mergeChildren(info1, info2, errs),
                             null, // REVIEW: mergeDepends?
                             info1 == null || info2 == null

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeCollector.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeCollector.java
@@ -190,7 +190,7 @@ public class TypeCollector
             }
 
         assert m_listMulti == null;
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
         }
 
     /**
@@ -231,7 +231,7 @@ public class TypeCollector
             }
 
         return m_listSingle == null
-                ? Collections.EMPTY_LIST
+                ? Collections.emptyList()
                 : ensureMulti();
         }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -2339,7 +2339,7 @@ public abstract class TypeConstant
                 false, infoPri.getTypeParams(), infoPri.getClassAnnotations(), infoPri.getMixinAnnotations(),
                 infoPri.getExtends(), infoPri.getRebases(), infoPri.getInto(),
                 infoPri.getContributionList(), infoPri.getClassChain(), infoPri.getDefaultChain(),
-                mapProps, mapMethods, mapVirtProps, Collections.EMPTY_MAP, ListMap.EMPTY,
+                mapProps, mapMethods, mapVirtProps, Collections.emptyMap(), ListMap.EMPTY,
                 null, fIncomplete ? Progress.Incomplete : Progress.Complete);
         }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -123,7 +123,7 @@ public abstract class TypeConstant
     @Override
     public TypeConstant resolveGenericType(String sFormalName)
         {
-        return getGenericParamType(sFormalName, Collections.EMPTY_LIST);
+        return getGenericParamType(sFormalName, Collections.emptyList());
         }
 
 
@@ -437,7 +437,7 @@ public abstract class TypeConstant
         {
         return isModifyingType()
                 ? getUnderlyingType().getParamTypes()
-                : Collections.EMPTY_LIST;
+                : Collections.emptyList();
         }
 
     /**
@@ -4544,7 +4544,7 @@ public abstract class TypeConstant
                     }
                 }
             }
-        return listMatch == null ? Collections.EMPTY_LIST : listMatch;
+        return listMatch == null ? Collections.emptyList() : listMatch;
         }
 
     /**
@@ -4618,7 +4618,7 @@ public abstract class TypeConstant
                     }
                 }
             }
-        return listMatch == null ? Collections.EMPTY_LIST : listMatch;
+        return listMatch == null ? Collections.emptyList() : listMatch;
         }
 
     /**
@@ -6032,7 +6032,7 @@ public abstract class TypeConstant
 
         return typeLeftN.isDuckTypeAbleFrom(typeRightN) &&
                typeLeftN.isInterfaceAssignableFrom(
-                        typeRightN, accessRight, Collections.EMPTY_LIST).isEmpty()
+                        typeRightN, accessRight, Collections.emptyList()).isEmpty()
                 ? Relation.IS_A
                 : Relation.INCOMPATIBLE;
         }
@@ -6316,7 +6316,7 @@ public abstract class TypeConstant
             mapUsage.put(sTypeName, Usage.IN_PROGRESS);
             try
                 {
-                usage = checkConsumption(sTypeName, access, Collections.EMPTY_LIST);
+                usage = checkConsumption(sTypeName, access, Collections.emptyList());
                 }
             catch (RuntimeException | Error e)
                 {
@@ -6370,7 +6370,7 @@ public abstract class TypeConstant
             mapUsage.put(sTypeName, Usage.IN_PROGRESS);
             try
                 {
-                usage = checkProduction(sTypeName, access, Collections.EMPTY_LIST);
+                usage = checkProduction(sTypeName, access, Collections.emptyList());
                 }
             catch (RuntimeException | Error e)
                 {
@@ -7332,8 +7332,8 @@ public abstract class TypeConstant
                             }
 
                         String       sName      = constName.getValue();
-                        TypeConstant typePLeft  = typeLeft.getGenericParamType(sName, Collections.EMPTY_LIST);
-                        TypeConstant typePRight = typeRight.getGenericParamType(sName, Collections.EMPTY_LIST);
+                        TypeConstant typePLeft  = typeLeft.getGenericParamType(sName, Collections.emptyList());
+                        TypeConstant typePRight = typeRight.getGenericParamType(sName, Collections.emptyList());
 
                         if (!typePRight.equals(typePLeft))
                             {

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeInfo.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeInfo.java
@@ -149,7 +149,7 @@ public class TypeInfo
         f_cInvalidations      = cInvalidations;
         f_struct              = infoConstraint.f_struct;
         f_cDepth              = infoConstraint.f_cDepth;
-        f_mapTypeParams       = Collections.EMPTY_MAP;
+        f_mapTypeParams       = Collections.emptyMap();
         f_aannoClass          = Annotation.NO_ANNOTATIONS;
         f_aannoMixin          = Annotation.NO_ANNOTATIONS;
         f_typeExtends         = infoConstraint.f_type;
@@ -1053,7 +1053,7 @@ public class TypeInfo
         MethodStructure method = (MethodStructure) idMethod.getComponent();
         if (method != null && !method.hasChildren())
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         Map<IdentityConstant, Map<String, PropertyInfo>> mapProps = m_mapNestedProperties;
@@ -1079,7 +1079,7 @@ public class TypeInfo
                 }
             if (map == null)
                 {
-                map = Collections.EMPTY_MAP;
+                map = Collections.emptyMap();
                 }
             mapProps.put(idMethod, map);
             }
@@ -1123,7 +1123,7 @@ public class TypeInfo
                 }
             if (map == null)
                 {
-                map = Collections.EMPTY_MAP;
+                map = Collections.emptyMap();
                 }
             mapProps.put(idProp, map);
             }
@@ -1915,7 +1915,7 @@ public class TypeInfo
                 }
 
             // cache the result
-            m_setOps = setOps = (setOps == null ? Collections.EMPTY_SET : setOps);
+            m_setOps = setOps = (setOps == null ? Collections.emptySet() : setOps);
             }
 
         return setOps;
@@ -2104,7 +2104,7 @@ public class TypeInfo
             // cache the miss
             if (setMethods == null)
                 {
-                mapMethods.put(sKey, setMethods = Collections.EMPTY_SET);
+                mapMethods.put(sKey, setMethods = Collections.emptySet());
                 }
             else if (fAny && setMethods.size() == 1)
                 {
@@ -2189,7 +2189,7 @@ public class TypeInfo
             if (setMethods == null)
                 {
                 // cache the miss
-                mapMethods.put(sKey, setMethods = Collections.EMPTY_SET);
+                mapMethods.put(sKey, setMethods = Collections.emptySet());
                 }
             else if (fAny && setMethods.size() == 1)
                 {
@@ -2250,7 +2250,7 @@ public class TypeInfo
                 }
 
             // cache the result
-            m_setAuto = setAuto = (setAuto == null ? Collections.EMPTY_SET : setAuto);
+            m_setAuto = setAuto = (setAuto == null ? Collections.emptySet() : setAuto);
             }
 
         return setAuto;

--- a/javatools/src/main/java/org/xvm/asm/constants/UnionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/UnionTypeConstant.java
@@ -506,7 +506,7 @@ public class UnionTypeConstant
         {
         if (info1 == null || info2 == null)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         ConstantPool           pool = getConstantPool();
@@ -568,7 +568,7 @@ public class UnionTypeConstant
         {
         if (info1 == null || info2 == null)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         Map<PropertyConstant, PropertyInfo> map = new HashMap<>();
@@ -653,7 +653,7 @@ public class UnionTypeConstant
         {
         if (info1 == null || info2 == null)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         // calling info.getNarrowingMethod() can change the content of "MethodBySignature", causing

--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -3563,7 +3563,7 @@ public class Parser
                     {
                     if (!argsTrailing.isEmpty())
                         {
-                        if (args == Collections.emptyList())
+                        if (args.isEmpty())
                             {
                             args = argsTrailing;
                             }

--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -3554,7 +3554,7 @@ public class Parser
                     }
                 else
                     {
-                    args = Collections.EMPTY_LIST;
+                    args = Collections.emptyList();
                     }
 
                 // parenthesized arguments after the dims
@@ -3563,7 +3563,7 @@ public class Parser
                     {
                     if (!argsTrailing.isEmpty())
                         {
-                        if (args == Collections.EMPTY_LIST)
+                        if (args == Collections.emptyList())
                             {
                             args = argsTrailing;
                             }
@@ -3849,7 +3849,7 @@ public class Parser
                 if (match(Id.R_PAREN) != null)
                     {
                     // zero-argument lambda
-                    return new LambdaExpression(Collections.EMPTY_LIST, expect(Id.LAMBDA),
+                    return new LambdaExpression(Collections.emptyList(), expect(Id.LAMBDA),
                             parseLambdaBody(), tokLParen.getStartPosition());
                     }
 
@@ -5026,7 +5026,7 @@ public class Parser
             Token tokTest = match(Id.IDENTIFIER);
             if (tokTest == null)
                 {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
                 }
             else
                 {
@@ -5303,7 +5303,7 @@ public class Parser
             {
             if (match(Id.COMP_GT) != null)
                 {
-                types = Collections.EMPTY_LIST;
+                types = Collections.emptyList();
                 }
             else
                 {
@@ -5464,7 +5464,7 @@ public class Parser
         if (match(Id.L_PAREN, required) != null)
             {
             types = peek(Id.R_PAREN)
-                    ? Collections.EMPTY_LIST
+                    ? Collections.emptyList()
                     : parseTypeExpressionList(false);
             expect(Id.R_PAREN);
             }
@@ -5629,7 +5629,7 @@ public class Parser
         List<Parameter> listReturn;
         if (match(Id.VOID) != null)
             {
-            listReturn = Collections.EMPTY_LIST;
+            listReturn = Collections.emptyList();
             }
         else if (match(Id.L_PAREN) == null)
             {

--- a/javatools/src/main/java/org/xvm/compiler/ast/AnonInnerClass.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/AnonInnerClass.java
@@ -101,7 +101,7 @@ public class AnonInnerClass
      */
     public List<CompositionNode> getCompositions()
         {
-        return m_listCompositions == null ? Collections.EMPTY_LIST : m_listCompositions;
+        return m_listCompositions == null ? Collections.emptyList() : m_listCompositions;
         }
 
     /**
@@ -109,7 +109,7 @@ public class AnonInnerClass
      */
     public List<AnnotationExpression> getAnnotations()
         {
-        return m_listAnnos == null ? Collections.EMPTY_LIST : m_listAnnos;
+        return m_listAnnos == null ? Collections.emptyList() : m_listAnnos;
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/ast/AstNode.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/AstNode.java
@@ -1025,7 +1025,7 @@ public abstract class AstNode
         // collect available types for unnamed arguments and a map of named expressions
         Map<String, Expression> mapNamedExpr = cExpr > 0
                 ? extractNamedArgs(listExprArgs, errs)
-                : Collections.EMPTY_MAP;
+                : Collections.emptyMap();
 
         if (mapNamedExpr == null)
             {
@@ -1186,7 +1186,7 @@ public abstract class AstNode
                     }
                 }
             }
-        return mapNamed == null ? Collections.EMPTY_MAP : mapNamed;
+        return mapNamed == null ? Collections.emptyMap() : mapNamed;
         }
 
     /**
@@ -2012,7 +2012,7 @@ public abstract class AstNode
         Field[] fields = getChildFields();
         if (fields.length == 0)
             {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
             }
 
         Map<String, Object> map = new ListMap<>();

--- a/javatools/src/main/java/org/xvm/compiler/ast/CompositionNode.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/CompositionNode.java
@@ -523,7 +523,7 @@ public abstract class CompositionNode
             {
             if (vers == null)
                 {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
                 }
 
             List<Version> list = new ArrayList<>();

--- a/javatools/src/main/java/org/xvm/compiler/ast/ConditionalStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ConditionalStatement.java
@@ -18,7 +18,7 @@ public abstract class ConditionalStatement
     public ConditionalStatement(Token keyword, List<AstNode> conds)
         {
         this.keyword = keyword;
-        this.conds   = conds  == null ? Collections.EMPTY_LIST : conds;
+        this.conds   = conds  == null ? Collections.emptyList() : conds;
         }
 
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/Context.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Context.java
@@ -1632,7 +1632,7 @@ public class Context
         {
         Map<FormalConstant, TypeConstant> map = getFormalTypeMap(branch);
 
-        if (map == Collections.emptyMap())
+        if (map.isEmpty())
             {
             return switch (branch)
                 {

--- a/javatools/src/main/java/org/xvm/compiler/ast/Context.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Context.java
@@ -552,7 +552,7 @@ public class Context
      */
     public void merge(Map<String, Assignment> mapAdd)
         {
-        merge(mapAdd, Collections.EMPTY_MAP);
+        merge(mapAdd, Collections.emptyMap());
         }
 
     /**
@@ -1224,7 +1224,7 @@ public class Context
         {
         Map<String, Assignment> map = m_mapAssigned;
         return map == null
-                ? Collections.EMPTY_MAP
+                ? Collections.emptyMap()
                 : map;
         }
 
@@ -1306,7 +1306,7 @@ public class Context
         return hasInitialNames()
                 ? ensureNameMap()
                 : m_mapByName == null
-                        ? Collections.EMPTY_MAP
+                        ? Collections.emptyMap()
                         : m_mapByName;
         }
 
@@ -1585,7 +1585,7 @@ public class Context
     protected Map<String, Argument> getNarrowingMap(boolean fWhenTrue)
         {
         Map<String, Argument> map = fWhenTrue ? m_mapWhenTrue : m_mapWhenFalse;
-        return map == null ? Collections.EMPTY_MAP : map;
+        return map == null ? Collections.emptyMap() : map;
         }
 
     /**
@@ -1622,7 +1622,7 @@ public class Context
             case WhenFalse -> m_mapFormalWhenFalse;
             default        -> m_mapFormal;
             };
-        return map == null ? Collections.EMPTY_MAP : map;
+        return map == null ? Collections.emptyMap() : map;
         }
 
     /**
@@ -1632,7 +1632,7 @@ public class Context
         {
         Map<FormalConstant, TypeConstant> map = getFormalTypeMap(branch);
 
-        if (map == Collections.EMPTY_MAP)
+        if (map == Collections.emptyMap())
             {
             return switch (branch)
                 {
@@ -2913,7 +2913,7 @@ public class Context
         public Map<String, Boolean> getCaptureMap()
             {
             return m_mapCapture == null
-                    ? Collections.EMPTY_MAP
+                    ? Collections.emptyMap()
                     : m_mapCapture;
             }
 
@@ -2932,7 +2932,7 @@ public class Context
                 if (getCaptureMap().isEmpty())
                     {
                     // there are never more capture-registers than there are captures
-                    return Collections.EMPTY_MAP;
+                    return Collections.emptyMap();
                     }
 
                 m_mapRegisters = map = new HashMap<>();
@@ -2947,7 +2947,7 @@ public class Context
         public Map<String, Argument> getFormalMap()
             {
             return m_mapFormalInfo == null
-                    ? Collections.EMPTY_MAP
+                    ? Collections.emptyMap()
                     : m_mapFormalInfo;
             }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/IgnoredNameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/IgnoredNameExpression.java
@@ -110,6 +110,6 @@ public class IgnoredNameExpression
     @Override
     public Map<String, Object> getDumpChildren()
         {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
         }
     }

--- a/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
@@ -909,7 +909,7 @@ public class InvocationExpression
                     return null;
                     }
 
-                Map<FormalConstant, TypeConstant> mapTypeParams = Collections.EMPTY_MAP;
+                Map<FormalConstant, TypeConstant> mapTypeParams = Collections.emptyMap();
                 if (cTypeParams > 0)
                     {
                     transformTypeArguments(ctx, method, listArgs, atypeArgs);

--- a/javatools/src/main/java/org/xvm/compiler/ast/ListExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ListExpression.java
@@ -201,7 +201,7 @@ public class ListExpression
         if (typeRequired != null && typeRequired.isA(pool.typeMap()) && exprs.isEmpty())
             {
             MapExpression exprNew =  new MapExpression(new NamedTypeExpression(this, typeRequired),
-                    Collections.EMPTY_LIST, Collections.EMPTY_LIST, getEndPosition());
+                    Collections.emptyList(), Collections.emptyList(), getEndPosition());
             return replaceThisWith(exprNew).validate(ctx, typeRequired, errs);
             }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/MethodDeclarationStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/MethodDeclarationStatement.java
@@ -1012,7 +1012,7 @@ public class MethodDeclarationStatement
         int cDefaults = method.getDefaultParamCount();
         if (cDefaults > 0)
             {
-            StatementBlock block = adopt(new StatementBlock(Collections.EMPTY_LIST));
+            StatementBlock block = adopt(new StatementBlock(Collections.emptyList()));
 
             RootContext ctxMethod = new RootContext(block, method);
             Context     ctx       = ctxMethod.validatingContext();

--- a/javatools/src/main/java/org/xvm/compiler/ast/StageMgr.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/StageMgr.java
@@ -464,7 +464,7 @@ public class StageMgr
         List<AstNode> listPrevious = m_listRevisit;
         m_listRevisit = null;
         return listPrevious == null
-                ? Collections.EMPTY_LIST
+                ? Collections.emptyList()
                 : listPrevious;
         }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/SwitchStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/SwitchStatement.java
@@ -272,7 +272,7 @@ public class SwitchStatement
                 {
                 if (!entry.getKey().isDiscarded())
                     {
-                    addBreak(entry.getKey(), entry.getValue(), Collections.EMPTY_MAP, m_labelContinue);
+                    addBreak(entry.getKey(), entry.getValue(), Collections.emptyMap(), m_labelContinue);
                     }
                 }
             m_listContinues = null;
@@ -296,7 +296,7 @@ public class SwitchStatement
         // we will process the assignments ourselves; see SwitchContext.mergeBreaks()
         m_listBreaks.add(mapAsn);
 
-        super.addBreak(nodeOrigin, Collections.EMPTY_MAP, Collections.EMPTY_MAP, label);
+        super.addBreak(nodeOrigin, Collections.emptyMap(), Collections.emptyMap(), label);
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/compiler/ast/TupleExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TupleExpression.java
@@ -43,7 +43,7 @@ public class TupleExpression
     public TupleExpression(TypeExpression type, List<Expression> exprs, long lStartPos, long lEndPos)
         {
         this.type        = type;
-        this.exprs       = exprs == null ? Collections.EMPTY_LIST : exprs;
+        this.exprs       = exprs == null ? Collections.emptyList() : exprs;
         this.m_lStartPos = lStartPos;
         this.m_lEndPos   = lEndPos;
         }

--- a/javatools/src/main/java/org/xvm/compiler/ast/TypeCompositionStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TypeCompositionStatement.java
@@ -937,7 +937,7 @@ public class TypeCompositionStatement
         // validate and register annotations
         if (annotations != null && !annotations.isEmpty())
             {
-            if (compositions == null || compositions == Collections.emptyList())
+            if (compositions == null || compositions.isEmpty())
                 {
                 compositions = new ArrayList<>();
                 }

--- a/javatools/src/main/java/org/xvm/compiler/ast/TypeCompositionStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TypeCompositionStatement.java
@@ -937,7 +937,7 @@ public class TypeCompositionStatement
         // validate and register annotations
         if (annotations != null && !annotations.isEmpty())
             {
-            if (compositions == null || compositions == Collections.EMPTY_LIST)
+            if (compositions == null || compositions == Collections.emptyList())
                 {
                 compositions = new ArrayList<>();
                 }
@@ -2798,7 +2798,7 @@ public class TypeCompositionStatement
         StatementBlock blockBody = body;
         if (body == null)
             {
-            blockBody = adopt(new StatementBlock(Collections.EMPTY_LIST));
+            blockBody = adopt(new StatementBlock(Collections.emptyList()));
             }
         return new RootContext(blockBody, constructor);
         }

--- a/javatools/src/main/java/org/xvm/compiler/ast/VersionOverride.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/VersionOverride.java
@@ -108,7 +108,7 @@ public class VersionOverride
     @Override
     public Map<String, Object> getDumpChildren()
         {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
         }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/ClassComposition.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassComposition.java
@@ -563,14 +563,14 @@ public class ClassComposition
 
         if (!f_template.isGenericHandle())
             {
-            m_mapFields = Collections.EMPTY_MAP;
+            m_mapFields = Collections.emptyMap();
             return;
             }
 
         TypeConstant typePublic = f_typeInception.getUnderlyingType();
         if (typePublic instanceof PropertyClassTypeConstant)
             {
-            m_mapFields = Collections.EMPTY_MAP;
+            m_mapFields = Collections.emptyMap();
             return;
             }
 
@@ -706,7 +706,7 @@ public class ClassComposition
 
         m_cRegularFields = cRegular;
         m_mapFields      = mapFields.isEmpty()
-                ? Collections.EMPTY_MAP
+                ? Collections.emptyMap()
                 : mapFields.size() > 8
                     ? new LinkedHashMap<>(mapFields)
                     : mapFields;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
@@ -396,7 +396,7 @@ public class xRTCompiler
 
         protected List<String> getErrors()
             {
-            return m_log == null ? Collections.EMPTY_LIST : m_log;
+            return m_log == null ? Collections.emptyList() : m_log;
             }
 
         protected ModuleRepository getBuildRepository()

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
@@ -174,7 +174,7 @@ public class xContainerLinker
                                        ModuleStructure moduleApp, ObjectHandle hProvider, int iReturn)
         {
         NestedContainer containerNested = new NestedContainer(container,
-                moduleApp.getIdentityConstant(), Collections.EMPTY_LIST);
+                moduleApp.getIdentityConstant(), Collections.emptyList());
         return new CollectResources(containerNested, hProvider, iReturn).doNext(frame);
         }
 

--- a/javatools/src/main/java/org/xvm/tool/Compiler.java
+++ b/javatools/src/main/java/org/xvm/tool/Compiler.java
@@ -688,7 +688,7 @@ public class Compiler
             {
             List<File> path = (List<File>) values().get("L");
             return path == null
-                    ? Collections.EMPTY_LIST
+                    ? Collections.emptyList()
                     : path;
             }
 
@@ -700,7 +700,7 @@ public class Compiler
             {
             List<File> list = (List<File>) values().get(Trailing);
             return list == null
-                    ? Collections.EMPTY_LIST
+                    ? Collections.emptyList()
                     : list;
             }
 

--- a/javatools/src/main/java/org/xvm/tool/Disassembler.java
+++ b/javatools/src/main/java/org/xvm/tool/Disassembler.java
@@ -166,7 +166,7 @@ public class Disassembler
          */
         public List<File> getModulePath()
             {
-            return (List<File>) values().getOrDefault("L", Collections.EMPTY_LIST);
+            return (List<File>) values().getOrDefault("L", Collections.emptyList());
             }
 
         /**

--- a/javatools/src/main/java/org/xvm/tool/Runner.java
+++ b/javatools/src/main/java/org/xvm/tool/Runner.java
@@ -306,7 +306,7 @@ public class Runner
          */
         public List<File> getModulePath()
             {
-            return (List<File>) values().getOrDefault("L", Collections.EMPTY_LIST);
+            return (List<File>) values().getOrDefault("L", Collections.emptyList());
             }
 
         /**


### PR DESCRIPTION
Fixes 52 of the circa 1200 Java warnings we have.
