### PR TITLE
Fix a compiler bug

### DIFF
--- a/javatools/src/main/java/org/xvm/compiler/ast/DelegatingExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/DelegatingExpression.java
@@ -33,6 +33,12 @@ public abstract class DelegatingExpression
         return expr;
         }
 
+    @Override
+    public void markConditional()
+        {
+        expr.markConditional();
+        }
+
 
     // ----- compilation ---------------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.xvm.asm.Argument;
 import org.xvm.asm.ClassStructure;
-import org.xvm.asm.Component;
 import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.Constants.Access;
@@ -22,7 +21,6 @@ import org.xvm.asm.Register;
 import org.xvm.asm.ast.ExprAST;
 
 import org.xvm.asm.constants.ConditionalConstant;
-import org.xvm.asm.constants.IdentityConstant;
 import org.xvm.asm.constants.MethodConstant;
 import org.xvm.asm.constants.PropertyConstant;
 import org.xvm.asm.constants.SingletonConstant;
@@ -152,6 +150,15 @@ public abstract class Expression
     public ConditionalConstant toConditionalConstant()
         {
         throw notImplemented();
+        }
+
+    /**
+     * Mark this expression as "possibly" asymmetrical - returning conditional "False" on some branch.
+     *
+     * This method must be called *before* the validation or testFit.
+     */
+    public void markConditional()
+        {
         }
 
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/ReturnStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ReturnStatement.java
@@ -396,26 +396,7 @@ public class ReturnStatement
             TernaryExpression exprTernary = (TernaryExpression) listExprs.get(0);
             exprTernary.generateConditionalReturn(ctx, code, errs);
 
-            TernaryExprAST astTernary = (TernaryExprAST) exprTernary.getExprAST(ctx);
-
-            astResult = switch (exprTernary.getPlan())
-                {
-                case Symmetrical ->
-                    new ReturnStmtAST(astTernary);
-
-                case ThenIsFalse ->
-                    // we need to unroll the ternary expression into an "if-then-else" sequence
-                    new IfStmtAST(
-                        astTernary.getCond(),
-                        new ReturnStmtAST(new ConstantExprAST(pool.valFalse())),
-                        new ReturnStmtAST(astTernary.getElse()));
-
-                case ElseIsFalse ->
-                    new IfStmtAST(
-                        astTernary.getCond(),
-                        new ReturnStmtAST(astTernary.getThen()),
-                        new ReturnStmtAST(new ConstantExprAST(pool.valFalse())));
-                };
+            astResult = new ReturnStmtAST(exprTernary.getExprAST(ctx));
             }
         else
             {

--- a/javatools/src/main/java/org/xvm/compiler/ast/TernaryExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TernaryExpression.java
@@ -56,14 +56,13 @@ public class TernaryExpression
         return CHILD_FIELDS;
         }
 
-    /**
-     * Mark this ternary as "possibly" asymmetrical - returning conditional "false" on some branch.
-     *
-     * This method must be called *before* validation or testFit.
-     */
+    @Override
     public void markConditional()
         {
         m_fConditional = true;
+
+        exprThen.markConditional();
+        exprElse.markConditional();
         }
 
 
@@ -681,13 +680,13 @@ public class TernaryExpression
             {
             TypeConstant typeFalse = pool().typeFalse();
 
-            // test "? (true, result) : false" first
+            // test "? (True, result) : False" first
             if (exprElse.testFit(ctx, typeFalse, fExhaustive, null).isFit())
                 {
                 return m_plan = Plan.ElseIsFalse;
                 }
 
-            // test "? false : (true, result)" next
+            // test "? False : (True, result)" next
             if (exprThen.testFit(ctx, typeFalse, fExhaustive, null).isFit())
                 {
                 return m_plan = Plan.ThenIsFalse;

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -1,12 +1,25 @@
 module TestSimple {
 
-    void run() {
-        @Inject Console console;
-        assert &console.assigned; // this used to assert
+    @Inject Console console;
 
-        @Inject String greeting;
-        console.print(&greeting.assigned
-                ? greeting
-                : "no greeting");
+    void run() {
+        String s;
+        s = "?"; s := test(True, True);
+        console.print($"1) {s}");
+
+        s = "?"; s := test(True, False);
+        console.print($"2) {s}");
+
+        s = "?"; s := test(False, True);
+        console.print($"3) {s}");
+
+        s = "?"; s := test(False, False);
+        console.print($"4) {s}");
+    }
+
+    conditional String test(Boolean b0, Boolean b1) {
+        return b0                                 // this used to fail to compile
+            ? (b1 ? False : (True,"def"))
+            : (b1 ? (True,"abc") : (True, "xyz"));
     }
 }


### PR DESCRIPTION
Cliff reported a compiler bug: failure to compile a nested ternary:

    conditional String test(Boolean b0, Boolean b1) {
        return b0
            ? (b1 ? False : (True,"def"))
            : (b1 ? (True,"abc") : (True, "xyz"));
    }

This change fixes it as well as simplifies the BAST production of ReturnStatement