### PR TITLE
Add default args for Map.toString() API

### DIFF
--- a/lib_ecstasy/src/main/x/ecstasy/collections/Map.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/Map.x
@@ -725,6 +725,22 @@ interface Map<Key, Value>
         return buf;
     }
 
+    @Override
+    String toString(
+            String?                 sep         = ", ",
+            String?                 pre         = "[",
+            String?                 post        = "]",
+            String?                 keySep      = "=",
+            Int?                    limit       = Null,
+            String?                 trunc       = "...",
+            function String(Key)?   keyRender   = Null,
+            function String(Value)? valueRender = Null) {
+
+        StringBuffer buf = new StringBuffer(
+            estimateStringLength(sep, pre, post, keySep, limit, trunc, keyRender, valueRender));
+        return appendTo(buf, sep, pre, post, keySep, limit, trunc, keyRender, valueRender).toString();
+    }
+
 
     // ----- equality ------------------------------------------------------------------------------
 

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -3,9 +3,8 @@ module TestSimple {
     @Inject Console console;
 
     void run() {
-        while (True) {
-            String s = console.readLine("Test>");
-            console.print($"+++ {s} ---");
-        }
+        Map<Int, String> m = [1="a", 2="b"];
+
+        console.print(m.toString(pre="", post="", sep =",\n"));
     }
 }


### PR DESCRIPTION
About six month ago [we expanded Collection.toString() API](https://github.com/xtclang/xvm/commit/bd3e027dccf09e5a9716102eee49072f0fd67a14) to simplify the use of all the extra arguments on [appendTo() method](https://github.com/xtclang/xvm/blob/bd3e027dccf09e5a9716102eee49072f0fd67a14/lib_ecstasy/src/main/x/ecstasy/collections/Collection.x#L1108).

It seems very natural to do the same for the Map.toString().

As a minor wrinkle, while doing that change, I discovered two issues:

1.  An assertion in `TypeConstant.layerOnMethods()` that should've been an error.
2. An incorrect order of "re-base", "extends" and "into" contributions. Since the actual processing happens in reverse order (the last added contribution is processed first), the addition order should be "into", "extends" and "re-base" )so "re-base" would be processed first.)