### PR TITLE
Remove an unnecessary cast

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
@@ -99,24 +99,23 @@ public class xEnum
         {
         if (constant instanceof SingletonConstant constValue)
             {
-            EnumHandle hValue = (EnumHandle) constValue.getHandle();
-
-            if (hValue == null)
+            ObjectHandle hValue = constValue.getHandle();
+            if (hValue != null)
                 {
-                assert getStructure().getFormat() == Format.ENUMVALUE;
-
-                xEnum templateEnum = (xEnum) getSuper();
-
-                hValue = templateEnum.getEnumByConstant(constValue.getClassConstant());
-                constValue.setHandle(hValue);
-
-                if (hValue.isStruct())
-                    {
-                    return completeConstruction(frame, hValue);
-                    }
+                // Note: this could be an InitializingHandle
+                return frame.pushStack(hValue);
                 }
 
-            return frame.pushStack(hValue);
+            assert getStructure().getFormat() == Format.ENUMVALUE;
+
+            xEnum templateEnum = (xEnum) getSuper();
+
+            EnumHandle hEnum = templateEnum.getEnumByConstant(constValue.getClassConstant());
+            constValue.setHandle(hEnum);
+
+            return hEnum.isStruct()
+                    ? completeConstruction(frame, hEnum)
+                    : frame.pushStack(hEnum);
             }
 
         return super.createConstHandle(frame, constant);


### PR DESCRIPTION
Markus noticed an exception [in the log](https://scans.gradle.com/s/yysm4q3h6swfs/console-log/raw) for "runParallel" on GitHib:

    java.lang.ClassCastException: class org.xvm.runtime.ObjectHandle$InitializingHandle cannot be cast to class org.xvm.runtime.template.xEnum$EnumHandle (org.xvm.runtime.ObjectHandle$InitializingHandle and org.xvm.runtime.template.xEnum$EnumHandle are in unnamed module of loader 'app')
    at org.xvm.runtime.template.xEnum.createConstHandle(xEnum.java:102)
	at org.xvm.runtime.Utils.constructSingletonHandle(Utils.java:710)
	at org.xvm.runtime.Utils$1.process(Utils.java:630)
	at org.xvm.runtime.ServiceContext.execute(ServiceContext.java:638)
	at org.xvm.runtime.ServiceContext.drainWork(ServiceContext.java:361)
	at org.xvm.runtime.ServiceContext.execute(ServiceContext.java:412)
	at org.xvm.runtime.ServiceContext.ensureScheduled(ServiceContext.java:402)
	at org.xvm.runtime.ServiceContext.addRequest(ServiceContext.java:495)
	at org.xvm.runtime.ServiceContext.sendOp1Request(ServiceContext.java:1230)
	at org.xvm.runtime.Utils.initConstants(Utils.java:655)
	at org.xvm.asm.MethodStructure.ensureInitialized(MethodStructure.java:1575)
	at org.xvm.runtime.Frame.ensureInitialized(Frame.java:345)
	at org.xvm.runtime.Frame.invoke1(Frame.java:436)
	...
	
It's not reproducible locally and very intermittent there, so this change is an attempt to fix it.