### PR TITLE
Fixed broken build. ManualTests had had the TestFizzBuzz.x deleted, and replaced with FizzBuzz.x, that defines a module with a different name. It also does not contain the parameter passing tests that the original code has. Reverting.

### DIFF
--- a/manualTests/build.gradle.kts
+++ b/manualTests/build.gradle.kts
@@ -187,7 +187,7 @@ xtcRun {
      * TODO: Add a nicer DSL syntax with a nested modules section.
      */
     module {
-        moduleName = "TestFizzBuzz" // Will add other ways to resolve modules too.
+        moduleName = "FizzBuzz" // Will add other ways to resolve modules too.
         showVersion = true // Overrides env showVersion flag.
         moduleArgs("Hello, ", "World!")
     }

--- a/manualTests/src/main/x/FizzBuzz.x
+++ b/manualTests/src/main/x/FizzBuzz.x
@@ -1,6 +1,15 @@
+// TODO: Add unit tests for both broken and working code/runtime modules.
+// TODO: Add a "test debugger" task to manualTests with the assert:debug enabled, or something.
 module FizzBuzz {
-    void run() {
+    void run(String[] args = []) {
         @Inject Console console;
+
+        loop: for (String arg : args) {
+            console.print($"FizzBuzzArgument: (args[{loop.count}] = {arg})");
+        }
+
+        //assert:debug;
+
         for (Int x : 1..100) {
             console.print(
                 switch (x % 3, x % 5) {


### PR DESCRIPTION
Fixed broken build. ManualTests had had the TestFizzBuzz.x deleted, and replaced with FizzBuzz.x, that defines a module with a different name. It also does not contain the parameter passing tests that the original code has. Reverting.