### PR TITLE
Change the log level to "info" for expected "installDist" warning

### DIFF
--- a/build-logic/common-plugins/src/main/kotlin/XdkDistribution.kt
+++ b/build-logic/common-plugins/src/main/kotlin/XdkDistribution.kt
@@ -69,7 +69,7 @@ class XdkDistribution(project: Project): XdkProjectBuildLogic(project) {
             }
             return true
         }
-        logger.warn("$prefix 'distExe' is disabled for building distributions. Only 'tar.gz' and 'zip' are allowed.")
+        logger.info("$prefix 'distExe' is disabled for building distributions. Only 'tar.gz' and 'zip' are allowed.")
         return false
     }
 


### PR DESCRIPTION
Same as [this](https://github.com/xtclang/xvm/pull/152). Build should have no extraneous messages under normal successful execution. In the future, use --info to see these messages.