### PR TITLE
Harden the List.sorted() contract

### DIFF
--- a/lib_ecstasy/src/main/x/ecstasy/collections/List.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/List.x
@@ -618,12 +618,17 @@ interface List<Element>
     /**
      * Sort the contents of this list in the order specified by the optional [Type.Orderer].
      *
-     * @param order    (optional) the Orderer to use to sort the list, defaulting to using the
-     *                 "natural" sort order of the Element type
-     * @param inPlace  (optional) pass `True` to allow the List to sort itself "in place", if the
-     *                 List is able to do so
+     * @param order      (optional) the Orderer to use to sort the list, defaulting to using the
+     *                   "natural" sort order of the Element type
+     * @param collector  (optional) an [Aggregator] to use to collect the results; if specified,
+     *                   the value of `inPlace` argument is ignored
+     * @param inPlace    (optional) pass `True` to allow the List to sort itself "in place", if the
+     *                   List is able to do so
      *
      * @return the resultant list, which is the same as `this` for a mutable list
+     *
+     * @throws ReadOnly if the collector is not specified, the value of `inPlace` argument is `True`,
+     *                  but the List is not mutable
      */
     @Override
     <Result extends List!> Result sorted(Orderer?                     order     = Null,
@@ -646,7 +651,11 @@ interface List<Element>
                     : this[0 ..< size]).as(Result);
         }
 
-        return (this.inPlace && inPlace
+        if (inPlace && !this.inPlace) {
+            throw new ReadOnly();
+        }
+
+        return (inPlace
                 ? sort(order)
                 : super(order)).as(Result);
     }

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -2,14 +2,14 @@ module TestSimple {
     @Inject Console console;
 
     void run() {
-        new Test<Byte>(126).test();
-    }
-
-    class Test<Element extends Byte>(Element value) {
-        void test() {
-            Byte b; b = value;
-            Int byteCount = 1 + (b & 0x1F); // that used to blow up at runtime
-            console.print(byteCount);
+        Int[] ints = [3, 1, 2];
+        try {
+            ints.sorted(inPlace=True); // this used to produce an out-of-place result; should throw
+            console.print(ints);
+        } catch (ReadOnly ignore) {
+            console.print("Array is immutable");
         }
+
+        console.print(ints.sorted());
     }
 }


### PR DESCRIPTION
While working on something, I wrote a simple test similar to this:

        Int[] ints = [3, 1, 2];
        ints.sorted(inPlace=True);
        console.print(ints);

and was quite surprised to see a non-sorted result. In a minute, I realized that our List.sorted() API contract takes the value of `inPlace` argument as a suggestion and not a requirement. If the List (in this case an Array) is immutable it creates a new array, sorts and returns it. I think it's wrong and it should throw.

Proposed is the corresponding API doc and implementation change 