### PR TITLE
Resolve #191

### DIFF
--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -6152,7 +6152,13 @@ public class Parser
      */
     protected boolean eof()
         {
-        return !m_lexer.hasNext();
+        return !(m_lexer.hasNext() || notEof(m_token) || notEof(m_tokenPutBack));
+        }
+
+    private boolean notEof(Token token)
+        {
+        return token != null
+            && !(token.getStartPosition() == token.getEndPosition() && token.getId() == Id.R_CURLY);
         }
 
     /**

--- a/manualTests/src/main/x/numbers.x
+++ b/manualTests/src/main/x/numbers.x
@@ -246,13 +246,13 @@ module TestNumbers {
         while (True) {
             console.print($"f={f} d={d}");
             if (f.infinity) {
-                console.print($"++: {f + f)}\t{d + d}");
-                console.print($"--: {f - f)}\t{d - d}");
-                console.print($"**: {f * f)}\t{d * d}");
-                console.print($"//: {f / f)}\t{d / d}");
-                console.print($"+1: {f + 1)}\t{d + 1}");
-                console.print($"-1: {f - 1)}\t{d - 1}");
-                console.print($"1/: {1 / f)}\t{1 / d}");
+                console.print($"++: {f + f}\t{d + d}");
+                console.print($"--: {f - f}\t{d - d}");
+                console.print($"**: {f * f}\t{d * d}");
+                console.print($"//: {f / f}\t{d / d}");
+                console.print($"+1: {f + 1}\t{d + 1}");
+                console.print($"-1: {f - 1}\t{d - 1}");
+                console.print($"1/: {1 / f}\t{1 / d}");
 
                 console.print($"ln: {f.log()}\t{d.log()}");
                 break;


### PR DESCRIPTION
We were not correctly detecting EOF while parsing template expressions. Explicit EOF checking was based only on Lexer exhaustion, but that didn't account for the "current" token or the "push back" token. To complicate matters, when using the matching/peeking parsing helper methods, the parser will add a fake token (a closing curly brace) when EOF is encountered, so that deeply nested parsing code doesn't have to have to handle the repercussions of EOF until it comes back out from its deep recursion. Once we corrected the explicit EOF check to account for the current and push-back tokens, the pseudo token then obscured the EOF state, so we had to account for that as well. As a side-effect of fixing this, we uncovered an ancient syntax error (cut & pasted a half dozen times) in one of our tests. All fixed now.