### PR TITLE
Detach manual tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,31 @@ git checkout -B decriptive-branch-name
 git push --set-upstream origin descriptive-branch-name
 ```
 
-##### 2) Perform your changes, and commit them. We currently do not have any syntax requirements
-
-on commit descriptions, but it's a good idea to describe the purpose of the commit.
+Note that you can automate the second command above, and have all branches you create on your 
+machine immediately get attached to the upstream, so the rest of the world can see them. You do this 
+with the "git config" command, writing it to the scope you want it just like we described
+setting up "pull.rebase" in the section above. For example:
 
 ```
-git commit -m "Descriptive commit message, including a github issue reference, if one exists"
+git config --global push.autoSetupRemote true
+```
+
+This saves some time, if you create a lot of branches, but it also removes the use case 
+that you actually can just hack something locally, without necessarily making it
+immediately available to the rest of the world. Typically, an author would e.g. add some 
+alias in their shell to make it easy and frictionless to create new local branches, 
+and automatically or manually attach them to the remote, whichever
+is preferred. Also, all modern IDEs also have simple, ergonomic "one click attach"
+support to attach a local branch to its remote upstream branch. Most developers choose
+to keep the remote attach operation as a separate step, for these reasons.
+
+##### 2) Perform your changes, and commit them. 
+
+We currently do not have any syntax requirements on commit descriptions, but it's a good idea to describe 
+the purpose of the commit.
+
+```
+git commit -m "Descriptive commit message, including a GitHub issue reference, if one exists"
 ```
 
 ##### 3) Push your changes to the upstream and create a pull request, when you are ready for review

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Manual local build for **any computer** (for advanced users):
 *A note about this section: this workflow is supported by pretty much every
 common GUI in any common IDE, in one way or another. But in the interest of
 not having to document several instances with slightly different naming convention,
-or deliver a confusing tutorial, this section only describes the exact bare
-bones command line git commands that can be used to implement our workflow,
+or deliver a confusing tutorial, this section only describes the exact bare-bones 
+command line git commands that can be used to implement our workflow,
 which is also a common developer preference. All known IDEs just wrap these
 commands in one way or another.*
 
@@ -124,7 +124,7 @@ the config may or may not be rewritten by future updates.
 #### Always work in a branch. Do not work directly in master
 
 XTC will very soon switch to only allowing putting code onto the master branch through
-a pull request in a sub branch.
+a pull request in a sub-branch.
 
 In order to minimize git merges, and to keep master clean, with a minimum of complexity,
 the recommended workflow for submitting a pull request is as follows:
@@ -520,7 +520,7 @@ to a local repositories and the XTC GitHub org repository.
 3) To publish the XDK distro to Maven Central: (... TODO ... )
 
 You can already refer to the XDK and the XTC Plugin as external artifacts for your favourite
-XTC project, either by mnaually setting up a link to the XTC Org GitHub Maven Repository like this:
+XTC project, either by manually setting up a link to the XTC Org GitHub Maven Repository like this:
 
 ```
 repositories {
@@ -595,10 +595,10 @@ projects or the XDK. None of them are at all specific to XTC:
   as part of its source controlled configuration. 
   1) On the Maven model level, this means semantically versioned Maven artifacts. 
   2) On the software build and execution level, this also means specific versions of external
-    pieces of software, for example Java, NodeJS or Yarn. This also means that we CAN and SHOULD
+    pieces of software, for example Java, Node.js or Yarn. This also means that we CAN and SHOULD
     always be able to containerize for development purposes.
 
-Today, it is pretty safe to assume that most open source developers who has worked on any Gradle
+Today, it is pretty safe to assume that most open source developers who have worked on any Gradle
 or Maven based project has at least the most important parts of the above knowledge.
 We have spent significant architectural effort to ensure that an adopter who wants to become an 
 XTC or XDK user or developer does not need to acquire *any* knowledge that is

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ the recommended workflow for submitting a pull request is as follows:
 
 ```
 git checkout -B decriptive-branch-name
-git push --set-upstream origin descriptive-branch-name
+git push --set-upstream-to origin descriptive-branch-name
 ```
 
 Note that you can automate the second step, and have all branches you create on your 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ the recommended workflow for submitting a pull request is as follows:
 ##### 1) Create a new branch for your change, and connect it to the upstream:
 
 ```
-git checkout -B decriptive-branch-name
-git push --set-upstream-to origin descriptive-branch-name
+git checkout -B <decriptive-branch-name>
+git push --set-upstream origin <descriptive-branch-name>
 ```
 
 Note that you can automate the second step, and have all branches you create on your 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ git checkout -B decriptive-branch-name
 git push --set-upstream origin descriptive-branch-name
 ```
 
-Note that you can automate the second command above, and have all branches you create on your 
-machine immediately get attached to the upstream, so the rest of the world can see them. You do this 
-with the "git config" command, writing it to the scope you want it just like we described
-setting up "pull.rebase" in the section above. For example:
+Note that you can automate the second step, and have all branches you create on your 
+machine immediately get attached to the upstream on creation. This means that the rest
+of the world can see tem immediately. You can make this the default behavior 
+with the "git config" command, writing it to the scope you want it just like we 
+described setting up "pull.rebase" config in the section above. For example:
 
 ```
 git config --global push.autoSetupRemote true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import XdkDistribution.Companion.DISTRIBUTION_TASK_GROUP
 import org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_TASK_GROUP
+import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 
 /*
  * Main build file for the XVM project, producing the XDK.
@@ -23,7 +24,7 @@ private val includedBuildsWithPublications = listOfNotNull(xdk, plugin)
  * of the root build.gradle.kts, we have installed convention plugins, resolved version catalogs
  * and similar things.
  */
-val install by tasks.registering {
+val installDist by tasks.registering {
     group = DISTRIBUTION_TASK_GROUP
     description = "Install the XDK distribution in the xdk/build/distributions and xdk/build/install directories."
     XdkDistribution.distributionTasks.forEach {
@@ -73,6 +74,12 @@ val publish by tasks.registering {
     group = PUBLISH_TASK_GROUP
     description = "Task that aggregates publish tasks for builds with publications."
     dependsOn(publishLocal, publishRemote)
+}
+
+val manualTests by tasks.registering {
+    group = VERIFICATION_GROUP
+    description = "Run the manual tests for the XDK."
+    dependsOn(gradle.includedBuild("manualTests").task(":runXtc"))
 }
 
 GitHubPackages.publishTaskPrefixes.forEach { prefix ->

--- a/manualTests/build.gradle.kts
+++ b/manualTests/build.gradle.kts
@@ -1,6 +1,10 @@
 import org.xtclang.plugin.tasks.XtcCompileTask
+import org.xtclang.plugin.tasks.XtcRunAllTask
+import org.xtclang.plugin.tasks.XtcRunTask
 
-/*
+/**
+ * This is the manualTests project.
+ *
  * Test utilities.  This is a standalone XTC project, which should only depend on the XDK.
  * If we want to use it to debug the XDK, that is also fine, as it will do dependency
  * substitution on the XDK and XTC Plugin (and Javatools and other dependencies) correctly,
@@ -11,13 +15,53 @@ import org.xtclang.plugin.tasks.XtcCompileTask
  * artifacts for the XTC Gradle plugin and the XDK.
  */
 
+/**
+ * Plugins required. This is done through the Gradle version catalog mechanism. A version catalog
+ * is a single source of truth for dependent artifacts for a Gradle oroject. For the XVM repo,
+ * there is a "global" version catalog under $compositeBuildRootDirectory/gradle/libs/libs.versions.html.
+ * This makes it possible to alias artifacts to type safe (compile time knowable) hierarchical names.
+ * For example, "libs.plugins.xtc" will resolve to "org.xtclang:xtc-plugin:<xvm version>".
+ * This, in turn, means that the build should install that artifact with that version. It will look
+ * in any repositories you have specified. For example, if you have a section like
+ *
+ * repositories {
+ *    mavenCentral()
+ * }
+ *
+ * in your project settings, or defined in the build file (if you can, it is recommended to keep it in
+ * settings (for a best-practise example, please see the XTC Platform project and its XTC Plugin branch,
+ * which is either up for review as a pull request or already merged to master), the build will look
+ * for the artifact in any local caches, and if not found, then ask the mavenCentral artifact repo
+ * to if it knows about it and downloads/caches it. Basically, for any artifact on which you depend,
+ * you need to know group, id and version, to fully resolve it. Sometimes you are only interested in
+ * resolving any version, or latest version, or a version range, or a version with a specific Git tag, etc.
+ * To see how that works, please refer to the Maven or Gradle user guides.
+ *
+ * Gradle also supports "included builds". This means that any artifact identifier can be substituted
+ * with source control tree for a project that builds that artifact. This makes it possible for the XVM
+ * to partially build and verify itself, and it decouples paths, project modes and other things from
+ * configuration. Any change you will do in the XVM will "pretend" to be an artifact to its dependencies,
+ * if their settings contain that particular project as an includedBuild. Hence, building the manualTests
+ * module, will ensure that the plugin and the XDK are versioned, built and resolved from their code trees
+ * in the XVM repo. But the build doesn't have to know about that. For all it knows, it just resolves
+ * a named and versioned artifact. This build could be torn out and turn into a separate project and
+ * still resolve the artifacts for any configured repository, without changing a line of code.
+ *
+ */
 plugins {
     alias(libs.plugins.xdk.build.versioning)
     alias(libs.plugins.xtc)
 }
 
-val sanityCheckRuntime = getXdkPropertyBoolean("org.xtclang.build.sanityCheckRuntime", false)
-
+/**
+ * Dependencies required. The xdk cam be retrieved with the "xdk" consumer configuration, which
+ * will look for a file/dir hierarchy that contains the modules from the javatools and lib directories
+ * of an XTC installation. We currently publish XDK releases as zipped artifacts in our GitHub Maven
+ * repositoru (and soon also on mavenCentral after the next official release). If you want to use
+ * a zipped XDK artifact, use the "xdkDistribution" depeendency instead. Again, we recommend you
+ * look at the XTC platform repository, or the XTC template app, that is a simple Hello World, to
+ * understand how to build a project with XTC and Gradle.
+ */
 dependencies {
     xdk(libs.xdk)
 }
@@ -44,7 +88,7 @@ sourceSets {
                 "**/exceptions.x",
                 "**/FizzBuzz.x",
                 "**/generics.x",
-                "**/innerouter.x", // TODO @lagergren case sensitivity issue; this does not work: "**/innerOuter.x",
+                "**/innerouter.x",
                 "**/files.x",
                 "**/IO.x",
                 "**/lambda.x",
@@ -66,28 +110,63 @@ sourceSets {
 }
 
 /**
- * It's important to understand what causes caching problems and unnecessary rebuilds in Gradle.
- * One of these things is tasks depending on System environment variables.
- * To fix that particular issue, an input of the form inputs.property("langEnvironment") { System.getenv(ENV_VAR) }
- * needs to be added to the task configuration or any plugin that uses is must be aware of it.
- * <p>
- * Also Using doFirst and doLast from a build script on a cacheable task ties you to build script changes since
- * the implementation of the closure comes from the build script. If possible, you should use separate tasks instead.
- * <p>
- * @see <a href="https://docs.gradle.org/current/userguide/common_caching_problems.html">Gradle User Guide on caching</a>
+ * Applying the XTC plugin, adds a couple of default extensions to the project: xtcCompile and xtcRun
+ * are the only ones that may be necessary to care about, if you are working an XTC project build.
+ * The "xtcCompile" extension contains common configuration for all XTC compilation tasks in
+ * the current project. The "xtcRun" extensions contains common configuration for all XTC runner tasks
+ * in a project. Every XtcCompleTask and XtcRunTask will inherit these configurations, but it's possible
+ * to override any value in the extension on a per-task basis in the task configuration.
+ *
+ * Applying the XTC plugin to a Gradle project creates a few tasks by default. This is the pattern used
+ * by most Gradle language plugins for compiled languages. These are the once that the XTC programmer
+ * may be interested in:
+ *
+ * 1) The compile tasks for each source set
+ * 2) The run tasks for each source set.
+ *
+ * A compile task is added for each source set. Just like for other language plugins that use source sets,
+ * we have a default source set for xtc code called "main" and one called "test" (currently not
+ * used for much). The name of a compile task is derived from the name of the source set it will
+ * compile, and upon detecting changes, recompile. Hence, if you have a "test" source set, you
+ * will be given a "compileTextXtc" task, just as it would work with Java, Scala, Clojure etc.
+ * For the default source set (by convention always renamed "main"), the task will just be called
+ * "compileXtc", just like the default Java plugin compile task for the main source set is called
+ * "compileJava".  Since the plugin currently creates XTC main and test source sets by default, you
+ * will get compile tasks for both of these, even if they are empty. If you declare your own
+ * source sets above, e.g. "negativeTests", you will get a compile task and run tasks for that too.
+ *
+ * Run tasks work similarly, and are similarly named. At the moment, we also add a "runAll<SourceSetName>Xtc"
+ * per source set. This may not be how the finished DSL will look.
+ *
+ * Your XDK application can be executed by calling any of the run tasks. The run task will make sure
+ * that all dependencies it needs are compiled, resolved from repositories and on the module path
+ * when any module is run.
+ *
+ * NOTE: In Gradle, properly set up, any task and configuration in a build relies on implicitly
+ * or explicitly defined inputs and outputs. Should they no longer hash to the same values, the task
+ * cannot be cached. Otherwise, a task may be skipped and use its cached values. This also means
+ * that you should never have to call any cleanup tasks, or any tasks that create dependencies of
+ * another task in a correctly implemented Gradle build. This may confuse some users that come from
+ * other languages. For example, in C/C++, a "clean" task in a Makefile will delete everything that
+ * has be built, and a following build will start from scratch. The "clean" task in the Gradle build
+ * lifecycle does the same, i.e. by default deletes everything a project has built, but AS LONG AS
+ * YOU HAVE THE BUILD CACHE ENABLED YOUR NEXT BUILD WILL STILL REUSE CACHED ARTIFACTS, IF THEIR
+ * INPUTS AND OUTPUTS ARE UNCHANGED. This is the whole point of the Gradle build cache, and XTC
+ * respects those semantics, as a Gradle citizen should. So, for example, to create a distribution
+ * of the XDK (./gradlew installDist), this is the only task you should need to code. If any
+ * of its dependencies are gone, or have changed so that their inputs and outputs now differ,
+ * it will be re-run, but otherwise, its build data will just be retrieved from the build cache.
+ * "./gradlew clean" amd then "./gradlew build" is an anti-pattern, and if your build requires
+ * these to work properly, that is a bug that should be reporoted to the build script author.
+ *
+ * To see more information on why a task is re-run, skipped or retrieved from the build cache,
+ * you can run Gradle with the --info flag.
+ *
  */
-fun alwaysRebuild(): Boolean {
-    val rebuild = (System.getenv("ORG_XTCLANG_BUILD_SANITY_CHECK_RUNTIME_FORCE_REBUILD") ?: "false").toBoolean()
-    if (rebuild) {
-        logger.warn("$prefix manualTest compile configuration is set to force rebuild (forceRebuild: true)")
-    }
-    return rebuild
-}
-
 xtcCompile {
-   /*
-    * Displays XTC runtime version (should be semanticVersion of this XDK), default is "false"
-    */
+    /*
+     * Displays XTC runtime version (should be semanticVersion of this XDK), default is "false"
+     */
     showVersion = false
 
     /*
@@ -111,9 +190,10 @@ xtcCompile {
      * Should all compilations be forced to rerun every time this build is performed? This is NOT recommended,
      * as it removes pretty much every advantage that Gradle with dynamic dependency management gives you. It
      * should be used only for testing purposes, and never for anything else, in a typical build, distribution
-     * generation or execution of an XTC app.
+     * generation or execution of an XTC app. You should never have to enable forceRebuild unless you are doing
+     * something like functionality testing during XVM compiler development.
      */
-    forceRebuild = alwaysRebuild()
+    forceRebuild = false
 
     /*
      * By default, a Gradle task swallows stdin, but it's possible to override standard input and
@@ -173,29 +253,105 @@ xtcRun {
      * Currently, all module configurations in the xtcRun DSL will be executed in sequence,
      * as their order declared.
      *
-     * We suspect that the pre-generated run tasks from the XTC Plugin are not the most optimal
-     * and intuitive way of running XTC modules. It's probably cleaner for the user to modify
-     * the configuration on task level for any runtime task, and add many simple custom run tasks
-     * for clarity. However, we haven't ahd the cycles to support the standard overrides for
-     * modules to run (all other DSL can be overridden) at task level. It is easy and encouraged
-     * to contribute to the XTC Plugin build DSL, so that we get more functionality, clearer
-     * and shorter syntax, and new features that we feel we require. It's not clear what all
-     * of these are, but working with an XTC project that applies the XTC Plugin will likely
-     * discover most of the shortcomings quickly, so that we can file enhancement requests.
-     *
-     * TODO: Add parallelism, and a simpler way to work with this.
-     * TODO: Add a nicer DSL syntax with a nested modules section.
+     * The project-global run configuration is mostly modelled on the Java Application plugin,
+     * which has a single configuration with mainClass, and a single run task. This makes sense,
+     * because if you added individual run tasks for individual modules, they would have to
+     * accept inputs (from where?), which we sort of do when it comes to the simple test
+     * default, but they would also not be a standard "here is my outputs" Gradle task. For
+     * a new task, registered without any outputs in the configuration, Gradle will always treat
+     * it as stale (does the equivalent of our Tasks.considerNeverUpToDate()), so out of the box
+     * a run task (or any Gradle task) will not be cached. Of course XTC run tasks can do anything
+     * as well, and they don't declare any outputs for the same reason.
      */
+    val moduleTestName = getTestModuleName() // module name on command line or 'TestSimple' as default
+    // Special case - use the Runner to run all tests in parallel, as long as the xtcRunAll tasks does not
+    // automatically do this with everything in the module path of the source set. Also modify that task
+    // after bugfixing to have a parallel option, through the XTC runner, or whatever it may be.
     module {
-        moduleName = "TestFizzBuzz" // Will add other ways to resolve modules too.
-        showVersion = true // Overrides env showVersion flag.
-        moduleArgs("Hello, ", "World!")
+        if (!shouldRunAllTestsInParallel()) {
+            moduleName = moduleTestName
+        } else {
+            moduleName = "Runner"
+            moduleArgs(
+                "TestAnnotations",
+                "TestArray",
+                "TestCollections",
+                "TestDefAsn",
+                "TestTry",
+                "TestGenerics",
+                "TestInnerOuter",
+                "TestFiles",
+                "TestIO",
+                "TestLambda",
+                "TestLiterals",
+                "TestLoops",
+                "TestNesting",
+                "TestNumbers",
+                "TestProps",
+                "TestMaps",
+                "TestMisc",
+                "TestQueues",
+                "TestServices",
+                "TestReflection",
+                "TestRegularExpressions",
+                "TestTuples"
+            )
+        }
     }
 }
 
+/**
+ * The task configuration below can be used to modify the behavior of the XTC compile task
+ * As-is, it is a no-op except for the logger output.
+ */
 tasks.withType<XtcCompileTask>().configureEach {
-    enabled = true // TODO @lagergren sanityCheckRuntime
     doLast {
-        logger.lifecycle("$prefix *** RECOMPILING: $name")
+        assert(prefix.contains(project.name) && prefix.contains(name)) { "Task prefix and name should contain the project name and task name." }
+        logger.lifecycle("$prefix (compile task) executed.")
     }
+}
+
+/**
+ * The task configuration below can be used to modify the behavior of the XTC "run"" task
+ * As-is, it is a no-op except for the logger output.
+ */
+tasks.withType<XtcRunTask>().configureEach {
+    doLast {
+        logger.lifecycle("$prefix XTC manualTests 'xtcRun' task executed.")
+    }
+}
+
+/**
+ * The task configuration below can be used to modify the behavior of the XTC "run all" task.
+ * As-is, it is a no-op except for the logger output.
+ *
+ *  TODO: We should also create a configuration containing all compiled modules from a source set, that
+ *        can be used to generate this list of module names. In fact, such a configuration is already created
+ *        internally, or at least componenets enough to weave it, by the plugin, when it processes source sets,
+ *        so it should be a very small enhancement in code size.
+ *
+ *   TODO: We should also support something like module groups, and be able to specify e.g. run all modules
+ *        sin a module group by group name, by passing properties on the command lines with -P or one of the other
+ *        supported property resolution mechanisms for Gradle and/or the Gradle XTC Plugin.
+ */
+
+tasks.withType<XtcRunAllTask>().configureEach {
+    doLast {
+        logger.lifecycle("$prefix XTC manualTests 'xtcRunAll' task executed.")
+    }
+}
+/**
+ * Makes it possible to pass -PtestName=<name of a test module> on the ./gradlew command line, e.g.
+ *   ./gradlew -PtestName=TestFizzBuzz
+ *
+ * If the property is not set, it will default to TestSimple
+ *
+ * If it's set to all, we should run all tests in parallel.
+ */
+fun getTestModuleName(defaultTestName: String = "TestSimple"): String {
+    return if (hasProperty("testName")) (properties["testName"] as String) else defaultTestName
+}
+
+fun shouldRunAllTestsInParallel(): Boolean {
+    return getTestModuleName() == "all"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,4 +38,6 @@ includeBuild("plugin")
 includeBuild("xdk")
 includeBuild("manualTests")
 
+// The manualTests project is part of this repository, but will only be included if the user asks for it.
+
 rootProject.name = "xvm"


### PR DESCRIPTION
On the way to detaching manual tests. 

Added support for specifying individual test names, and/or running all known test modules in parallel with the Xtc Runner (to be part of xUnit). 

They are still resolved as an included build, and getting them into an environment where the build does not know about them is easy, however, they have to move about the build, so there may be some resolution overhead. If you do not run gradle clean, this should not be a burden that adds any build time after a first run to fill the build cache. If you find yourself needing to do gradlew clean, and hence have to re-resolve manual tests and other parts of the build a lot, please report that as a GitHub issue, because we are close to a fully incremental build and we want to get there as soon as we can. 

If this can be reviewed, tested and merged, I'd be happy to sort out any remaining overhead in another pull request, but this should be a decent base.

Btw - I also need to figure out why the xtcRunAll task has stopped working somewhere along the way, so that I can simplify this even further.
