### PR TITLE
Add a compiler check for self-assigned properties

### DIFF
--- a/javatools/src/main/java/org/xvm/compiler/Compiler.java
+++ b/javatools/src/main/java/org/xvm/compiler/Compiler.java
@@ -1413,6 +1413,10 @@ public class Compiler
      */
     public static final String MISSING_PARAM_RESOURCE             = "COMPILER-200";
     /**
+     * Property {0} is assigned to itself.
+     */
+    public static final String PROP_SELF_ASSIGNED                 = "COMPILER-201";
+    /**
      * {0} is not yet implemented.
      */
     public static final String NOT_IMPLEMENTED                     = "COMPILER-NI";

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -1109,7 +1109,7 @@ public class NameExpression
                         case This:
                             if (idProp.equals(argLVal))
                                 {
-                                log(errs, Severity.WARNING, Compiler.PROP_SELF_ASSIGNED,
+                                log(errs, Severity.ERROR, Compiler.PROP_SELF_ASSIGNED,
                                         idProp.getName());
                                 }
                             code.add(new L_Get(idProp, argLVal));

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -1107,6 +1107,11 @@ public class NameExpression
                             }
 
                         case This:
+                            if (idProp.equals(argLVal))
+                                {
+                                log(errs, Severity.WARNING, Compiler.PROP_SELF_ASSIGNED,
+                                        idProp.getName());
+                                }
                             code.add(new L_Get(idProp, argLVal));
 
                             m_astResult = new PropertyExprAST(ctx.getThisRegisterAST(), idProp);

--- a/javatools/src/main/resources/errors.properties
+++ b/javatools/src/main/resources/errors.properties
@@ -248,6 +248,7 @@ COMPILER-197 = Attempt to mutate the captured variable "{0}". (If intended, add 
 COMPILER-198 = Invalid annotation combination: "{0}" and "{1}" are incompatible.
 COMPILER-199 = A resource (file or directory) is missing.
 COMPILER-200 = Parameter {0} ("{1}") points to a missing resource "{2}".
+COMPILER-201 = Property "{0}" is assigned to itself.
 COMPILER-NI  = "{0}" is not yet implemented.
 
 VERIFY-01 = Unknown fatal verifier error: "{0}".

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -6,4 +6,11 @@ module TestSimple {
         console.print(s.split(' '));       // old behavior
         console.print(s.split(' ', True)); // new behavior
     }
+
+    class Test(String value) {
+        private String values;
+        construct(String value) {
+            this.values = values; // causes a compiler warning
+        }
+    }
 }


### PR DESCRIPTION
A fix for issue https://github.com/xtclang/xvm/issues/155.

It's relatively simple. The only question in my mind: should it be a warning or an error?