### PR TITLE
Tweaked SepratorWrap checkstyle rule

### DIFF
--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -76,6 +76,7 @@
         </module>
         <module name="Indentation">
             <property name="basicOffset" value="4"/>
+            <property name="lineWrappingIndentation" value="8"/>
             <property name="caseIndent" value="0"/>
         </module>
         <module name="InnerAssignment"/>

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -122,7 +122,10 @@
         <module name="RedundantImport"/>
         <module name="RedundantModifier"/>
         <module name="RightCurly"/>
-        <module name="SeparatorWrap"/>
+        <module name="SeparatorWrap">
+            <property name="option" value="nl"/>
+            <property name="tokens" value="DOT"/>
+        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
         <module name="StaticVariableName"/>

--- a/gradle/checkstyle/xtc-idea-style.xml
+++ b/gradle/checkstyle/xtc-idea-style.xml
@@ -48,6 +48,8 @@
         <emptyLine />
         <package name="java.util" withSubpackages="true" static="false" />
         <emptyLine />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
         <package name="groovy" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="kotlin" withSubpackages="true" static="false" />
@@ -86,7 +88,7 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="8" />
     </indentOptions>
     <arrangement>
       <groups />

--- a/javatools_unicode/src/main/java/org/xvm/tool/BuildUnicodeTables.java
+++ b/javatools_unicode/src/main/java/org/xvm/tool/BuildUnicodeTables.java
@@ -212,10 +212,16 @@ public class BuildUnicodeTables {
         }
 
         final var sb = new StringBuilder();
-        sb.append(name).append(": [index] \"str\" (freq) \n--------------------");
+        sb.append(name)
+            .append(": [index] \"str\" (freq) \n--------------------");
         int index = 0;
         for (final var entry : map.entrySet()) {
-            sb.append("\n[").append(index).append("] \"").append(entry.getKey()).append("\" (").append(entry.getValue()).append("x)");
+            sb.append("\n[")
+                .append(index)
+                .append("] \"")
+                .append(entry.getKey())
+                .append("\" (")
+                .append(entry.getValue()).append("x)");
             entry.setValue(index++);
         }
 
@@ -317,7 +323,9 @@ public class BuildUnicodeTables {
         @Override
         public String toString() {
             final var sb = new StringBuilder();
-            sb.append("UCD description=").append(description).append(", repertoire=\n");
+            sb.append("UCD description=")
+                .append(description)
+                .append(", repertoire=\n");
 
             int c = 0;
             for (final var item : repertoire) {

--- a/javatools_unicode/src/main/java/org/xvm/tool/BuildUnicodeTables.java
+++ b/javatools_unicode/src/main/java/org/xvm/tool/BuildUnicodeTables.java
@@ -213,15 +213,15 @@ public class BuildUnicodeTables {
 
         final var sb = new StringBuilder();
         sb.append(name)
-            .append(": [index] \"str\" (freq) \n--------------------");
+                .append(": [index] \"str\" (freq) \n--------------------");
         int index = 0;
         for (final var entry : map.entrySet()) {
             sb.append("\n[")
-                .append(index)
-                .append("] \"")
-                .append(entry.getKey())
-                .append("\" (")
-                .append(entry.getValue()).append("x)");
+                    .append(index)
+                    .append("] \"")
+                    .append(entry.getKey())
+                    .append("\" (")
+                    .append(entry.getValue()).append("x)");
             entry.setValue(index++);
         }
 
@@ -324,8 +324,8 @@ public class BuildUnicodeTables {
         public String toString() {
             final var sb = new StringBuilder();
             sb.append("UCD description=")
-                .append(description)
-                .append(", repertoire=\n");
+                    .append(description)
+                    .append(", repertoire=\n");
 
             int c = 0;
             for (final var item : repertoire) {

--- a/plugin/src/main/java/org/xtclang/plugin/ProjectDelegate.java
+++ b/plugin/src/main/java/org/xtclang/plugin/ProjectDelegate.java
@@ -104,7 +104,7 @@ public abstract class ProjectDelegate<T, R> {
     }
 
     public static XtcBuildRuntimeException buildException(
-        final Logger logger, final String prefix, final Throwable t, final String msg, final Object... args) {
+            final Logger logger, final String prefix, final Throwable t, final String msg, final Object... args) {
         logger.error(msg, t);
         return new XtcBuildRuntimeException(t, prefix + ": " + msg, args);
     }

--- a/plugin/src/main/java/org/xtclang/plugin/XtcPlugin.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcPlugin.java
@@ -14,11 +14,10 @@ import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("unused")
 public class XtcPlugin implements Plugin<Project> {
-    /** Software component for an XTC project, equivalent to components["java"], used e.g. for publishing */
-    private static final Set<Class<?>> REQUIRED_PLUGINS = Set.of(
-        JavaBasePlugin.class,
-        XtcProjectPlugin.class
-    );
+    /**
+     * Software component for an XTC project, equivalent to components["java"], used e.g. for publishing
+     */
+    private static final Set<Class<?>> REQUIRED_PLUGINS = Set.of(JavaBasePlugin.class, XtcProjectPlugin.class);
 
     @Override
     public void apply(final Project project) {

--- a/plugin/src/main/java/org/xtclang/plugin/XtcProjectDelegate.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcProjectDelegate.java
@@ -170,7 +170,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
             runTask.dependsOn(XDK_EXTRACT_TASK_NAME);
             runTask.dependsOn(compileTasks);
             logger.info("{} XtcRunTask named '{}': added dependency on: '{}' and '{}'",
-                prefix, runTask.getName(), XDK_EXTRACT_TASK_NAME, compileTasks.getNames());
+                    prefix, runTask.getName(), XDK_EXTRACT_TASK_NAME, compileTasks.getNames());
         });
         // We should increase granularity for the dependencies, so that we have an xtc equivalent of the "classes" task,
         // probable a "modules" and "<sourceSetName>" modules task. TODO: Do this when getting rid of the Java base plugin.
@@ -182,7 +182,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
                 sourceSets.forEach(sourceSet -> {
                     final var processResourcesTasks = List.of(getProcessResourcesTaskName(sourceSet), getJavaProcessResourcesTaskName(sourceSet));
                     logger.info("{} Adding resource dependency for compile task '{}' -> ({}, resource tasks: {})",
-                        prefix, task.getName(), sourceSets, processResourcesTasks);
+                            prefix, task.getName(), sourceSets, processResourcesTasks);
                     task.dependsOn(processResourcesTasks);
                 });
             }
@@ -308,7 +308,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
             task.from(resourceDirs);
             task.into(outputDir);
             task.doLast(t -> logger.info("{} Processed XTC resources for source set: {} (srcDirs: {}, destination: {})",
-                prefix, sourceSet.getName(), sourceSet.getResources().getSrcDirs(), outputDir.get()));
+                    prefix, sourceSet.getName(), sourceSet.getResources().getSrcDirs(), outputDir.get()));
         });
 
         compileTask.configure(task -> {
@@ -317,7 +317,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
             // TODO Fix more exact processResources semantics so that we use the build as resource path, and not the src. This works for first merge.
             if (forceRebuild.get()) {
                 logger.warn("{} WARNING: '{}' Force rebuild is true for this compile task. Task is flagged as always stale/non-cacheable.",
-                    prefix(projectName, compileTaskName), compileTaskName);
+                        prefix(projectName, compileTaskName), compileTaskName);
                 considerNeverUpToDate(task);
             }
             // Register this task as an XTC language compiler. Not a Java compiler.
@@ -378,7 +378,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
             task.setGroup(XDK_VERSION_GROUP_NAME);
             task.setDescription("Display XTC version for project, and sanity check its application.");
             task.doLast(t -> logger.info("{} XTC (version '{}'); Semantic Version: '{}'",
-                prefix(projectName, XDK_VERSION_TASK_NAME), project.getVersion(), getSemanticVersion()));
+                    prefix(projectName, XDK_VERSION_TASK_NAME), project.getVersion(), getSemanticVersion()));
         });
 
         tasks.register(XDK_VERSION_FILE_TASK_NAME, task -> {
@@ -390,7 +390,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
                 final var semanticVersion = getSemanticVersion();
                 final var file = version.get().getAsFile();
                 logger.info("{} Writing version information: '{}' to '{}'",
-                    prefix(projectName, XDK_VERSION_FILE_TASK_NAME), semanticVersion, file.getAbsolutePath());
+                            prefix(projectName, XDK_VERSION_FILE_TASK_NAME), semanticVersion, file.getAbsolutePath());
                 try {
                     Files.writeString(file.toPath(), semanticVersion + System.lineSeparator());
                 } catch (final IOException e) {
@@ -450,7 +450,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
 
         final var xtcModule = configs.register(xtcModuleConsumerConfig, config -> {
             config.setDescription(
-                "Configuration that contains location of the .xtc file created by other entities, so that they can be declared as dependencies.");
+                        "Configuration that contains location of the .xtc file created by other entities, so that they can be declared as dependencies.");
             config.setCanBeResolved(true);
             config.setCanBeConsumed(false);
             addXtcModuleAttributes(config);
@@ -538,7 +538,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
             final var location = getXdkContentsDir();
             artifactHandler.add(XDK_CONFIG_NAME_CONTENTS, location, artifact -> {
                 logger.info("{} Adding outgoing XDK contents artifact to project {} ({}) builtBy {} (dir).",
-                    prefix, projectName, location.get(), extractTask.getName());
+                        prefix, projectName, location.get(), extractTask.getName());
                 artifact.builtBy(extractTask);
                 artifact.setType(ArtifactTypeDefinition.DIRECTORY_TYPE);
             });
@@ -549,7 +549,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
         final String name = parentDisplayName + '.' + XTC_LANGUAGE_NAME;
         final String displayName = parentDisplayName + ' ' + XTC_LANGUAGE_NAME + " source";
         logger.info("{} Creating XTC source directory set from (parentName: {} parentDisplayName: {}, name: {}, displayName: {})",
-            prefix, parentName, parentDisplayName, name, displayName);
+                prefix, parentName, parentDisplayName, name, displayName);
 
         final ObjectFactory objects = project.getObjects();
         final var xtcSourceDirectorySet = objects.newInstance(DefaultXtcSourceDirectorySet.class, objects.sourceDirectorySet(name, displayName));
@@ -593,7 +593,7 @@ public class XtcProjectDelegate extends ProjectDelegate<Void, Void> {
             config.getResolutionStrategy().eachDependency(dependency -> {
                 final var request = dependency.getRequested();
                 logger.info("{} Config '{}'    Requests dependency (artifact: {}, moduleId: {})",
-                    prefix, config.getName(), requestToNotation(request), request.getModule());
+                        prefix, config.getName(), requestToNotation(request), request.getModule());
             });
         });
     }

--- a/plugin/src/main/java/org/xtclang/plugin/launchers/BuildThreadLauncher.java
+++ b/plugin/src/main/java/org/xtclang/plugin/launchers/BuildThreadLauncher.java
@@ -66,7 +66,7 @@ public class BuildThreadLauncher<E extends XtcLauncherTaskExtension, T extends X
         try {
             if (task.hasVerboseLogging()) {
                 logger.lifecycle("{} WARNING: (equivalent to what we are executing without forking in current thread) JavaExec command: {}",
-                    prefix, cmd.toString());
+                        prefix, cmd.toString());
             }
             // TODO: Rewrite super.redirectIo so we can reuse it here. That is prettier. Push and pop streams to field?
             //   (may be even more readable to implement it as a try-with-resources of some kind)

--- a/plugin/src/main/java/org/xtclang/plugin/launchers/JavaExecLauncher.java
+++ b/plugin/src/main/java/org/xtclang/plugin/launchers/JavaExecLauncher.java
@@ -117,7 +117,7 @@ public class JavaExecLauncher<E extends XtcLauncherTaskExtension, T extends XtcL
         if (resolvedFromConfig != null && resolvedFromXdk != null) {
             if (!versionConfig.equals(versionXdk) || !areIdenticalFiles(resolvedFromConfig, resolvedFromXdk)) {
                 logger.warn("{} Different '{}' files resolved, preferring the non-XDK version: {}",
-                    prefix, JAVATOOLS_JAR_NAME, resolvedFromConfig.getAbsolutePath());
+                        prefix, JAVATOOLS_JAR_NAME, resolvedFromConfig.getAbsolutePath());
                 return processJar(resolvedFromConfig);
             }
         }
@@ -125,7 +125,7 @@ public class JavaExecLauncher<E extends XtcLauncherTaskExtension, T extends XtcL
         if (resolvedFromConfig != null) {
             assert resolvedFromXdk == null;
             logger.info("{} Resolved unique '{}' from config/artifacts/dependencies: {} (version: {})",
-                prefix, JAVATOOLS_JAR_NAME, resolvedFromConfig.getAbsolutePath(), versionConfig);
+                    prefix, JAVATOOLS_JAR_NAME, resolvedFromConfig.getAbsolutePath(), versionConfig);
             return processJar(resolvedFromConfig);
         }
 

--- a/plugin/src/main/java/org/xtclang/plugin/launchers/NativeBinaryLauncher.java
+++ b/plugin/src/main/java/org/xtclang/plugin/launchers/NativeBinaryLauncher.java
@@ -28,7 +28,7 @@ public class NativeBinaryLauncher<E extends XtcLauncherTaskExtension, T extends 
         final var jvmArgs = cmd.getJvmArgs();
         if (DefaultXtcLauncherTaskExtension.hasModifiedJvmArgs(jvmArgs)) {
             logger.warn("{} WARNING: Launcher for mainClassName '{}' has non-default JVM args ({}). These are ignored, as we are running a native launcher.",
-                prefix, mainClassName, jvmArgs);
+                    prefix, mainClassName, jvmArgs);
         }
         return super.validateCommandLine(cmd);
     }

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
@@ -237,7 +237,7 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
             return new JavaExecLauncher<>(project, this);
         } else {
             logger.warn("{} WARNING: Created XTC launcher: Running launcher in the same thread as the build process. This is not recommended for production",
-                prefix);
+                    prefix);
             return new BuildThreadLauncher<>(project, this);
         }
     }

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
@@ -48,10 +48,10 @@ import org.xtclang.plugin.launchers.XtcLauncher;
  * <p>
  * We add a default run task to an XTC project. The default is either run nothing, or run everything.
  * First it looks in xtcRun and tries to run the modules from there.
- *    If no modules are there, we just say "nothing to run"
- *    Later - support command line modules, if we don't want to just keep that logic in build scripts, which is fine and can be lazy too.
- *    If there is a module command line, we replace the xtcRun modules with these, and we leave the tasks alone.
- *    They still override, but if you haven't touched the default xtcRun task that does what you want, i.e. runXtc -PmoduleName=foo
+ * If no modules are there, we just say "nothing to run"
+ * Later - support command line modules, if we don't want to just keep that logic in build scripts, which is fine and can be lazy too.
+ * If there is a module command line, we replace the xtcRun modules with these, and we leave the tasks alone.
+ * They still override, but if you haven't touched the default xtcRun task that does what you want, i.e. runXtc -PmoduleName=foo
  * If there is a module config in the task, it overrides/replaces those totally.
  * <p>
  * We should easily be able to create XTC run tasks of our own
@@ -76,7 +76,7 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
      * delegate. We are slowly getting rid of this delegate pattern, now that the intra-plugin
      * needed types have been resolved.
      *
-     * @param project  Project
+     * @param project Project
      */
     @Inject
     public XtcRunTask(final Project project) {
@@ -219,7 +219,7 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
 
         if (isEmpty()) {
             logger.warn("{} Task extension '{}' and/or local task configuration do not declare any modules to run for '{}'. Skipping task.",
-                prefix, ext.getName(), getName());
+                    prefix, ext.getName(), getName());
             return emptyList();
         }
 
@@ -254,10 +254,10 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
 
     @SuppressWarnings("UnusedReturnValue")
     private ExecResult runSingleModule(
-        final XtcRunModule runConfig,
-        final XtcLauncher<XtcRuntimeExtension,
-        ? extends XtcLauncherTask<XtcRuntimeExtension>> launcher,
-        final CommandLine cmd) {
+            final XtcRunModule runConfig,
+            final XtcLauncher<XtcRuntimeExtension,
+            ? extends XtcLauncherTask<XtcRuntimeExtension>> launcher,
+            final CommandLine cmd) {
         // TODO: Maybe make this inheritable + add a runMultipleModules, so that we can customize even better
         //  (e.g. XUnit, and a less hacky way of executing the XTC parallel test runner, for example)
         logger.info("{} Executing resolved xtcRuntime module closure: {}", prefix(), runConfig);

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcSourceTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcSourceTask.java
@@ -230,7 +230,7 @@ public abstract class XtcSourceTask extends XtcLauncherTask<XtcCompilerExtension
         assert dir != null && dir.isDirectory();
         final var isTopLevelSrc = topLevelSourceDirs.contains(dir);
         logger.info("{} Checking if {} is a module definition (currently, just checking if it's a top level file): {}",
-            prefix(), file.getAbsolutePath(), isTopLevelSrc);
+                prefix(), file.getAbsolutePath(), isTopLevelSrc);
         if (isTopLevelSrc || XDK_TURTLE_SOURCE_FILENAME.equalsIgnoreCase(file.getName())) {
             logger.info("{} Found module definition: {}", prefix(), file.getAbsolutePath());
             return true;


### PR DESCRIPTION
The Oracle/Sun codestyle represented by checkstyle.xml used the SeparatorWrap module, with default options, which means that for a chain of calls, e.g. StringBuilder append, separated with dots, the dot goes at the end of the line. It is more common to keep it at the start of the line, so modified that rule a little bit to allow us to have chained operators first. This is already enforced for && and || logic and similar constructrs, so it feels consistent. We can of course revisit later, and we need to get an autoformatter that works without eating all explicit line breaks, but that's a different problem. First order of business is to have a checkstyle.xml that represents a working code standard.