### PR TITLE
Fix the compiler inference inconsistencies

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
@@ -165,7 +165,7 @@ public class DynamicFormalConstant
                 {
                 }
             }
-        return null;
+        return resolver.resolveFormalType(this);
         }
 
     @Override
@@ -244,10 +244,7 @@ public class DynamicFormalConstant
     @Override
     public String getValueString()
         {
-        int nReg = getRegisterIndex();
-
-        return (nReg >= Register.UNKNOWN ? "?" : String.valueOf(nReg)) +
-               "=>" + m_constFormal.getValueString();
+        return getName() + '.' + m_constFormal.getName();
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
@@ -12,7 +12,6 @@ import java.util.Set;
 
 import org.xvm.asm.Annotation;
 import org.xvm.asm.ClassStructure;
-import org.xvm.asm.Component;
 import org.xvm.asm.ComponentResolver.ResolutionCollector;
 import org.xvm.asm.ComponentResolver.ResolutionResult;
 import org.xvm.asm.ConstantPool;
@@ -679,14 +678,14 @@ public class IntersectionTypeConstant
         // since Enum values cannot be extended, an Enum value type cannot be combined with any
         // other type and an intersection with a formal type doesn't actually narrow that Enum value type;
         // this obviously applies to Nullable
-        if (isEnumValue(typeRight))
+        if (typeRight.isEnumValue())
             {
-            if (isEnumValue(thisLeft1) && thisLeft2.isFormalType())
+            if (thisLeft1.isEnumValue() && thisLeft2.isFormalType())
                 {
                 // Nullable + Element <= Nullable (if Element's constraint is trivial)
                 return rel1.worseOf(typeRight.calculateRelation(thisLeft2.resolveConstraints()));
                 }
-            if (thisLeft1.isFormalType() && isEnumValue(thisLeft2))
+            if (thisLeft1.isFormalType() && thisLeft2.isEnumValue())
                 {
                 // Element + Lesser <= Lesser (if Element's constraint is trivial)
                 return rel2.worseOf(typeRight.calculateRelation(thisLeft1.resolveConstraints()));
@@ -694,16 +693,6 @@ public class IntersectionTypeConstant
             }
 
         return rel1.worseOf(rel2);
-        }
-
-    /**
-     * @return true iff the type represents an Enum value
-     */
-    private boolean isEnumValue(TypeConstant typeRight)
-        {
-        return typeRight.isExplicitClassIdentity(false) &&
-               typeRight.getExplicitClassFormat() == Component.Format.ENUMVALUE
-               || typeRight.isOnlyNullable();
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -524,7 +524,7 @@ public abstract class TypeConstant
     public boolean isEnumValue()
         {
         return isExplicitClassIdentity(false) &&
-               getExplicitClassFormat() == Component.Format.ENUMVALUE
+                    getExplicitClassFormat() == Component.Format.ENUMVALUE
                || isOnlyNullable();
         }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -519,6 +519,16 @@ public abstract class TypeConstant
         }
 
     /**
+     * @return true iff the type represents an Enum value
+     */
+    public boolean isEnumValue()
+        {
+        return isExplicitClassIdentity(false) &&
+               getExplicitClassFormat() == Component.Format.ENUMVALUE
+               || isOnlyNullable();
+        }
+
+    /**
      * @return true iff this type represents a virtual child type
      */
     public boolean isVirtualChild()
@@ -931,12 +941,30 @@ public abstract class TypeConstant
             return that;
             }
 
-        // the type of Type is known to have a distributive property:
-        // Type<X> + Type<Y> == Type<X + Y>
-        return this.isTypeOfType() && this.getParamsCount() > 0 &&
-               that.isTypeOfType() && that.getParamsCount() > 0
-                ? this.getParamType(0).combine(pool, that.getParamType(0)).getType()
-                : pool.ensureIntersectionTypeConstant(this, that);
+        if (this.getClass() == that.getClass() && isSingleUnderlyingClass(true))
+            {
+            if (this instanceof ParameterizedTypeConstant)
+                {
+                TypeConstant typeThis = this.getUnderlyingType();
+                TypeConstant typeThat = that.getUnderlyingType();
+                if (typeThis.equals(typeThat))
+                    {
+                    // Parameterized types are known to have a distributive property:
+                    // T<E1> + T<E2> == T<E1 + E2>
+                    TypeConstant[] atypeThis  = this.getParamTypesArray();
+                    TypeConstant[] atypeThat  = that.getParamTypesArray();
+                    int            cTypes     = Math.max(atypeThis.length, atypeThat.length);
+                    TypeConstant[] atypeInter = new TypeConstant[cTypes];
+                    for (int i = 0; i < cTypes; i++)
+                        {
+                        atypeInter[i] = this.getParamType(i).combine(pool, that.getParamType(i));
+                        }
+                    return pool.ensureParameterizedTypeConstant(typeThis, atypeInter);
+                    }
+                }
+            }
+
+        return pool.ensureIntersectionTypeConstant(this, that);
         }
 
     /**
@@ -963,12 +991,53 @@ public abstract class TypeConstant
             return this;
             }
 
-        // type Type is known to have a distributive property:
-        // Type<X> | Type<Y> == Type<X | Y>
-        return this.isTypeOfType() && this.getParamsCount() > 0 &&
-               that.isTypeOfType() && that.getParamsCount() > 0
-                ? this.getParamType(0).union(pool, that.getParamType(0)).getType()
-                : pool.ensureUnionTypeConstant(this, that);
+        if (this.getClass() == that.getClass() && isSingleUnderlyingClass(true))
+            {
+            if (this instanceof ParameterizedTypeConstant)
+                {
+                TypeConstant typeThis = this.getUnderlyingType();
+                TypeConstant typeThat = that.getUnderlyingType();
+                if (typeThis.equals(typeThat))
+                    {
+                    // Parameterized types are known to have a distributive property:
+                    // T<E1> | T<E2> == T<E1 | E2>
+                    TypeConstant[] atypeThis  = this.getParamTypesArray();
+                    TypeConstant[] atypeThat  = that.getParamTypesArray();
+                    int            cTypes     = Math.max(atypeThis.length, atypeThat.length);
+                    TypeConstant[] atypeUnion = new TypeConstant[cTypes];
+                    for (int i = 0; i < cTypes; i++)
+                        {
+                        atypeUnion[i] = this.getParamType(i).union(pool, that.getParamType(i));
+                        }
+                    return pool.ensureParameterizedTypeConstant(typeThis, atypeUnion);
+                    }
+                }
+            else if (this instanceof ImmutableTypeConstant)
+                {
+                // if (T1 | T2) is a single underlying class type, then
+                // (immutable T1) | (immutable T2) == (immutable (T1 | T2))
+                TypeConstant typeThis  = this.getUnderlyingType();
+                TypeConstant typeThat  = that.getUnderlyingType();
+                TypeConstant typeUnion = typeThis.union(pool, typeThat);
+                if (typeUnion.isSingleUnderlyingClass(true))
+                    {
+                    return pool.ensureImmutableTypeConstant(typeUnion);
+                    }
+                // atm, we don't allow (immutable (T1 | T2))
+                }
+            else if (this.isEnumValue() && that.isEnumValue())
+                {
+                // if both T1 and T2 are enum values of the same enum, then use the enum type
+                IdentityConstant idEnumThis = this.getSingleUnderlyingClass(false).getNamespace();
+                IdentityConstant idEnumThat = that.getSingleUnderlyingClass(false).getNamespace();
+                if (idEnumThis.equals(idEnumThat))
+                    {
+                    return idEnumThis.getType();
+                    }
+                }
+            }
+
+        return pool.ensureUnionTypeConstant(this, that);
         }
 
     /**
@@ -6542,13 +6611,21 @@ public abstract class TypeConstant
     /**
      * Check if this type contains a dynamic formal type based on the specified register.
      *
-     * @param register  the register to check for (null for all)
+     * @param register the register to check for (null for all)
      *
      * @return true iff the TypeConstant contains a dynamic formal type
      */
     public boolean containsDynamicType(Register register)
         {
         return getUnderlyingType().containsDynamicType(register);
+        }
+
+    /**
+     * @return true iff this type contains any dynamic formal type
+     */
+    public boolean containsDynamicType()
+        {
+        return containsDynamicType(null);
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/op/MoveVar.java
+++ b/javatools/src/main/java/org/xvm/asm/op/MoveVar.java
@@ -10,6 +10,7 @@ import org.xvm.asm.OpMove;
 import org.xvm.asm.Register;
 
 import org.xvm.asm.constants.TypeConstant;
+
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.ExceptionHandle;

--- a/javatools/src/main/java/org/xvm/compiler/ast/ArrayAccessExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ArrayAccessExpression.java
@@ -132,6 +132,10 @@ public class ArrayAccessExpression
         {
         }
 
+    @Override
+    public void resetLValueTypes(Context ctx)
+        {
+        }
 
     // ----- compilation ---------------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/AssignmentStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/AssignmentStatement.java
@@ -703,12 +703,6 @@ public class AssignmentStatement
                         atypeRight = exprRightNew.getTypes();
                         }
                     }
-                else
-                    {
-                    // this could only happen after an error had been reported
-                    assert errs.hasSeriousErrors();
-                    return null;
-                    }
 
                 if (fInfer)
                     {
@@ -716,7 +710,6 @@ public class AssignmentStatement
                     }
 
                 merge(ctxRValue, ctxLValue);
-
                 exprLeft.markAssignment(ctxRValue, false, errs);
                 break;
                 }
@@ -724,6 +717,7 @@ public class AssignmentStatement
 
         if (exprRightNew == null)
             {
+            nodeLeft.resetLValueTypes(ctx);
             return null;
             }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/AstNode.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/AstNode.java
@@ -464,7 +464,7 @@ public abstract class AstNode
         }
 
     /**
-     * Code Container method: TODO
+     * (Code Container method.)
      *
      * @return the required return types from the code container, which comes from the signature if
      *         is specified, or from the specified required type during validation, or from the
@@ -476,7 +476,7 @@ public abstract class AstNode
         }
 
     /**
-     * Code Container method: Determine if the code container represents a method or function with
+     * (Code Container method.) Determine if the code container represents a method or function with
      * a conditional return.
      *
      * @return true iff the code container has a conditional return
@@ -487,7 +487,7 @@ public abstract class AstNode
         }
 
     /**
-     * Code Container method: TODO
+     * (Code Container method.) Collect the return types into the specified array.
      *
      * @param atypeRet  the types being returned
      */
@@ -510,7 +510,7 @@ public abstract class AstNode
         }
 
     /**
-     * (LValue method)
+     * (LValue method.)
      *
      * @return true iff this AstNode is syntactically capable of being an L-Value
      */
@@ -520,7 +520,7 @@ public abstract class AstNode
         }
 
     /**
-     * (LValue method)
+     * (LValue method.)
      *
      * @return the syntactically-capable LValue expression, iff {@link #isLValueSyntax()} returns
      *         true
@@ -531,7 +531,7 @@ public abstract class AstNode
         }
 
     /**
-     * (LValue method)
+     * (LValue method.) Update the LValue based on the RValue types.
      *
      * @param ctx     the compiler context
      * @param branch  the branch to apply the inference to
@@ -540,6 +540,17 @@ public abstract class AstNode
      */
     public void updateLValueFromRValueTypes(Context ctx, Context.Branch branch, boolean fCond,
                                             TypeConstant[] aTypes)
+        {
+        throw notLValue();
+        }
+
+    /**
+     * (LValue method.) Reset any inferences for the LValue types (usually due to a compilation
+     * failure).
+     *
+     * @param ctx the compiler context
+     */
+    public void resetLValueTypes(Context ctx)
         {
         throw notLValue();
         }
@@ -1797,7 +1808,7 @@ public abstract class AstNode
     /**
      * @return true iff all the specified types are equal to the "void" tuple
      */
-    protected boolean isVoid(TypeConstant... atype)
+    protected static boolean isVoid(TypeConstant... atype)
         {
         for (TypeConstant type : atype)
             {
@@ -2028,9 +2039,7 @@ public abstract class AstNode
         }
 
     /**
-     * TODO doc
-     *
-     * @return
+     * Used for debugging only.
      */
     public String getDumpDesc()
         {

--- a/javatools/src/main/java/org/xvm/compiler/ast/Context.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Context.java
@@ -553,7 +553,7 @@ public class Context
                     TypeConstant typeArg = getVar(sName).getType();
                     if (!regDest.getType().equals(typeArg))
                         {
-                        mapArgMods.putIfAbsent(sName, regDest.narrowType(typeArg));
+                        mapArgMods.put(sName, regDest.narrowType(typeArg));
                         }
                     }
                 }

--- a/javatools/src/main/java/org/xvm/compiler/ast/Context.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Context.java
@@ -543,6 +543,20 @@ public class Context
                 {
                 mapArgMods.put(sName, getVar(sName));
                 }
+
+            // there could be some narrowed arguments that didn't get into the assignment map
+            for (String sName : getNameMap().keySet())
+                {
+                if (!mapArgMods.containsKey(sName) &&
+                        ctxDest.getVar(sName) instanceof Register regDest)
+                    {
+                    TypeConstant typeArg = getVar(sName).getType();
+                    if (!regDest.getType().equals(typeArg))
+                        {
+                        mapArgMods.putIfAbsent(sName, regDest.narrowType(typeArg));
+                        }
+                    }
+                }
             }
         }
 
@@ -577,9 +591,13 @@ public class Context
                 asnNew = getVarAssignment(sName).join(asnNew);
                 }
             mapAsn.put(sName, asnNew);
+            }
 
-            Register regNew = (Register) mapAddArg.get(sName);
-            if (regNew != null)
+        for (Entry<String, Argument> entry : mapAddArg.entrySet())
+            {
+            String sName = entry.getKey();
+
+            if (entry.getValue() instanceof Register regNew)
                 {
                 Register regOld = (Register) getVar(sName);
                 assert regOld != null;
@@ -804,6 +822,30 @@ public class Context
                 {
                 mapNarrowing.keySet().retainAll(map.keySet());
                 }
+            }
+        }
+
+    /**
+     * Restore the original types for all narrowed arguments in this context.
+     */
+    public void restoreOriginalTypes()
+        {
+        for (String sName : getNameMap().keySet())
+            {
+            restoreOriginalType(sName);
+            }
+        }
+
+    /**
+     * Restore the original type for the specified argument.
+     *
+     * @param sName  the argument name
+     */
+    protected void restoreOriginalType(String sName)
+        {
+        if (getVar(sName) instanceof Register regOrig)
+            {
+            replaceArgument(sName, Branch.Always, regOrig.restoreType());
             }
         }
 
@@ -1427,7 +1469,10 @@ public class Context
                reg.getOriginalType().isFormalType() ||
                reg.getOriginalType().getParamType(0).isFormalType();
 
-        replaceArgument(sName, branch, reg.narrowType(typeNarrow));
+        if (reg.isInPlace() || !reg.getType().equals(typeNarrow))
+            {
+            replaceArgument(sName, branch, reg.narrowType(typeNarrow));
+            }
         }
 
     /**
@@ -1479,7 +1524,13 @@ public class Context
             }
         else
             {
-            map.remove(sName);
+            map.remove(sName); // remove the argument from this scope before calling "getVar()"
+
+            Argument argOrig = getVar(sName);
+            if (argOrig != null && !argOrig.getType().equals(regOrig.getType()))
+                {
+                map.put(sName, regOrig);
+                }
             }
         }
 
@@ -1576,16 +1627,13 @@ public class Context
         Map<FormalConstant, TypeConstant> map = ensureFormalTypeMap(branch);
 
         TypeConstant typeOld = map.get(constFormal);
-        if (typeOld != null)
+        if (typeOld == null)
             {
-            TypeConstant typeNew = argNew.getType();
-
-            TypeConstant typeJoin = typeNew.union(pool(), typeOld);
-            map.put(constFormal, typeJoin);
+            map.remove(constFormal);
             }
         else
             {
-            map.remove(constFormal);
+            map.put(constFormal, argNew.getType().union(pool(), typeOld));
             }
         }
 
@@ -1665,12 +1713,19 @@ public class Context
             public TypeConstant resolveFormalType(FormalConstant constFormal)
                 {
                 TypeConstant typeType = getFormalTypeMap(branch).get(constFormal);
-                if (typeType == null)
+                if (typeType != null)
                     {
-                    return resolveLocalVar(constFormal.getName(), branch);
+                    assert typeType.isTypeOfType();
+                    return typeType.getParamType(0);
                     }
-                assert typeType.isTypeOfType();
-                return typeType.getParamType(0);
+
+                String   sName = constFormal.getName();
+                Argument arg   = getLocalVar(sName, branch);
+                return arg == null
+                        ? isFunction() || !constFormal.isProperty()
+                                ? null
+                                : getThisClass().getFormalType().resolveGenericType(sName)
+                        : extractElementType(arg);
                 }
 
             @Override
@@ -1688,19 +1743,16 @@ public class Context
                         }
                     }
 
-                return resolveLocalVar(sFormalName, branch);
+                Argument arg = getLocalVar(sFormalName, branch);
+                return arg == null
+                        ? isFunction()
+                                ? null
+                                : getThisClass().getFormalType().resolveGenericType(sFormalName)
+                        : extractElementType(arg);
                 }
 
-            private TypeConstant resolveLocalVar(String sFormalName, Branch branch)
+            private TypeConstant extractElementType(Argument arg)
                 {
-                Argument arg = getLocalVar(sFormalName, branch);
-                if (arg == null)
-                    {
-                    return isFunction()
-                            ? null
-                            : getThisClass().getFormalType().resolveGenericType(sFormalName);
-                    }
-
                 TypeConstant typeType = arg.getType();
                 return typeType.isTypeOfType()
                         ? typeType.getParamType(0)

--- a/javatools/src/main/java/org/xvm/compiler/ast/ElseExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ElseExpression.java
@@ -130,7 +130,7 @@ public class ElseExpression
         if (!expr1New.isShortCircuiting())
             {
             expr1New.log(errs, Severity.ERROR, Compiler.SHORT_CIRCUIT_REQUIRED);
-            return replaceThisWith(expr1New);
+            return null;
             }
 
         // the only allowed type mismatch is a conditional result on the left (expr1) and the value

--- a/javatools/src/main/java/org/xvm/compiler/ast/ElvisExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ElvisExpression.java
@@ -204,7 +204,7 @@ public class ElvisExpression
             if (type1.isOnlyNullable())
                 {
                 expr1New.log(errs, Severity.ERROR, Compiler.ELVIS_ONLY_NULLABLE);
-                return replaceThisWith(expr2New);
+                return null;
                 }
 
             // the second check is for not-nullable type that is still allowed to be assigned from
@@ -212,7 +212,7 @@ public class ElvisExpression
             if (!type1.isNullable() && !pool.typeNull().isA(type1.resolveConstraints()))
                 {
                 expr1New.log(errs, Severity.ERROR, Compiler.ELVIS_NOT_NULLABLE);
-                return replaceThisWith(expr1New);
+                return null;
                 }
 
             type1Non = type1.removeNullable();

--- a/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
@@ -737,13 +737,10 @@ public abstract class Expression
                         // if the expression's type is an enum value, widen it to its parent
                         // Enumeration; for example, if the argument is Null, widen the type to
                         // Nullable, if the type is True widen it to Boolean, etc.
-                        if (typeResolved.isExplicitClassIdentity(false))
+                        if (typeResolved.isEnumValue())
                             {
-                            IdentityConstant id = (IdentityConstant) typeResolved.getDefiningConstant();
-                            if (id.getComponent().getFormat() == Component.Format.ENUMVALUE)
-                                {
-                                typeResolved = id.getNamespace().getType();
-                                }
+                            typeResolved = typeResolved.getSingleUnderlyingClass(false).
+                                                getNamespace().getType();
                             }
                         mapResolve.put(sName, typeResolved);
                         }

--- a/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
@@ -871,12 +871,12 @@ public class InvocationExpression
                 int             cReturns    = atypeReturn == null ? 0 : atypeReturn.length;
                 boolean         fCondReturn = method.isConditionalReturn() && cReturns > 1;
 
-                if (cTypeParams > 0)
+                if (cParams > 0)
                     {
-                    // purge the type parameters and resolve the method signature
-                    // against all the types we know by now (marking unresolved as "pending")
-                    if (cParams > 0)
+                    if (cTypeParams > 0)
                         {
+                        // purge the type parameters and resolve the method signature
+                        // against all the types we know by now (marking unresolved as "pending")
                         GenericTypeResolver resolver = makeTypeParameterResolver(ctx, method, true,
                                 typeLeft,
                                 fCall || cReturns == 0
@@ -894,7 +894,22 @@ public class InvocationExpression
                         }
                     else
                         {
-                        atypeParams = TypeConstant.NO_TYPES;
+                        atypeParams = atypeParams.clone();
+                        }
+                    }
+                else
+                    {
+                    atypeParams = TypeConstant.NO_TYPES;
+                    }
+
+                // now try to resolve the formal types for parameters validation
+                for (int i = 0, c = atypeParams.length; i < c; i++)
+                    {
+                    TypeConstant type = atypeParams[i];
+                    if (type.containsFormalType(true))
+                        {
+                        // choose the wider type between the original and resolved ones
+                        atypeParams[i] = type.union(pool, ctx.resolveFormalType(type));
                         }
                     }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/LiteralExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/LiteralExpression.java
@@ -263,6 +263,12 @@ public class LiteralExpression
             }
 
         assert constVal != null;
+
+        if (typeRequired != null && typeRequired.isFormalType())
+            {
+            // find a conversion to the constraint type
+            typeRequired = typeRequired.resolveConstraints();
+            }
         return finishValidation(ctx, typeRequired, typeActual, TypeFit.Fit, constVal, errs);
         }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/MethodDeclarationStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/MethodDeclarationStatement.java
@@ -530,7 +530,7 @@ public class MethodDeclarationStatement
                     {
                     // this is a short-hand property method
                     List<AnnotationExpression> annotations =
-                        ((PropertyDeclarationStatement) getParent().getParent()).annotations; // TODO: replace
+                        ((PropertyDeclarationStatement) getParent().getParent()).annotations;
 
                     MethodStructure methodSuper = findRefMethod(property, annotations, sName, params);
                     if (methodSuper == null)

--- a/javatools/src/main/java/org/xvm/compiler/ast/MultipleLValueStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/MultipleLValueStatement.java
@@ -116,6 +116,16 @@ public class MultipleLValueStatement
         }
 
     @Override
+    public void resetLValueTypes(Context ctx)
+        {
+        List<AstNode>  listLVals = LVals;
+        for (int i = 0, c = listLVals.size(); i < c; ++i)
+            {
+            listLVals.get(i).resetLValueTypes(ctx);
+            }
+        }
+
+    @Override
     protected boolean isRValue(Expression exprChild)
         {
         return false;
@@ -344,6 +354,12 @@ public class MultipleLValueStatement
                                                 TypeConstant[] aTypes)
             {
             getParent().updateLValueFromRValueTypes(ctx, branch, fCond, aTypes);
+            }
+
+        @Override
+        public void resetLValueTypes(Context ctx)
+            {
+            getParent().resetLValueTypes(ctx);
             }
 
         @Override

--- a/javatools/src/main/java/org/xvm/compiler/ast/NotNullExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NotNullExpression.java
@@ -99,13 +99,18 @@ public class NotNullExpression
                 return null;
 
             case 1:
-                return atype[0].removeNullable();
+                {
+                TypeConstant type = atype[0];
+                return type.isNullable() ? type.removeNullable() : null;
+                }
 
             default:
+                {
                 TypeConstant type0 = atype[0];
                 return type0.isA(pool().typeBoolean())
                         ? atype[1]
-                        : type0.removeNullable();
+                        : type0.isNullable() ? type0.removeNullable() : null;
+                }
             }
         }
 
@@ -182,7 +187,7 @@ public class NotNullExpression
         if (!fCond && !typeResult.isNullable() && !pool().typeNull().isA(typeResult.resolveConstraints()))
             {
             exprNew.log(errs, Severity.ERROR, Compiler.ELVIS_NOT_NULLABLE);
-            return replaceThisWith(exprNew);
+            return null;
             }
 
         AstNode parent = getParent();
@@ -241,6 +246,12 @@ public class NotNullExpression
     protected boolean allowsConditional(Expression exprChild)
         {
         return m_fCond;
+        }
+
+    @Override
+    public void resetLValueTypes(Context ctx)
+        {
+        expr.resetLValueTypes(ctx);
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/compiler/ast/StatementBlock.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/StatementBlock.java
@@ -454,7 +454,7 @@ public class StatementBlock
                         }
                     }
 
-                if (stmtNew == null || !stmtNew.isCompletable() || errs.isAbortDesired())
+                if (errs.isAbortDesired())
                     {
                     break;
                     }

--- a/javatools/src/main/java/org/xvm/compiler/ast/TryStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TryStatement.java
@@ -210,6 +210,12 @@ public class TryStatement
                 @Override
                 protected void promoteNarrowedType(String sName, Argument arg, Branch branch)
                     {
+                    // this is only called when the context is reachable; since the exception may or
+                    // may not happen, we need to restore the original type
+                    if (!isVarDeclaredInThisScope(sName))
+                        {
+                        getOuterContext().restoreOriginalType(sName);
+                        }
                     }
 
                 @Override

--- a/javatools/src/main/java/org/xvm/compiler/ast/UnaryPlusExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/UnaryPlusExpression.java
@@ -59,6 +59,7 @@ public class UnaryPlusExpression
                 {
                 log(errs, Severity.ERROR, Compiler.MISSING_OPERATOR,
                         operator.getValueText(), typeRight.getValueString());
+                return null;
                 }
             }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/VariableDeclarationStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/VariableDeclarationStatement.java
@@ -145,19 +145,26 @@ public class VariableDeclarationStatement
     public void updateLValueFromRValueTypes(Context ctx, Context.Branch branch, boolean fCond,
                                             TypeConstant[] aTypes)
         {
-        if (aTypes != null && aTypes.length >= 1)
-            {
-            TypeExpression exprType = this.type;
-            if (exprType instanceof VariableTypeExpression)
-                {
-                exprType.setTypeConstant(aTypes[0]);
+        assert aTypes != null && aTypes.length >= 1;
 
-                if (m_reg != null)
-                    {
-                    m_reg.specifyActualType(aTypes[0]);
-                    }
+        TypeExpression exprType = this.type;
+        if (exprType instanceof VariableTypeExpression)
+            {
+            TypeConstant type = aTypes[0];
+            exprType.setTypeConstant(type);
+
+            if (m_reg != null)
+                {
+                m_reg.specifyActualType(type);
                 }
             }
+        getLValueExpression().updateLValueFromRValueTypes(ctx, branch, fCond, aTypes);
+        }
+
+    @Override
+    public void resetLValueTypes(Context ctx)
+        {
+        getLValueExpression().resetLValueTypes(ctx);
         }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -799,7 +799,8 @@ public abstract class ClassTemplate
                             return Op.R_CALL;
 
                         case Op.R_EXCEPTION:
-                            return Op.R_EXCEPTION;
+                            // raise an exception for the original property instead
+                            break ;
 
                         default:
                             throw new IllegalStateException();

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -885,8 +885,8 @@ public class Frame
                             break;
 
                         default:
-                            System.err.println("WARNING: suspicious assignment from: " +
-                                typeFrom.getValueString() + " to: " + typeTo.getValueString());
+                            System.err.println("WARNING: suspicious assignment at " + this +
+                                " from: " + typeFrom.getValueString() + " to: " + typeTo.getValueString());
                             break;
                         }
                     break;
@@ -1523,7 +1523,7 @@ public class Frame
         ConstantPool pool = poolContext();
         if (type.containsFormalType(true))
             {
-            type = type.resolveGenerics(pool, getGenericsResolver(type.containsDynamicType(null)));
+            type = type.resolveGenerics(pool, getGenericsResolver(type.containsDynamicType()));
 
             if (type.containsFormalType(true))
                 {
@@ -2638,7 +2638,7 @@ public class Frame
                     }
 
                 // don't cache dynamic types
-                boolean fDynamic = type.containsDynamicType(null);
+                boolean fDynamic = type.containsDynamicType();
 
                 type = type.resolveGenerics(poolContext(), getGenericsResolver(fDynamic));
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -183,7 +183,7 @@ public class xRTType
             TypeConstant typeData = typeTarget.getParamType(0);
 
             typeData = typeData.resolveGenerics(pool,
-                    frame.getGenericsResolver(typeData.containsDynamicType(null)));
+                    frame.getGenericsResolver(typeData.containsDynamicType()));
             return frame.pushStack(typeData.normalizeParameters().ensureTypeHandle(frame.f_context.f_container));
             }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
@@ -229,7 +229,7 @@ public class xArray
         if (typeArray.containsFormalType(true))
             {
             typeArray = typeArray.resolveGenerics(frame.poolContext(),
-                            frame.getGenericsResolver(typeArray.containsDynamicType(null)));
+                            frame.getGenericsResolver(typeArray.containsDynamicType()));
             }
 
         if (fSet)

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xListMap.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xListMap.java
@@ -55,7 +55,7 @@ public class xListMap
             if (typeMap.containsFormalType(true))
                 {
                 typeMap = typeMap.resolveGenerics(frame.poolContext(),
-                        frame.getGenericsResolver(typeMap.containsDynamicType(null)));
+                        frame.getGenericsResolver(typeMap.containsDynamicType()));
                 }
 
             Map<Constant, Constant> mapValues = constMap.getValue();

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
@@ -117,7 +117,7 @@ public class xTuple
         TypeConstant typeTuple = constTuple.getType();
 
         typeTuple = typeTuple.resolveGenerics(frame.poolContext(),
-                        frame.getGenericsResolver(typeTuple.containsDynamicType(null)));
+                        frame.getGenericsResolver(typeTuple.containsDynamicType()));
 
         ObjectHandle[] ahValue   = new ObjectHandle[c];
         boolean        fDeferred = false;
@@ -806,6 +806,37 @@ public class xTuple
                 return super.makeImmutable();
                 }
             return true;
+            }
+
+        @Override
+        protected TypeConstant augmentType(TypeConstant type)
+            {
+            ObjectHandle[] ahValue     = m_ahValue;
+            TypeConstant[] atypeOrig   = type.getParamTypesArray();
+            TypeConstant[] atypeActual = null;
+
+            for (int i = 0, c = ahValue.length; i < c; i++)
+                {
+                ObjectHandle hValue = ahValue[i];
+                if (hValue == null)
+                    {
+                    // this can only be a scenario of a conditional Tuple
+                    assert i > 0 && ahValue[0] == xBoolean.FALSE;
+                    return type;
+                    }
+                TypeConstant typeVal = hValue.getType();
+                if (!typeVal.equals(atypeOrig[i]))
+                    {
+                    if (atypeActual == null)
+                        {
+                        atypeActual = atypeOrig.clone();
+                        }
+                    atypeActual[i] = typeVal;
+                    }
+                }
+            return super.augmentType(atypeActual == null
+                    ? type
+                    : type.getConstantPool().ensureTupleType(atypeActual));
             }
 
         @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
@@ -103,7 +103,7 @@ public class xClass
             TypeConstant     typeClz  = idClz.getValueType(frame.poolContext(), null);
 
             typeClz = typeClz.resolveGenerics(frame.poolContext(),
-                        frame.getGenericsResolver(typeClz.containsDynamicType(null)));
+                        frame.getGenericsResolver(typeClz.containsDynamicType()));
 
             ClassTemplate template = switch (idClz.getComponent().getFormat())
                 {

--- a/javatools/src/main/java/org/xvm/runtime/template/xConst.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xConst.java
@@ -595,7 +595,7 @@ public class xConst
                 TypeConstant typeProp = (TypeConstant) pool.register(clzBase.getFieldType(enid));
 
                 typeProp = typeProp.resolveGenerics(pool,
-                            frameCaller.getGenericsResolver(typeProp.containsDynamicType(null)));
+                            frameCaller.getGenericsResolver(typeProp.containsDynamicType()));
 
                 switch (typeProp.callEquals(frameCaller, h1, h2, Op.A_STACK))
                     {
@@ -792,7 +792,7 @@ public class xConst
                 TypeConstant typeProp = (TypeConstant) pool.register(clzBase.getFieldType(enid));
 
                 typeProp = typeProp.resolveGenerics(pool,
-                            frameCaller.getGenericsResolver(typeProp.containsDynamicType(null)));
+                            frameCaller.getGenericsResolver(typeProp.containsDynamicType()));
 
                 MethodStructure methodHash = typeProp.findCallable(HASH_SIG);
                 if (methodHash == null)

--- a/lib_ecstasy/src/main/x/ecstasy/collections/Array.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/Array.x
@@ -223,7 +223,7 @@ class Array<Element>
          * @return a reified array delegate that provides storage for the elements that it
          *         represents
          */
-        ArrayDelegate reify(Mutability? mutability = Null);
+        ArrayDelegate! reify(Mutability? mutability = Null);
     }
 
     /**
@@ -577,7 +577,7 @@ class Array<Element>
     }
 
     @Override
-    Array toArray(Mutability? mutability = Null, Boolean inPlace = False) {
+    Array! toArray(Mutability? mutability = Null, Boolean inPlace = False) {
         if (mutability == Null || mutability == this.mutability) {
             return this;
         }
@@ -595,7 +595,7 @@ class Array<Element>
     }
 
     @Override
-    Array reify(Mutability? mutability = Null) {
+    Array! reify(Mutability? mutability = Null) {
         ArrayDelegate<Element> reifiedDelegate = delegate.reify(mutability);
         return &delegate == &reifiedDelegate
                 ? this

--- a/lib_ecstasy/src/main/x/ecstasy/collections/arrays/FPNumberArray.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/arrays/FPNumberArray.x
@@ -565,7 +565,6 @@ mixin FPNumberArray<Element extends FPNumber>
             ResultType?      negInfinity     = Null) {
         assert Range<Number> range := ResultType.range()
                 as $"{ResultType} a is not fixed length integer type";
-        assert range.is(Range<ResultType>);
 
         function Element(ResultType) elementOf = ResultType.converterTo(Element);
         Element min = elementOf(range.effectiveLowerBound);

--- a/lib_ecstasy/src/main/x/ecstasy/collections/deferred/PartitionedCollection.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/deferred/PartitionedCollection.x
@@ -128,7 +128,7 @@ class PartitionedCollection<Element>
                   }
                 : instantiateEmptyReified();
 
-            if (DeferredCollection<FromElement> nextDeferred := original.is(DeferredCollection<Element>)){
+            if (DeferredCollection<Element> nextDeferred := original.is(DeferredCollection<Element>)){
                 // provide an accumulator to the deferred collection so that it gives us all of its
                 // data, and we'll collect the data (for the other partition) that our buddy needs,
                 // while all the data that is in our partition will get piped straight through to

--- a/lib_jsondb/src/main/x/jsondb/Client.x
+++ b/lib_jsondb/src/main/x/jsondb/Client.x
@@ -1471,6 +1471,7 @@ service Client<Schema extends RootSchema> {
                 DBObjectImpl dbo = deferred.dbo;
                 if (dbo != prevDbo) {
                     dbo.dboResetDeferred_();
+                    prevDbo = dbo;
                 }
 
                 if (!failure, function Boolean(DBObjectImpl) adjust ?= deferred.adjust) {

--- a/manualTests/src/main/x/misc.x
+++ b/manualTests/src/main/x/misc.x
@@ -180,7 +180,7 @@ module TestMisc {
         Int b = 45;
         // this is an error: console.print("a=" + a + ", b=" + b + ", a?:b=" + (a ?: b));
 
-        Int? c = a;
+        Int? c = a > 0 ? a : Null;
         console.print("c=" + c + ", b=" + b + ", c?:b=" + (c ?: b));
 
         static Int? trustMeItMightNotBeNull() {
@@ -194,8 +194,8 @@ module TestMisc {
     void testElseExpr() {
         console.print("\n** testElseExpr()");
 
-        IntLiteral? a = Null;
         Int b = 7;
+        IntLiteral? a = b > 0 ? Null : 17;
         console.print("a=" + a + ", b=" + b + ", a?.toInt64():b=" + (a?.toInt64():b));
         // [11] VAR #-238, ecstasy:Int64 #2                             // create temp var "#2" to hold the result of the else expression (ok!)
         // [12] VAR #-256, ecstasy:Nullable | ecstasy:IntLiteral #3     // create temp var #3 to hold ... um ... wrong! (wasted)     TODO?
@@ -402,7 +402,7 @@ module TestMisc {
         s := checkPositive(99);
         console.print($"99 => {s}");
 
-        String? s2 = s;
+        String? s2 = s.size > 0 ? s : Null;
         if (String s3 ?= s2) {
             console.print($"value is not Null: {s3}");
         } else {
@@ -433,7 +433,8 @@ module TestMisc {
     void testAssignOps() {
         console.print("\n** testAssignOps()");
 
-        Int? n = Null;
+        Boolean f0 = True;
+        Int? n = f0 ? Null : -1;
         n ?:= 4;
         console.print("n=" + n + " (should be 4)");
 

--- a/manualTests/src/main/x/reflect.x
+++ b/manualTests/src/main/x/reflect.x
@@ -443,7 +443,8 @@ module TestReflection {
                 // need to get a Ref for the property:
                 // - must be assigned
                 // - actual type cannot be Service
-                val ref = prop.of(o);
+                assert val s := &o.revealAs(c.StructType);
+                val ref = prop.of(s);
                 console.print($|     assigned={ref.assigned}, peek()={ref.peek()}, actualType={ref.actualType}
                                  |     isService={ref.isService}, isConst={ref.isConst}
                                  |     isImmutable={ref.isImmutable}, hasName={{String name = "n/a"; name := ref.hasName(); return name;}}, var={ref.is(Var)}


### PR DESCRIPTION
The compiler used to have a slightly different type inference logic between AssignmentStatement and  VariableDeclarationStatement. While the former always called "updateLValueFromRValueTypes()" at the end of the validation, the later did not. As a result, as Cliff first discovered, processing of 
   
    Int? n = 0;
    ... // use n 
    
was quite different from 

    Int? n;
    n = 0;
    ... // use n 
    
In the second scenario the compiler would "know" that "n" is not Null, while in the first one it did not, which is definitely wrong. The obvious solution was to add the following line at the end of VariableDeclarationStatement#updateLValueFromRValueTypes(). 

    getLValueExpression().updateLValueFromRValueTypes(ctx, branch, fCond, aTypes);

However, this simple fix uncovered a slew of bugs we have never seen before (the obvious reason we have not stepped onto any of those was that that `Int? n; n = 0;` style of variable initialization is quite unusual.

The good news is that the fix in this PR (on top of resolving the compilation inconsistency) made the compiler to uncover a couple of bugs that were not yet known (e.g. [this line was missing](https://github.com/xtclang/xvm/blob/dc66740a5969a5ca74251b2e44e0d8649baa7687/lib_jsondb/src/main/x/jsondb/Client.x#L1474), the Array API was a nothch off, and a couple of other small issues)