### PR TITLE
Change the Console.readLine() API

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/xTerminalConsole.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/xTerminalConsole.java
@@ -61,43 +61,6 @@ public class xTerminalConsole
         return pool().ensureEcstasyTypeConstant("io.Console");
         }
 
-    @Override
-    public int invokeNative1(Frame frame, MethodStructure method,
-                             ObjectHandle hTarget, ObjectHandle hArg, int iReturn)
-        {
-        switch (method.getName())
-            {
-            case "readLine": // Boolean suppressEcho = False
-                {
-                boolean fEcho = hArg != xBoolean.TRUE;
-
-                try
-                    {
-                    StringHandle hLine;
-                    if (fEcho || CONSOLE == null)
-                        {
-                        String sLine = CONSOLE_IN.readLine();
-                        hLine = sLine == null
-                            ? xString.EMPTY_STRING
-                            : xString.makeHandle(sLine);
-                        }
-                    else
-                        {
-                        char[] achLine = CONSOLE.readPassword();
-                        hLine = achLine == null
-                            ? xString.EMPTY_STRING
-                            : xString.makeHandle(achLine);
-                        }
-                    return frame.assignValue(iReturn, hLine);
-                    }
-                catch (IOException e)
-                    {
-                    return frame.raiseException(xException.ioException(frame, e.getMessage()));
-                    }
-                }
-            }
-        return super.invokeNative1(frame, method, hTarget, hArg, iReturn);
-        }
 
     @Override
     public int invokeNativeN(Frame frame, MethodStructure method, ObjectHandle hTarget,
@@ -132,6 +95,43 @@ public class xTerminalConsole
                         // fall through
                     case Op.R_EXCEPTION:
                         return iResult;
+                    }
+                }
+
+            case "readLine": // String prompt = "", Boolean suppressEcho = False
+                {
+                char[] achPrompt = ahArg[0] instanceof StringHandle hString
+                                    ? hString.getValue() : null;
+                boolean fEcho    = ahArg[1] != xBoolean.TRUE;
+
+                try
+                    {
+                    if (achPrompt != null)
+                        {
+                        CONSOLE_OUT.print(achPrompt);
+                        CONSOLE_OUT.flush();
+                        }
+
+                    StringHandle hLine;
+                    if (fEcho || CONSOLE == null)
+                        {
+                        String sLine = CONSOLE_IN.readLine();
+                        hLine = sLine == null
+                            ? xString.EMPTY_STRING
+                            : xString.makeHandle(sLine);
+                        }
+                    else
+                        {
+                        char[] achLine = CONSOLE.readPassword();
+                        hLine = achLine == null
+                            ? xString.EMPTY_STRING
+                            : xString.makeHandle(achLine);
+                        }
+                    return frame.assignValue(iReturn, hLine);
+                    }
+                catch (IOException e)
+                    {
+                    return frame.raiseException(xException.ioException(frame, e.getMessage()));
                     }
                 }
             }

--- a/javatools_bridge/src/main/x/_native/TerminalConsole.x
+++ b/javatools_bridge/src/main/x/_native/TerminalConsole.x
@@ -7,7 +7,7 @@ service TerminalConsole
     void print(Object object= "", Boolean suppressNewline = False);
 
     @Override
-    String readLine(Boolean suppressEcho = False);
+    String readLine(String prompt = "", Boolean suppressEcho = False);
 
     @Override
     String toString() {

--- a/lib_cli/src/main/x/cli.x
+++ b/lib_cli/src/main/x/cli.x
@@ -56,9 +56,7 @@ module cli.xtclang.org {
          */
         void runLoop(Catalog catalog) {
             while (True) {
-                console.print(commandPrompt, suppressNewline=True);
-
-                String command = console.readLine();
+                String command = console.readLine(commandPrompt);
 
                 if (!runCommand(command.split(' ', trim=True), catalog)) {
                     return;

--- a/lib_ecstasy/src/main/x/ecstasy/io/Console.x
+++ b/lib_ecstasy/src/main/x/ecstasy/io/Console.x
@@ -14,10 +14,11 @@ interface Console {
     /**
      * Read a line of user input from the console.
      *
+     * @param prompt        (optional) the textual prompt to output to the console
      * @param suppressEcho  (optional) pass True to prevent the automatic display of typed input to
      *                      the console as it is typed
      *
      * @return the input string
      */
-    String readLine(Boolean suppressEcho = False);
+    String readLine(String prompt = "", Boolean suppressEcho = False);
 }

--- a/manualTests/src/main/x/runner.x
+++ b/manualTests/src/main/x/runner.x
@@ -60,7 +60,7 @@ module Runner {
         }
 
         @Override
-        String readLine(Boolean suppressEcho = False) {
+        String readLine(String prompt = "", Boolean suppressEcho = False) {
             throw new Unsupported();
         }
     }

--- a/manualTests/src/main/x/webTests/Curl.x
+++ b/manualTests/src/main/x/webTests/Curl.x
@@ -31,11 +31,8 @@ module Curl {
         Client.PasswordCallback callback = realm ->
             {
             console.print($"Realm: {realm}");
-            console.print("User name: ", suppressNewline=True);
-            String name = console.readLine();
-
-            console.print("Password: ", suppressNewline=True);
-            String password = console.readLine(suppressEcho = True);
+            String name     = console.readLine("User name: ");
+            String password = console.readLine("Password: ", suppressEcho = True);
 
             return name, password;
             };

--- a/manualTests/src/main/x/webTests/Hello.x
+++ b/manualTests/src/main/x/webTests/Hello.x
@@ -38,8 +38,7 @@ module Hello
         File   store = /resources/hello/https.p12;
         String password;
         if (args.size == 0) {
-            console.print("Enter password:", suppressNewline=True);
-            password = console.readLine(suppressEcho=True);
+            password = console.readLine("Enter password:", suppressEcho=True);
         } else {
             password = args[0];
         }


### PR DESCRIPTION
The gist of the change is to add the "prompt" argument to the "readLine" API:
    
    String readLine(String prompt = "", Boolean suppressEcho = False)
   
First, IMHO it's not a bad consolidation of steps that basically **always** come together - printing a prompt, suppressing a new line, immediately followed by the readLine() call.

However, I would not consider changing it right now if I didn't step on the following anomaly.

While trying to integrate [jline](https://github.com/jline/jline3) support into the native [TerminalConsole](https://github.com/xtclang/xvm/blob/master/javatools_bridge/src/main/x/_native/TerminalConsole.x) I observed a very weird behavior. When I used [the readLine API that takes a prompt as an argument](https://github.com/jline/jline3/blob/19c031c0bccaeea6a4346bc82c04c7bd3ec18888/reader/src/main/java/org/jline/reader/LineReader.java#L586), everything behaved correctly. If I did it in two steps, printing the prompt first and calling prompt-less readLine() method next, the line editing (back space) could remove the prompt as it were a part of the entered string itself. 

To avoid that behavior we would need either report a bug with jline and wait for a resolution or change our "readLine" to take the prompt.