### PR TITLE
Change the xtcCompile/compileXtc task default for the 'rebuild' flag and add an override

### DIFF
--- a/javatools_launcher/build.gradle.kts
+++ b/javatools_launcher/build.gradle.kts
@@ -19,6 +19,8 @@ val launcherExecutableDir = layout.projectDirectory.dir("src/main/resources/exe"
 
 val processResources by tasks.registering(Copy::class) {
     from(files(launcherExecutableDir))
+    // TODO: This may cause a warning in IDEA with non-delegated compilation, but it is safe.
+    //   "Cannot resolve resource filtering of . IDEA may fail to build project. Consider using delegated build (enabled by default)."
     exclude("**/README.md")
     eachFile {
         relativePath = RelativePath(true, name)

--- a/manualTests/build.gradle.kts
+++ b/manualTests/build.gradle.kts
@@ -205,13 +205,27 @@ xtcCompile {
     fork = true
 
     /*
-     * Should all compilations be forced to rerun every time this build is performed? This is NOT recommended,
-     * as it removes pretty much every advantage that Gradle with dynamic dependency management gives you. It
-     * should be used only for testing purposes, and never for anything else, in a typical build, distribution
-     * generation or execution of an XTC app. You should never have to enable forceRebuild unless you are doing
-     * something like functionality testing during XVM compiler development.
+     * Should all compilations be forced to rerun every time this build is performed? This is not
+     * the same thing as touching all source, and the default is "true". Rebuild means that if the
+     * compiler is called, XTC cannot ignore the compile request. XCC may chose to ignore a compile
+     * request when .x source code is unchanged, but the javatools.jar (i.e. the Compiler internals
+     * themselves) have been changed, unless the rebuild flag is set. This also means that for
+     * the default value "true", rebuild means that any change to the Launcher/javatools code will
+     * cause all xtc modules in the XDK to be rebuilt. For a lot of cases, an developer modding
+     * javatools does not need or what this, but at the moment we have no finer grained dependency
+     * mechanism to detect if any changes affect the compiler or runtime alone, or if it requires
+     * actually regenerating the XTC modules from unchanged source. For any one not working on the
+     * actual XDK, this is not a problem. For the XDK itself, the "true" default may cause longer
+     * rebuilds, but you can override the default value of the rebuild flag with the
+     * -PxtcDefaultRebuild=false" on the "gradlew" command line, or with the equivalent system
+     * variable ORG_GRADLE_PROJECT_xtcDefaultRebuild=false" exported or passed on the "gradlew"
+     * command line.
+     *
+     * Default is true (basically only meaning that if javatools.jar has changed, we need to
+     * rerun every job that depends on it, but NOT meaning that all .x source files are touched
+     * and updated, or anything like that).
      */
-    forceRebuild = false
+    rebuild = false
 
     /*
      * By default, a Gradle task swallows stdin, but it's possible to override standard input and

--- a/plugin/src/main/java/org/xtclang/plugin/XtcBuildRuntimeException.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcBuildRuntimeException.java
@@ -1,5 +1,7 @@
 package org.xtclang.plugin;
 
+import static org.xtclang.plugin.XtcBuildException.resolveEllipsis;
+
 import java.io.Serial;
 
 import org.gradle.api.GradleException;
@@ -23,6 +25,6 @@ public class XtcBuildRuntimeException extends GradleException {
     }
 
     XtcBuildRuntimeException(final Throwable cause, final String msg, final Object... args) {
-        this(cause, XtcBuildException.resolveEllipsis(msg, args));
+        this(cause, resolveEllipsis(msg, args));
     }
 }

--- a/plugin/src/main/java/org/xtclang/plugin/XtcCompilerExtension.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcCompilerExtension.java
@@ -13,5 +13,5 @@ public interface XtcCompilerExtension extends XtcLauncherTaskExtension {
 
     Property<String> getXtcVersion();
 
-    Property<Boolean> getForceRebuild();
+    Property<Boolean> getRebuild();
 }

--- a/plugin/src/main/java/org/xtclang/plugin/XtcPluginConstants.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcPluginConstants.java
@@ -55,9 +55,6 @@ public final class XtcPluginConstants {
     // Config artifacts from the XDK build:
     public static final String XDK_CONFIG_NAME_ARTIFACT_JAVATOOLS_FATJAR = "javatools-fatjar";
 
-    // Debugging (for example, adding significant events to output without increasing the log level)
-    public static final String XTC_PLUGIN_VERBOSE_PROPERTY = "ORG_XTCLANG_PLUGIN_VERBOSE";
-
     // Default "empty" values for collections and Gradle API classes.
     public static final Set<File> EMPTY_FILE_COLLECTION = Collections.emptySet();
     public static final String UNSPECIFIED = Project.DEFAULT_VERSION;

--- a/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcCompilerExtension.java
+++ b/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcCompilerExtension.java
@@ -8,25 +8,34 @@ import org.gradle.api.provider.Property;
 import org.xtclang.plugin.XtcCompilerExtension;
 
 public class DefaultXtcCompilerExtension extends DefaultXtcLauncherTaskExtension implements XtcCompilerExtension {
+    private static final String REBUILD_FLAG_DEFAULT_PROPERTY = "xtcDefaultRebuild";
+
     // Even though we have getters, these need to be protected for subclasses to be able to use them in the build DSL
     // We still have to have getters, or the plugin validation fails, and we might as well put the input properties on
     // those for readability.
     protected final Property<Boolean> disableWarnings;
-    protected final Property<Boolean> isStrict;
+    protected final Property<Boolean> strict;
     protected final Property<Boolean> hasQualifiedOutputName;
     protected final Property<Boolean> hasVersionedOutputName;
     protected final Property<String> stamp;
-    protected final Property<Boolean> shouldForceRebuild;
+    protected final Property<Boolean> rebuild;
 
     @Inject
     public DefaultXtcCompilerExtension(final Project project) {
         super(project);
+
+        final var rebuildDefaultProperty = project.findProperty(REBUILD_FLAG_DEFAULT_PROPERTY);
+        final var rebuildDefaultValue = rebuildDefaultProperty == null || Boolean.parseBoolean(rebuildDefaultProperty.toString());
+        if (!rebuildDefaultValue) {
+            logger.warn("{} Project has global override for default value of rebuild flag: false", prefix);
+        }
+        this.rebuild = objects.property(Boolean.class).convention(rebuildDefaultValue);
+
         this.disableWarnings = objects.property(Boolean.class).convention(false);
-        this.isStrict = objects.property(Boolean.class).convention(false);
+        this.strict = objects.property(Boolean.class).convention(false);
         this.hasQualifiedOutputName = objects.property(Boolean.class).convention(false);
         this.hasVersionedOutputName = objects.property(Boolean.class).convention(false);
         this.stamp = objects.property(String.class);
-        this.shouldForceRebuild = objects.property(Boolean.class).convention(false);
     }
 
     @Override
@@ -36,7 +45,7 @@ public class DefaultXtcCompilerExtension extends DefaultXtcLauncherTaskExtension
 
     @Override
     public Property<Boolean> getStrict() {
-        return isStrict;
+        return strict;
     }
 
     @Override
@@ -55,7 +64,7 @@ public class DefaultXtcCompilerExtension extends DefaultXtcLauncherTaskExtension
     }
 
     @Override
-    public Property<Boolean> getForceRebuild() {
-        return shouldForceRebuild;
+    public Property<Boolean> getRebuild() {
+        return rebuild;
     }
 }

--- a/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcLauncherTaskExtension.java
+++ b/plugin/src/main/java/org/xtclang/plugin/internal/DefaultXtcLauncherTaskExtension.java
@@ -28,8 +28,8 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
     protected final Property<Boolean> debug;
     protected final Property<Integer> debugPort;
     protected final Property<Boolean> debugSuspend;
-    protected final Property<Boolean> isVerbose;
-    protected final Property<Boolean> isFork;
+    protected final Property<Boolean> verbose;
+    protected final Property<Boolean> fork;
     protected final Property<Boolean> showVersion;
     protected final Property<Boolean> useNativeLauncher;
     protected final Property<InputStream> stdin;
@@ -43,12 +43,16 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
         this.logger = project.getLogger();
 
         final var env = System.getenv();
+
+        // TODO: Consider replacing the debug configuration with the debug flags inherited directly from its JavaExec extension
+        //   DSL, or at least reimplementing them so that they look the same for different kinds of launchers.
         this.debug = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG", "false")));
         this.debugPort = objects.property(Integer.class).convention(Integer.parseInt(env.getOrDefault("XTC_DEBUG_PORT", "4711")));
         this.debugSuspend = objects.property(Boolean.class).convention(Boolean.parseBoolean(env.getOrDefault("XTC_DEBUG_SUSPEND", "true")));
+
         this.jvmArgs = objects.listProperty(String.class).convention(DEFAULT_JVM_ARGS);
-        this.isVerbose = objects.property(Boolean.class).convention(false);
-        this.isFork = objects.property(Boolean.class).convention(true);
+        this.verbose = objects.property(Boolean.class).convention(false);
+        this.fork = objects.property(Boolean.class).convention(true);
         this.showVersion = objects.property(Boolean.class).convention(false);
         this.useNativeLauncher = objects.property(Boolean.class).convention(false);
         this.stdin = objects.property(InputStream.class);
@@ -75,7 +79,7 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
 
     @Override
     public Property<Boolean> getFork() {
-        return isFork;
+        return fork;
     }
 
     @Override
@@ -90,7 +94,7 @@ public abstract class DefaultXtcLauncherTaskExtension implements XtcLauncherTask
 
     @Override
     public Property<Boolean> getVerbose() {
-        return isVerbose;
+        return verbose;
     }
 
     @Override

--- a/plugin/src/main/java/org/xtclang/plugin/launchers/JavaExecLauncher.java
+++ b/plugin/src/main/java/org/xtclang/plugin/launchers/JavaExecLauncher.java
@@ -43,7 +43,8 @@ public class JavaExecLauncher<E extends XtcLauncherTaskExtension, T extends XtcL
 
         if (task.hasVerboseLogging()) {
             final var launchLine = cmd.toString(javaToolsJar);
-            logger.lifecycle("{} JavaExec command (launcher {}):", prefix, getClass().getSimpleName(), launchLine);
+            logger.lifecycle("{} JavaExec command (launcher {}):", prefix, getClass().getSimpleName());
+            logger.lifecycle("{}     {}", prefix, launchLine);
         }
 
         final var builder = resultBuilder(cmd);

--- a/plugin/src/main/java/org/xtclang/plugin/launchers/XtcLauncher.java
+++ b/plugin/src/main/java/org/xtclang/plugin/launchers/XtcLauncher.java
@@ -22,10 +22,11 @@ public abstract class XtcLauncher<E extends XtcLauncherTaskExtension, T extends 
 
     @Override
     public String toString() {
-        return String.format("%s (launcher='%s', task='%s', fork=%s, native=%s).", prefix, getClass().getSimpleName(), taskName, isFork(), isNativeLauncher());
+        return String.format("%s (launcher='%s', task='%s', fork=%s, native=%s).",
+                prefix, getClass().getSimpleName(), taskName, shouldFork(), isNativeLauncher());
     }
 
-    protected boolean isFork() {
+    protected boolean shouldFork() {
         return task.getFork().get();
     }
 

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcDefaultTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcDefaultTask.java
@@ -38,7 +38,7 @@ public abstract class XtcDefaultTask extends DefaultTask {
     private boolean isBeingExecuted;
 
     protected XtcDefaultTask(final Project project) {
-        this(project, ProjectDelegate.OVERRIDE_VERBOSE_LOGGING);
+        this(project, ProjectDelegate.hasVerboseLogging(project));
     }
 
     protected XtcDefaultTask(final Project project, final boolean overrideVerboseLogging) {

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
@@ -60,8 +60,8 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
     protected final Property<Boolean> debug;
     protected final Property<Integer> debugPort;
     protected final Property<Boolean> debugSuspend;
-    protected final Property<Boolean> isVerbose;
-    protected final Property<Boolean> isFork;
+    protected final Property<Boolean> verbose;
+    protected final Property<Boolean> fork;
     protected final Property<Boolean> showVersion;
     protected final Property<Boolean> useNativeLauncher;
 
@@ -93,8 +93,8 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
 
         this.jvmArgs = objects.listProperty(String.class).convention(ext.getJvmArgs());
 
-        this.isVerbose = objects.property(Boolean.class).convention(ext.getVerbose());
-        this.isFork = objects.property(Boolean.class).convention(ext.getFork());
+        this.verbose = objects.property(Boolean.class).convention(ext.getVerbose());
+        this.fork = objects.property(Boolean.class).convention(ext.getFork());
         this.showVersion = objects.property(Boolean.class).convention(ext.getShowVersion());
         this.useNativeLauncher = objects.property(Boolean.class).convention(ext.getUseNativeLauncher());
     }
@@ -106,7 +106,7 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
 
     @Override
     public boolean hasVerboseLogging() {
-        return super.hasVerboseLogging() || isVerbose.get();
+        return super.hasVerboseLogging() || verbose.get();
     }
 
     @Internal
@@ -205,12 +205,12 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
 
     @Input
     public Property<Boolean> getVerbose() {
-        return isVerbose;
+        return verbose;
     }
 
     @Input
     public Property<Boolean> getFork() {
-        return isFork;
+        return fork;
     }
 
     @Input
@@ -227,11 +227,6 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
     @Input
     public ListProperty<String> getJvmArgs() {
         return jvmArgs;
-    }
-
-    @Input
-    public Property<Boolean> getIsVerbose() {
-        return isVerbose;
     }
 
     @Internal

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcRunTask.java
@@ -186,7 +186,7 @@ public abstract class XtcRunTask extends XtcLauncherTask<XtcRuntimeExtension> im
 
         final var cmd = new CommandLine(XTC_RUNNER_CLASS_NAME, resolveJvmArgs());
         cmd.addBoolean("--version", getShowVersion().get());
-        cmd.addBoolean("--verbose", getIsVerbose().get());
+        cmd.addBoolean("--verbose", getVerbose().get());
         // When using the Gradle XTC plugin, having the 'xec' runtime decide to recompile stuff, is not supposed to be a thing.
         // The whole point about the plugin is that we guarantee source->module up-to-date relationships, as long as you follow
         // the standard build lifecycle model.

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcSourceTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcSourceTask.java
@@ -182,34 +182,6 @@ public abstract class XtcSourceTask extends XtcLauncherTask<XtcCompilerExtension
         return this;
     }
 
-    /**
-     * Update the lastModified on all source files to 'now' in the epoch. This is probably overkill, as it is used
-     * only for "forceRebuild", which really making the compileXtc[SourceSetName] tasks non-cacheable and never up
-     * to date during configuration, should be enough to accomplish. TODO: Verify this.
-     */
-    public void touchAllSource() {
-        getSource().forEach(src -> {
-            final var before = src.lastModified();
-            final var after = touch(src);
-            logger.info("{} *** File: {} (before: {}, after: {})", prefix(), src.getAbsolutePath(), before, after);
-        });
-        logger.info("{} Updated lastModified of {}.getSource() and resources to 'now' in the epoch.", prefix(), getName());
-    }
-
-    private long touch(final File file) {
-        return touch(file, System.currentTimeMillis());
-    }
-
-    private long touch(final File file, final long now) {
-        final var oldLastModified = file.lastModified();
-        if (!file.setLastModified(now)) {
-            logger.warn("{} Failed to update modification time stamp for file: {}", prefix(), file.getAbsolutePath());
-        }
-        logger.info("{} Touch file: {} (timestamp: {} -> {})", prefix(), file.getAbsolutePath(), oldLastModified, now);
-        assert file.lastModified() == now;
-        return now;
-    }
-
     protected static boolean isXtcSourceFile(final File file) {
         // TODO: Previously we called a Launcher method to ensure this was a module, but all these files should be in the top
         //   level directory of a source set, and this means that xtc will assume they are all module definitions, and fail if this

--- a/plugin/src/test/java/org/xtclang/plugin/SimpleXtcPluginTest.java
+++ b/plugin/src/test/java/org/xtclang/plugin/SimpleXtcPluginTest.java
@@ -14,16 +14,25 @@ import org.junit.jupiter.api.Test;
 // TODO: Add build script test toolkit tests that check a dsl runs the correct modules, and that it accepts
 //   command line properties, project properties/args to control which tasks to run.
 public class SimpleXtcPluginTest {
+    private static final String XTC_PLUGIN_ID = "org.xtclang.xtc-plugin";
+
+    private static Project newProject(final String name) {
+        final var project = ProjectBuilder.builder().withName(name).build();
+        project.setGroup("org.xtclang");
+        project.setVersion("1.0");
+        return project;
+    }
+
     @Test
     public void verifyPostPluginApplicationState() {
-        final Project project = ProjectBuilder.builder().build();
+        final Project project = newProject("verifyPostPluginApplicationState");
         final TaskContainer tasks = project.getTasks();
 
         final int tasksBefore = tasks.size();
         System.out.println("There are " + tasksBefore + " tasks in project '" + project.getName() + "' before plugin application:");
         tasks.forEach(task -> System.err.println('\t' + task.getName()));
 
-        project.getPluginManager().apply("org.xtclang.xtc-plugin");
+        project.getPluginManager().apply(XTC_PLUGIN_ID);
 
         final int tasksAfter = tasks.size();
         System.out.println("There are " + tasksAfter + " tasks in project '" + project.getName() + "' after plugin application:");


### PR DESCRIPTION
Changed the xtcCompile/compileXtc task default for the 'rebuild' flag to true. Stopped touching code as part of the rebuild config, because it is semantically incorrect. Cleaned up warnings. Added the property xtcDefaultRebuild, whose default is true, which will always add the --rebuild flag to the xcc process launched from the XtcCompileTask, as we know it is stale. This forces XTC to recompile XTC if any change has been made in Javatools, to ensure build soundness. To disable this, the property should be set to false, which will call xcc without --rebuild, potentially creating errors later, if the Javatools behavior changes.

Please test this with the xtcDefaultRebuild flag set to true and false and ensure it does what I think it does. Note that Gradle is smart enough to treat a very trivial whitespace change, for example, as non significant, so you need to add a small and trivial change, e.g. adding a line with a comment in Component.java, or something, that is more than just white space to produce a different hash value for the build cache. 

You can run with the old behavior with 

-PxtcDefaultRebuild=false on the Gradle command line, or by setting the corresponding environment variable "ORG_GRADLE_PROJECT_xtcDefaultRebuild=false", or by adding it on a per project basis, or any other variant of Gradle property assignment or its environment variable equivalents. 

I recommend that you also run with the -PxtcPluginOverrideVerboseLogging property set to true, or its equivalent, the env var ORG_GRADLE_PROJECT_xtcPluginOverrideVerboseLogging. 

That will show you a little bit of extra life cycle information, but nothing close to the info level, so that you can examine generated Java launcher command lines easily. 
