### PR TITLE
Add better abstraction to distribution building code.

### DIFF
--- a/build-logic/aggregator/src/main/kotlin/org.xtclang.build.aggregator.gradle.kts
+++ b/build-logic/aggregator/src/main/kotlin/org.xtclang.build.aggregator.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 private class XdkBuildAggregator(project: Project) : Runnable {
     companion object {
         private val lifeCycleTasks =
-            listOfNotNull(ASSEMBLE_TASK_NAME, BUILD_TASK_NAME, CHECK_TASK_NAME, CLEAN_TASK_NAME)
+            listOf(ASSEMBLE_TASK_NAME, BUILD_TASK_NAME, CHECK_TASK_NAME, CLEAN_TASK_NAME)
     }
 
     private val prefix = "[${project.name}]"

--- a/build-logic/common-plugins/src/main/kotlin/GitHubPackages.kt
+++ b/build-logic/common-plugins/src/main/kotlin/GitHubPackages.kt
@@ -32,11 +32,11 @@ class GitHubPackages(project: Project) : XdkProjectBuildLogic(project) {
         private const val GITHUB_USER_RO_DEFAULT_VALUE = "xtclang-bot"
         private const val GITHUB_TOKEN_RO_DEFAULT_VALUE = "Z2hwX0ZjNGRWeDhNYmxPcnZDYWZrRW96Q0NrQXAzaVZ5RjBUb0NheAo="
 
-        val publishTaskPrefixes = listOfNotNull("list", "delete")
-        val publishTaskSuffixesRemote = listOfNotNull("AllRemotePublications")
-        val publishTaskSuffixesLocal = listOfNotNull("AllLocalPublications")
+        val publishTaskPrefixes = listOf("list", "delete")
+        val publishTaskSuffixesRemote = listOf("AllRemotePublications")
+        val publishTaskSuffixesLocal = listOf("AllLocalPublications")
 
-        fun restHeaders(token: String): List<Pair<String, String>> = listOfNotNull(
+        fun restHeaders(token: String): List<Pair<String, String>> = listOf(
             "Accept" to "application/vnd.github+json",
             "X-GitHub-Api-Version" to "2022-11-28",
             "Authorization" to "Bearer $token")

--- a/build-logic/common-plugins/src/main/kotlin/XdkDistribution.kt
+++ b/build-logic/common-plugins/src/main/kotlin/XdkDistribution.kt
@@ -1,4 +1,3 @@
-import XdkBuildLogic.Companion.getDateTimeStampWithTz
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
@@ -9,15 +8,15 @@ class XdkDistribution(project: Project): XdkProjectBuildLogic(project) {
     companion object {
         const val DISTRIBUTION_TASK_GROUP = "distribution"
         const val MAKENSIS = "makensis"
+        const val JAVATOOLS_JARFILE_PATTERN = "**/javatools*"
 
         private const val BUILD_NUMBER = "BUILD_NUMBER"
         private const val CI = "CI"
-        private const val LOCALDIST_BACKUP_DIR = "localdist-backup"
 
         private val currentOs = OperatingSystem.current()
         private val isCiEnabled = System.getenv(CI) == "true"
 
-        val distributionTasks = listOfNotNull("distTar", "distZip", "distExe")
+        val distributionTasks = listOfNotNull("distTar", "distZip")
     }
 
     init {
@@ -32,8 +31,10 @@ class XdkDistribution(project: Project): XdkProjectBuildLogic(project) {
         """.trimIndent())
     }
 
+    @Suppress("MemberVisibilityCanBePrivate") // No it can't, IntelliJ
     val distributionName: String get() = project.name // Default: "xdk"
 
+    @Suppress("MemberVisibilityCanBePrivate") // No it can't, IntelliJ
     val distributionVersion: String get() = buildString {
         append(project.version)
         if (isCiEnabled) {

--- a/build-logic/common-plugins/src/main/kotlin/XdkDistribution.kt
+++ b/build-logic/common-plugins/src/main/kotlin/XdkDistribution.kt
@@ -16,7 +16,7 @@ class XdkDistribution(project: Project): XdkProjectBuildLogic(project) {
         private val currentOs = OperatingSystem.current()
         private val isCiEnabled = System.getenv(CI) == "true"
 
-        val distributionTasks = listOfNotNull("distTar", "distZip")
+        val distributionTasks = listOf("distTar", "distZip", "distExe")
     }
 
     init {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 private val xdk = gradle.includedBuild("xdk")
 private val plugin = gradle.includedBuild("plugin")
-private val includedBuildsWithPublications = listOfNotNull(xdk, plugin)
+private val includedBuildsWithPublications = listOf(xdk, plugin)
 
 /**
  * Installation and distribution tasks that aggregate publishable/distributable included

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,19 +29,13 @@ val installDist by tasks.registering {
     XdkDistribution.distributionTasks.forEach {
         dependsOn(xdk.task(":$it"))
     }
-    dependsOn(xdk.task(":installDist"))
+    dependsOn(xdk.task(":$name"))
 }
 
 val installLocalDist by tasks.registering {
     group = DISTRIBUTION_TASK_GROUP
     description = "Build and overwrite any local distribution with the new distribution produced by the build."
     dependsOn(xdk.task(":$name"))
-}
-
-val install by tasks.registering {
-    doLast {
-        TODO("The 'install' task has been renamed to 'installDist', as per the common standard.")
-    }
 }
 
 /*

--- a/javatools/build.gradle.kts
+++ b/javatools/build.gradle.kts
@@ -124,7 +124,7 @@ val sanityCheckJar by tasks.registering {
 
         DebugBuild.verifyJarFileContents(
             project,
-            listOfNotNull(
+            listOf(
                 "implicit.x", // verify the implicits are in the jar
                 "org/xvm/tool/Compiler", // verify the javatools package is in there, including Compiler and Runner
                 "org/xvm/tool/Runner",

--- a/lib_ecstasy/build.gradle.kts
+++ b/lib_ecstasy/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.xtc)
 }
 
-val xdkTurtle by configurations.registering {
+val xdkTurtleConsumer by configurations.registering {
     isCanBeResolved = true
     isCanBeConsumed = false
     attributes {
@@ -24,11 +24,19 @@ val xdkTurtle by configurations.registering {
     }
 }
 
+val xdkUnicodeConsumer by configurations.registering {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    attributes {
+        attribute(CATEGORY_ATTRIBUTE, objects.named(LIBRARY))
+        attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objects.named("unicodeDir"))
+    }
+}
+
 dependencies {
-    // TODO: Find out why xdkJavaTools is not an unstable API, while xdkTurtle and xdkUnicode are.
     xdkJavaTools(libs.javatools)
     @Suppress("UnstableApiUsage")
-    xdkTurtle(libs.javatools.turtle) // A dependency declaration like this works equally well if we are working with an included build/project or with an artifact. This is exactly what we want.
+    xdkTurtleConsumer(libs.javatools.turtle) // A dependency declaration like this works equally well if we are working with an included build/project or with an artifact. This is exactly what we want.
 }
 
 val compileXtc by tasks.existing(XtcCompileTask::class) {
@@ -45,15 +53,7 @@ sourceSets {
     main {
         xtc {
             // mack.x is in a different project, and does not build on its own, hence we add it to the lib_ecstasy source set instead.
-            srcDir(xdkTurtle)
+            srcDir(xdkTurtleConsumer)
         }
-        //resources {
-            // Skip the local unicode files if we are in "rebuild unicode" mode.
-            //if (xdkBuild.rebuildUnicode()) {
-            //    exclude("**/ecstasy/text**")
-            //}
-        //}
     }
 }
-
-// TODO Add resource processing for unicode

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -78,7 +78,7 @@ gradlePlugin {
             displayName = getXdkProperty("$pprefix.plugin.display.name")
             description = getXdkProperty("$pprefix.plugin.description")
             logger.info("$prefix Configuring gradlePlugin; pluginId=$pluginId, implementationClass=$implementationClass, displayName=$displayName, description=$description")
-            tags = listOfNotNull("xtc", "language", "ecstasy", "xdk")
+            tags = listOf("xtc", "language", "ecstasy", "xdk")
         }
     }
 }

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
@@ -114,18 +114,20 @@ public class XtcCompileTask extends XtcSourceTask implements XtcCompilerExtensio
 
     /**
      * Add an output Filename mapping.
-     * TODO Why does IntelliJ think these are unused? Check that it doesn't lead to any unknown dependency problems for the Plugin.
      */
+    @SuppressWarnings("unused") // No, IntelliJ. It's not.
     public void outputFilename(final String from, final String to) {
         outputFilenames.add(from);
         outputFilenames.add(to);
     }
 
+    @SuppressWarnings("unused") // No, IntelliJ. It's not.
     public void outputFilename(final Pair<String, String> pair) {
         outputFilenames.add(pair.getFirst());
         outputFilenames.add(pair.getSecond());
     }
 
+    @SuppressWarnings("unused") // No, IntelliJ. It's not.
     public void outputFilename(final Provider<String> from, final Provider<String> to) {
         outputFilenames.add(from);
         outputFilenames.add(to);

--- a/xdk.properties
+++ b/xdk.properties
@@ -23,10 +23,6 @@ org.xtclang.publications.sign=false
 # Force republications of Gradle plugins every build, without explicitly changing versions.
 org.xtclang.publish.build.identifiers=false
 
-# Should install build the distExe by default - currently requires running in an environment
-# or container where 'makensis' with the EnVar plugin is installed and available.
-# org.xtclang.install.distExe=false
-
 # Java Properties; used by the XTC precompiled Java convention plugin.
 org.xtclang.java.jdk=21
 org.xtclang.java.enablePreview=false
@@ -35,4 +31,3 @@ org.xtclang.java.maxErrors=100
 org.xtclang.java.warningsAsErrors=true
 org.xtclang.java.lint=true
 org.xtclang.java.test.stdout=false
-org.xtclang.java.maxHeap=4G

--- a/xdk/build.gradle.kts
+++ b/xdk/build.gradle.kts
@@ -43,16 +43,6 @@ val xdkProvider by configurations.registering {
     }
 }
 
-val xtcUnicodeConsumer by configurations.registering {
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    // TODO: Can likely remove these.
-    attributes {
-        attribute(CATEGORY_ATTRIBUTE, objects.named(LIBRARY))
-        attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objects.named("unicodeDir"))
-    }
-}
-
 dependencies {
     xdkJavaTools(libs.javatools)
     xtcModule(libs.xdk.ecstasy)
@@ -316,7 +306,7 @@ val installLocalDist by tasks.registering {
         listOf("xcc", "xec", "xtc").forEach {
             val symLink = File(binDir, it)
             logger.info("$prefix Copying launcher '$it' -> '${launcherExe.asFile}' (on Windows, this may require developer mode settings).")
-            Files.copy(symLink.toPath(), launcherExe.asFile.toPath())
+            Files.copy(launcherExe.asFile.toPath(), symLink.toPath())
         }
     }
 }

--- a/xdk/build.gradle.kts
+++ b/xdk/build.gradle.kts
@@ -1,9 +1,9 @@
 import XdkBuildLogic.Companion.XDK_ARTIFACT_NAME_DISTRIBUTION_ARCHIVE
 import XdkDistribution.Companion.DISTRIBUTION_TASK_GROUP
+import XdkDistribution.Companion.JAVATOOLS_JARFILE_PATTERN
 import org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE
 import org.gradle.api.attributes.Category.LIBRARY
 import org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE
-import org.gradle.api.logging.LogLevel.INFO
 import org.gradle.language.base.plugins.LifecycleBasePlugin.BUILD_GROUP
 import org.xtclang.plugin.tasks.XtcCompileTask
 import java.io.ByteArrayOutputStream
@@ -135,51 +135,55 @@ val publishPluginToLocalDist by tasks.registering {
  * resolve outputs to other tasks to their explicit destination files yet, unless they have run.
  * However, we _can_ use a from spec that refers to a task, which then becomes a dependency.
  */
+
+private fun distContents(): CopySpec {
+    return copySpec {
+        val resources = tasks.processResources.get().outputs.files.asFileTree
+        logger.info("$prefix Distribution contents need to use lazy resources.")
+        from(resources) {
+            eachFile {
+                includeEmptyDirs = false
+            }
+        }
+        from(xtcLauncherBinaries) {
+            into("bin")
+        }
+        from(configurations.xtcModule) {
+            into("lib")
+            exclude("**/javatools*")
+        }
+        from(configurations.xtcModule) {
+            into("javatools")
+            include("**/javatools*")
+        }
+        from(configurations.xdkJavaTools) {
+            rename {
+                assert(it.endsWith(".jar"))
+                it.replace(Regex("-.*.jar"), ".jar")
+            }
+            into("javatools") // should just be one file with corrected dependencies, assert?
+        }
+        if (shouldPublishPluginToLocalDist()) {
+            val published = publishPluginToLocalDist.get().outputs.files
+            from(published) {
+                into("repo")
+            }
+        }
+        from(tasks.xtcVersionFile)
+    }
+}
+
 distributions {
     main {
-        distributionBaseName = xdkDist.distributionName
-        assert(distributionBaseName.get() == "xdk") // TODO: Should really rename the distribution to "xdk" explicitly per convention.
-        contents {
-            /*
-             * 1) copy build plugin repository publication of the XTC plugin to install/xdk/repo
-             * 2) copy xdk resources/main/xdk to install/xdk/
-             * 3) copy javatools_launcher/bin/\* to install/xdk/bin/
-             * 4) copy XDK modules to install/xdk/lib
-             * 5) copy javatools.jar, turtle and bridge to install/xdk/javatools
-             */
-            val xdkTemplate = tasks.processResources.map { File(it.outputs.files.singleFile, "xdk") }
-            from(xdkTemplate) {
-            }
-            from(xtcLauncherBinaries) {
-                into("bin")
-            }
-            from(configurations.xtcModule) {
-                // This copies everything not a javatools jar into javatools, which is where XTC wants the
-                // javatools_turtle.xtc and javatools_bridge.xtc modules.
-                // TODO consider breaking out javatools_bridge.xtc, javatools_turtle.xtc into a separate configuration.
-                into("lib")
-                exclude("**/javatools*")
-            }
-            from(configurations.xtcModule) {
-                into("javatools")
-                include("**/javatools*")
-            }
-            from(configurations.xdkJavaTools) {
-                rename {
-                    assert(it.endsWith(".jar"))
-                    it.replace(Regex("-.*.jar"), ".jar")
-                }
-                into("javatools") // should just be one file with corrected dependencies, assert?
-            }
-            if (shouldPublishPluginToLocalDist()) {
-                val published = publishPluginToLocalDist.get().outputs.files
-                from(published) {
-                    into("repo")
-                }
-            }
-            from(tasks.xtcVersionFile)
-        }
+        contentSpec(xdkDist.distributionName, xdkDist.distributionVersion)
     }
+    // The contents logic is broken out so we can use it in multiple distributions, should we want
+    // to build e.g. linux/windows/mac zip files. It's still not perfectly aligned with any release
+    // pipeline, or tools like JReleaser, but its a potential way to create more than one distribution and
+    // use them as the basis for any framework that works with Gradle installs and distros.
+    //create("xdk-macos") {
+    //    contentSpec("xdk", xdkDist.distributionVersion, "macosx")
+    //}
 }
 
 val cleanXdk by tasks.registering(Delete::class) {
@@ -211,11 +215,7 @@ val distExe by tasks.registering {
     description = "Use an NSIS compatible plugin to create the Windows .exe installer."
 
     dependsOn(distZip)
-    onlyIf {
-        xdkDist.shouldCreateWindowsDistribution()
-    }
 
-    // TODO: Why do we need this dependency? Likely just remove it.
     val nsi = file("src/main/nsi/xdkinstall.nsi")
     val makensis = XdkBuildLogic.findExecutableOnPath(XdkDistribution.MAKENSIS)
     onlyIf {
@@ -274,10 +274,11 @@ val assembleDist by tasks.existing {
  */
 val installDist by tasks.existing {
     inputs.files(tasks.processXtcResources, tasks.processResources)
+    dependsOn(tasks.assembleDist)
     doLast {
         logger.info("$prefix '$name' Installed distribution to '${project.layout.buildDirectory.get()}/install/' directory.")
         logger.info("$prefix Installation files:")
-        printTaskOutputs(INFO)
+        printTaskOutputs(LogLevel.INFO)
     }
 }
 
@@ -314,8 +315,8 @@ val installLocalDist by tasks.registering {
         // TODO: The launchers should just be application plugin scripts, this is kind of ridiculous.
         listOf("xcc", "xec", "xtc").forEach {
             val symLink = File(binDir, it)
-            logger.info("$prefix Creating symlink for launcher '$it' -> '${launcherExe.asFile}' (on Windows, this may require developer mode settings).")
-            Files.createSymbolicLink(symLink.toPath(), launcherExe.asFile.toPath())
+            logger.info("$prefix Copying launcher '$it' -> '${launcherExe.asFile}' (on Windows, this may require developer mode settings).")
+            Files.copy(symLink.toPath(), launcherExe.asFile.toPath())
         }
     }
 }
@@ -323,5 +324,58 @@ val installLocalDist by tasks.registering {
 val test by tasks.existing {
     doLast {
         TODO("Implement response to the check lifecycle, probably some kind of aggregate XUnit.")
+    }
+}
+
+/**
+ * Creates distribution contents based on a distribution name, version and classifier.
+ * This logic is used for the nain distribution artifact (named "xdk"), and the contents
+ * has been broken out into this function so that we can easily generate ore installations
+ * and distributions with slightly different contents, for example, based o OS, and with
+ * an OS specific launcher already in "bin".
+ */
+private fun Distribution.contentSpec(distName: String, distVersion: String, distClassifier: String = "") {
+    distributionBaseName = distName
+    version = distVersion
+    if (distClassifier.isNotEmpty()) {
+        @Suppress("UnstableApiUsage")
+        distributionClassifier = distClassifier
+    }
+
+    contents {
+        val xdkTemplate = tasks.processResources.map {
+            logger.info("$prefix Resolving processResources output (this should be during the execution phase).");
+            File(it.outputs.files.singleFile, "xdk")
+        }
+        from(xdkTemplate) {
+            eachFile {
+                includeEmptyDirs = false
+            }
+        }
+        from(xtcLauncherBinaries) {
+            into("bin")
+        }
+        from(configurations.xtcModule) {
+            into("lib")
+            exclude(JAVATOOLS_JARFILE_PATTERN)
+        }
+        from(configurations.xtcModule) {
+            into("javatools")
+            include(JAVATOOLS_JARFILE_PATTERN)
+        }
+        from(configurations.xdkJavaTools) {
+            rename {
+                assert(it.endsWith(".jar"))
+                it.replace(Regex("-.*.jar"), ".jar")
+            }
+            into("javatools") // should just be one file with corrected dependencies, assert?
+        }
+        if (shouldPublishPluginToLocalDist()) {
+            val published = publishPluginToLocalDist.get().outputs.files
+            from(published) {
+                into("repo")
+            }
+        }
+        from(tasks.xtcVersionFile)
     }
 }

--- a/xdk/settings.gradle.kts
+++ b/xdk/settings.gradle.kts
@@ -17,7 +17,7 @@ val xdkProjectPath = rootDir
 /**
  * The explicit XDK subprojects that are built for each library included in the XDK.
  */
-listOfNotNull(
+listOf(
     "lib_ecstasy",
     "lib_collections",
     "lib_aggregate",

--- a/xdk/src/main/resources/xdk/bin/cfg_linux.sh
+++ b/xdk/src/main/resources/xdk/bin/cfg_linux.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# get directory of this script
+if [[ -e "$0" ]]; then
+  DIR=$(dirname "$0")
+  DIR="$(cd "$(dirname "$DIR")" || exit; pwd)/$(basename "$DIR")"
+  EXP="Y"
+fi
+
+if [[ ! -e "${DIR}/cfg_linux.sh" ]]; then
+  DIR="$( cd "$( dirname "${(%):-%N}" )" && pwd )"
+  EXP="Y"
+fi
+
+# find the Java executable
+JTYPE=`type -p java`
+if [[ -n "${JTYPE}" ]]; then
+  JEXEC="java"
+  JADD=""
+elif [[ -n "${JAVA_HOME}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]];  then
+  ADD="${JAVA_HOME}/bin/"
+  JEXEC="${ADD}java"
+else
+  echo "Unable to find the java executable; add it to PATH, or set JAVA_HOME"
+  exit 1
+fi
+
+# verify Java version 17 or later
+JVER=$("${JEXEC}" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JMAJ="${JVER%%.*}"
+if [[ "${JMAJ}" -lt "21" ]]; then
+  echo "Java version is ${JVER}; Java 21 or later required"
+  exit 1
+fi
+
+if [[ -e "${DIR}/cfg_macos.sh" ]]; then
+  # copy launcher to various command names
+  echo "Creating command line tools: \"xcc\", \"xec\""
+  cp "${DIR}/linux_launcher" "${DIR}/xcc"
+  cp "${DIR}/linux_launcher" "${DIR}/xec"
+
+  if [[ "${EXP}" == "Y" ]]; then
+    if [[ -n "${ADD}" ]]; then
+      echo "Adding Java to PATH"
+      PATH="${PATH:+${PATH}:}${ADD}"
+    fi
+    case ":${PATH:=${DIR}}:" in
+      *:"${DIR}":*)  ;;
+      *) export PATH="${PATH:+${PATH}:}${DIR}"  ;;
+    esac
+  else
+    echo "Unable to export PATH; use \".\" or \"source\" to execute this shell file"
+  fi
+else
+  echo "Unable to identify directory containing cfg_linux.sh"
+fi


### PR DESCRIPTION
Added parameterizable distribution contents so we can modify it for several different Gradle distributions with different classifiers to get a more versatile release pipeline. Haven't actually done any yet, would want to discuss with @cpurdy first.

However, this should be possible to get in as a trivial abstraction raising change.

Also cleaned up several things related to the build, like dead code, unused configurations and so on.