### PR TITLE
Added feedback from yesterday's meeting, with all debug properties now being both ENV vars and first class DSL members.

### DIFF
--- a/manualTests/build.gradle.kts
+++ b/manualTests/build.gradle.kts
@@ -269,6 +269,7 @@ xtcRun {
 // This shows how to add a custom run task that overrides the global xtcRun config.
 val runTwoTestsInSequence by tasks.registering(XtcRunTask::class) {
     group = "application"
+    debug = true
     verbose = true // override a default from xtcRun
     module {
         moduleName = "EchoTest"

--- a/manualTests/build.gradle.kts
+++ b/manualTests/build.gradle.kts
@@ -269,7 +269,13 @@ xtcRun {
 // This shows how to add a custom run task that overrides the global xtcRun config.
 val runTwoTestsInSequence by tasks.registering(XtcRunTask::class) {
     group = "application"
-    debug = true
+
+    // The default debugger settings are debug = false, debugPort = 4711 and debugSuspend = true
+    // If you run with debugSuspend = false, you can attacha devbugger to the debugPort at any time.
+    //debug = true
+    //debugPort = 5005
+    //debugSuspend = false
+
     verbose = true // override a default from xtcRun
     module {
         moduleName = "EchoTest"

--- a/plugin/src/main/java/org/xtclang/plugin/XtcLauncherTaskExtension.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcLauncherTaskExtension.java
@@ -30,7 +30,11 @@ public interface XtcLauncherTaskExtension extends Named {
 
     Property<Boolean> getDebug();
 
-    default void jvmArg(String arg) {
+    Property<Integer> getDebugPort();
+
+    Property<Boolean> getDebugSuspend();
+
+    default void jvmArg(final String arg) {
         jvmArgs(arg);
     }
 

--- a/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcLauncherTaskExtension.java
+++ b/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcLauncherTaskExtension.java
@@ -26,6 +26,8 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
 
     protected final ListProperty<String> jvmArgs;
     protected final Property<Boolean> debug;
+    protected final Property<Integer> debugPort;
+    protected final Property<Boolean> debugSuspend;
     protected final Property<Boolean> isVerbose;
     protected final Property<Boolean> isFork;
     protected final Property<Boolean> showVersion;
@@ -39,7 +41,11 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
         this.prefix = ProjectDelegate.prefix(project);
         this.objects = project.getObjects();
         this.logger = project.getLogger();
-        this.debug = objects.property(Boolean.class).convention(false);
+
+        final var env = System.getenv();
+        this.debug = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG", "false")));
+        this.debugPort = objects.property(Integer.class).convention(Integer.parseInt(env.getOrDefault("XTC_DEBUG_PORT", "4711")));
+        this.debugSuspend = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG_SUSPEND", "false")));
         this.jvmArgs = objects.listProperty(String.class).convention(DEFAULT_JVM_ARGS);
         this.isVerbose = objects.property(Boolean.class).convention(false);
         this.isFork = objects.property(Boolean.class).convention(true);
@@ -90,6 +96,16 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
     @Override
     public Property<Boolean> getDebug() {
         return debug;
+    }
+
+    @Override
+    public Property<Integer> getDebugPort() {
+        return debugPort;
+    }
+
+    @Override
+    public Property<Boolean> getDebugSuspend() {
+        return debugSuspend;
     }
 
     @Override

--- a/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcLauncherTaskExtension.java
+++ b/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcLauncherTaskExtension.java
@@ -45,7 +45,7 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
         final var env = System.getenv();
         this.debug = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG", "false")));
         this.debugPort = objects.property(Integer.class).convention(Integer.parseInt(env.getOrDefault("XTC_DEBUG_PORT", "4711")));
-        this.debugSuspend = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG_SUSPEND", "false")));
+        this.debugSuspend = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG_SUSPEND", "true")));
         this.jvmArgs = objects.listProperty(String.class).convention(DEFAULT_JVM_ARGS);
         this.isVerbose = objects.property(Boolean.class).convention(false);
         this.isFork = objects.property(Boolean.class).convention(true);

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
@@ -197,9 +197,12 @@ public class XtcCompileTask extends XtcSourceTask implements XtcCompilerExtensio
     @Override
     public void executeTask() {
         super.executeTask();
+        maybeAddJvmDebugArg();
 
         final var prefix = prefix();
         final var sourceSet = getCompileSourceSet();
+
+        maybeAddJvmDebugArg();
         final var args = new CommandLine(XTC_COMPILER_CLASS_NAME, getJvmArgs().get());
 
         if (getForceRebuild().get()) {

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
@@ -197,13 +197,10 @@ public class XtcCompileTask extends XtcSourceTask implements XtcCompilerExtensio
     @Override
     public void executeTask() {
         super.executeTask();
-        maybeAddJvmDebugArg();
 
         final var prefix = prefix();
         final var sourceSet = getCompileSourceSet();
-
-        maybeAddJvmDebugArg();
-        final var args = new CommandLine(XTC_COMPILER_CLASS_NAME, getJvmArgs().get());
+        final var args = new CommandLine(XTC_COMPILER_CLASS_NAME, resolveJvmArgs());
 
         if (getForceRebuild().get()) {
             logger.warn("{} WARNING: Force Rebuild was set; touching everything in sourceSet '{}' and its resources.", prefix, sourceSet.getName());

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -383,12 +384,12 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
         return value ? 'y' : 'n';
     }
 
-    protected final boolean maybeAddJvmDebugArg() {
+    protected final List<String> resolveJvmArgs() {
+        final var list = new ArrayList<>(getJvmArgs().get());
         if (getDebug().get()) {
-            jvmArg(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=%c,address=%d", yesOrNo(getDebugSuspend().get()), getDebugPort().get()));
+            list.add(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=%c,address=%d", yesOrNo(getDebugSuspend().get()), getDebugPort().get()));
             logger.lifecycle("{} Added debug argument: {}", prefix(), jvmArgs.get());
-            return true;
         }
-        return false;
+        return Collections.unmodifiableList(list);
     }
 }

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
@@ -184,9 +184,7 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
     public void executeTask() {
         super.executeTask();
 
-        maybeAddJvmDebugArg();
-
-        final var cmd = new CommandLine(XTC_RUNNER_CLASS_NAME, getJvmArgs().get());
+        final var cmd = new CommandLine(XTC_RUNNER_CLASS_NAME, resolveJvmArgs());
         cmd.addBoolean("--version", getShowVersion().get());
         cmd.addBoolean("--verbose", getIsVerbose().get());
         // When using the Gradle XTC plugin, having the 'xec' runtime decide to recompile stuff, is not supposed to be a thing.

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
@@ -78,6 +78,7 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
      *
      * @param project  Project
      */
+    @SuppressWarnings("ConstructorNotProtectedInAbstractClass") // Has to be public for code injection to work.
     @Inject
     public XtcRunTask(final Project project) {
         // TODO clean this up:
@@ -182,6 +183,8 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
     @Override
     public void executeTask() {
         super.executeTask();
+
+        maybeAddJvmDebugArg();
 
         final var cmd = new CommandLine(XTC_RUNNER_CLASS_NAME, getJvmArgs().get());
         cmd.addBoolean("--version", getShowVersion().get());


### PR DESCRIPTION
You can configure debug, debugPort and debugSuspend (boolean, default to false, int default to 4711, and boolean default to true) in any launcher extension DSL, and override it in any launcher task. 