### PR TITLE
The debug flag in the build DSL, and its environment variable shortcuts, now supersede the Gradle debug flagging.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,15 +9,6 @@ org.gradle.caching.debug=false
 # TODO: Experiment with enabling the configuration cache later
 org.gradle.configuration-cache=false
 
-# The "debug" property (default false) enables gradle debug mode. For the kotlin dsl, you can also step through
-# build scripts.
-#
-# (See: https://docs.gradle.org/current/userguide/troubleshooting.html#sec:troubleshooting_build_logic
-#  This will halt the build and allow you to attach a remote debugger to a specific port. The default is,
-#  5005, and you may have to use --no-daemon as well, unless you attach to a suspended task.)
-org.gradle.debug=false
-org.gradle.debug.port=5005
-
 # JVM and Gradle daemon flags. The default memory usage is 700M for a Daemon, which can be slow in extreme environments.
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4G
 


### PR DESCRIPTION
Either run from a task DSL inheriting "debug = true", or set the XTC_DEBUG (and optionally XTC_DEBUG_PORT) environment variables to get every launcher task to suspend and wait for the debugger to attach.  

TODO: I will come up with some nice command line variant to do this as well.  Just need to figure out what is easy to use and saves time. 


