### PR TITLE
Validate the user even if they have no roles

### DIFF
--- a/lib_web/src/main/x/web/security/FixedRealm.x
+++ b/lib_web/src/main/x/web/security/FixedRealm.x
@@ -124,7 +124,7 @@ const FixedRealm
     @Override
     conditional Set<String> validUser(String user) {
         return pwdsByUser.contains(user)
-                ? rolesByUser.get(user)
+                ? (True, rolesByUser.get(user) ?: [])
                 : False;
     }
 


### PR DESCRIPTION
Currently, if a user has no roles assigned, the `validUser` returns `false`.  This is an attempt to fix that, though I'm not sure if it's the right approach.