### PR TITLE
Add Runtime.logRuntimeException() API

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/Runtime.java
+++ b/javatools/src/main/java/org/xvm/runtime/Runtime.java
@@ -132,6 +132,18 @@ public class Runtime
         m_fDebugger = fActive;
         }
 
+    /**
+     * Log a runtime exception. Eventually, this will go to a log file...
+     *
+     * @return an error tag the logged exception
+     */
+    public static String logRuntimeException(String sErr)
+        {
+        String sTag = "RTError: " + System.currentTimeMillis();
+        System.err.println("*** " + sTag + '\n' + sErr);
+        return sTag;
+        }
+
 
     // ----- constants and fields ------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
@@ -28,6 +28,7 @@ import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.DeferredCallHandle;
+import org.xvm.runtime.Runtime;
 import org.xvm.runtime.ServiceContext;
 import org.xvm.runtime.TypeComposition;
 import org.xvm.runtime.Utils;
@@ -216,7 +217,7 @@ public class xRTAlgorithms
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(e.getMessage());
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -282,7 +283,7 @@ public class xRTAlgorithms
             }
         }
 
-    enum KeyForm {Public, Private, PublicOrSecret, PrivateOrSecret}
+    public enum KeyForm {Public, Private, PublicOrSecret, PrivateOrSecret}
 
 
     // ----- handles -------------------------------------------------------------------------------

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
@@ -17,6 +17,7 @@ import org.xvm.asm.constants.TypeConstant;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
+import org.xvm.runtime.Runtime;
 
 import org.xvm.runtime.template.xException;
 import org.xvm.runtime.template.xService;
@@ -222,7 +223,8 @@ public class xRTCertificateManager
 
                 if (sError != null)
                     {
-                    return frame.raiseException(xException.ioException(frame, sError));
+                    return frame.raiseException(xException.ioException(frame,
+                            Runtime.logRuntimeException(sError)));
                     }
                 }
 
@@ -232,7 +234,7 @@ public class xRTCertificateManager
             {
             return frame == null
                 ? Op.R_NEXT
-                : frame.raiseException(e.getMessage());
+                : frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTDecryptor.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTDecryptor.java
@@ -12,6 +12,7 @@ import org.xvm.asm.MethodStructure;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
+import org.xvm.runtime.Runtime;
 
 import org.xvm.runtime.template.xService;
 
@@ -93,7 +94,7 @@ public class xRTDecryptor
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(e.getMessage());
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -120,7 +121,7 @@ public class xRTDecryptor
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(e.getMessage());
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
@@ -52,6 +52,7 @@ import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.DeferredCallHandle;
 import org.xvm.runtime.ObjectHandle.GenericHandle;
+import org.xvm.runtime.Runtime;
 import org.xvm.runtime.ServiceContext;
 import org.xvm.runtime.TypeComposition;
 import org.xvm.runtime.Utils;
@@ -105,7 +106,7 @@ public class xRTKeyStore
         markNativeMethod("getPasswordInfo"   , STRING, null);
 
         ConstantPool pool = pool();
-        s_typeNamedPasssord = pool.ensureClassConstant(
+        s_typeNamedPassword = pool.ensureClassConstant(
                 pool.ensureModuleConstant("crypto.xtclang.org"), "CryptoPassword").getType();
 
         invalidateTypeInfo();
@@ -214,7 +215,7 @@ public class xRTKeyStore
         catch (Exception e)
             {
             return new DeferredCallHandle(xException.makeHandle(frame,
-                    "Illegal KeyStore arguments: " + e.getMessage()));
+                    Runtime.logRuntimeException("Illegal KeyStore arguments: " + e.getMessage())));
             }
         }
 
@@ -235,7 +236,7 @@ public class xRTKeyStore
                     }
                 catch (KeyStoreException e)
                     {
-                    return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+                    return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
                     }
                 }
             }
@@ -375,7 +376,7 @@ public class xRTKeyStore
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -452,7 +453,7 @@ public class xRTKeyStore
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -517,7 +518,7 @@ public class xRTKeyStore
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -547,7 +548,7 @@ public class xRTKeyStore
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -566,7 +567,7 @@ public class xRTKeyStore
             return hString;
             }
 
-        hPwd = hPwd.revealAs(frame, s_typeNamedPasssord);
+        hPwd = hPwd.revealAs(frame, s_typeNamedPassword);
         if (hPwd instanceof GenericHandle hNamed)
             {
             return (StringHandle) hNamed.getField(null, "password");
@@ -633,5 +634,5 @@ public class xRTKeyStore
     /**
      * Cached NamedPassword type.
      */
-    private static TypeConstant s_typeNamedPasssord;
+    private static TypeConstant s_typeNamedPassword;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
@@ -12,6 +12,7 @@ import org.xvm.asm.MethodStructure;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
+import org.xvm.runtime.Runtime;
 
 import org.xvm.runtime.template.xBoolean;
 import org.xvm.runtime.template.xService;
@@ -96,7 +97,7 @@ public class xRTSigner
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(e.getMessage());
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
 
@@ -124,7 +125,7 @@ public class xRTSigner
             }
         catch (GeneralSecurityException e)
             {
-            return frame.raiseException(e.getMessage());
+            return frame.raiseException(Runtime.logRuntimeException(e.getMessage()));
             }
         }
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
@@ -55,6 +55,7 @@ import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.JavaLong;
+import org.xvm.runtime.Runtime;
 import org.xvm.runtime.ServiceContext;
 import org.xvm.runtime.TypeComposition;
 import org.xvm.runtime.Utils;
@@ -309,7 +310,8 @@ public class xRTServer
         catch (Exception e)
             {
             frame.f_context.f_container.terminate(hServer.f_context);
-            return frame.raiseException(xException.ioException(frame, e.getMessage()));
+            return frame.raiseException(
+                    xException.ioException(frame, Runtime.logRuntimeException(e.getMessage())));
             }
         }
 
@@ -608,7 +610,8 @@ public class xRTServer
             }
         catch (IOException e)
             {
-            return frame.raiseException(xException.ioException(frame, e.getMessage()));
+            return frame.raiseException(
+                    xException.ioException(frame, Runtime.logRuntimeException(e.getMessage())));
             }
 
         if (cbBody > 0)
@@ -619,7 +622,8 @@ public class xRTServer
                 }
             catch (Throwable e)
                 {
-                return frame.raiseException(xException.ioException(frame, e.getMessage()));
+                return frame.raiseException(
+                    xException.ioException(frame, Runtime.logRuntimeException(e.getMessage())));
                 }
             }
         return Op.R_NEXT;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/xTerminalConsole.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/xTerminalConsole.java
@@ -25,6 +25,7 @@ import org.xvm.asm.constants.TypeConstant;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
+import org.xvm.runtime.Runtime;
 import org.xvm.runtime.Utils;
 
 import org.xvm.runtime.template.xBoolean;
@@ -165,7 +166,8 @@ public class xTerminalConsole
                 }
             catch (IOException e)
                 {
-                return frame.raiseException(xException.ioException(frame, e.getMessage()));
+                return frame.raiseException(xException.ioException(frame,
+                        Runtime.logRuntimeException(e.getMessage())));
                 }
             }
         else


### PR DESCRIPTION
While working on the platform (host.xqiz.it) I realized that when the platform code calls some library methods that fail and then decides to pass the underlying exception message to the client (CLI or browser), that original exception message may contain some information that we should not reveal to the outside world. As a solution, I added `Runtime.logRuntimeException()` function that takes a potentially confidential text and turns it into a tag message. The original message gets logged to the system console, while the tag gets thrown.