### PR TITLE
Allow adding extra WebServices to the HttpHandler

### DIFF
--- a/lib_web/src/main/x/web/WebService.x
+++ b/lib_web/src/main/x/web/WebService.x
@@ -58,6 +58,12 @@ mixin WebService(String path)
      */
     RequestIn? request;
 
+    /**
+     * The function that represents a WebService constructor.
+     */
+    typedef function WebService() as Constructor;
+
+
 
     // ----- processing ----------------------------------------------------------------------------
 

--- a/lib_web/src/main/x/web/WebService.x
+++ b/lib_web/src/main/x/web/WebService.x
@@ -64,7 +64,6 @@ mixin WebService(String path)
     typedef function WebService() as Constructor;
 
 
-
     // ----- processing ----------------------------------------------------------------------------
 
     /**

--- a/lib_xenia/src/main/x/xenia.x
+++ b/lib_xenia/src/main/x/xenia.x
@@ -2,7 +2,6 @@
  * The Web Server implementation.
  */
 module xenia.xtclang.org {
-    // external module dependencies
     package aggregate   import aggregate.xtclang.org;
     package collections import collections.xtclang.org;
     package crypto      import crypto.xtclang.org;
@@ -22,6 +21,7 @@ module xenia.xtclang.org {
     import web.RequestIn;
     import web.Session;
     import web.WebApp;
+    import web.WebService;
 
     import web.http.HostInfo;
 
@@ -100,12 +100,15 @@ module xenia.xtclang.org {
      * @param keystore   (optional) the keystore to use for tls certificates and encryption
      * @param tlsKey     (optional) the name of the key pair in the keystore to use for Tls; if not
      *                   specified, the first key pair will be used
+     * @param extras     (optional) a map of WebService classes for processing requests for the
+     *                   corresponding paths (see [HttpHandler])
      *
      * @return a function that allows to shutdown the server
      */
     function void () createServer(WebApp webApp,
                                   HostInfo route = DefaultHost, HostInfo? binding = Null,
-                                  KeyStore? keystore = Null, String? tlsKey = Null) {
+                                  KeyStore? keystore = Null, String? tlsKey = Null,
+                                  Map<Class<WebService>, WebService.Constructor> extras = []) {
         @Inject HttpServer server;
         binding ?:= route;
         try {
@@ -139,7 +142,7 @@ module xenia.xtclang.org {
                 keystore = store;
                 }
 
-            HttpHandler handler = new HttpHandler(route, webApp);
+            HttpHandler handler = new HttpHandler(route, webApp, extras);
             server.addRoute(route, handler, keystore, tlsKey);
 
             return () -> {

--- a/lib_xenia/src/main/x/xenia/ChainBundle.x
+++ b/lib_xenia/src/main/x/xenia/ChainBundle.x
@@ -2,8 +2,6 @@ import Catalog.EndpointInfo;
 import Catalog.MethodInfo;
 import Catalog.WebServiceInfo;
 
-import ecstasy.collections.CollectArray;
-
 import web.AcceptList;
 import web.Body;
 import web.BodyParam;
@@ -16,7 +14,6 @@ import web.QueryParam;
 import web.Response;
 import web.Session;
 import web.UriParam;
-import web.WebService;
 
 import web.codecs.Codec;
 import web.codecs.Format;

--- a/lib_xenia/src/main/x/xenia/HttpHandler.x
+++ b/lib_xenia/src/main/x/xenia/HttpHandler.x
@@ -13,7 +13,7 @@ import HttpServer.RequestInfo;
 
 
 /**
- * An low-level HTTP request entry point.
+ * A low-level HTTP request entry point.
  */
 @Concurrent
 service HttpHandler
@@ -22,11 +22,16 @@ service HttpHandler
      * Construct an HttpHandler that provides the specified web application as the implementation of
      * the specified host.
      *
-     * @param route  the HostInfo that routes to this handler
-     * @param app    the `WebApp` application to route to
+     * @param route   the HostInfo that routes to this handler
+     * @param app     the `WebApp` application to route to
+     * @param extras  (optional) a map of [WebService] classes for processing requests for the
+     *                corresponding [paths](WebService.path) that would otherwise be processed at a
+     *                more generic level or left unprocessed;  useful for injecting platform
+     *                services, such as the "ACME" protocol for certificate provisioning; all
+     *                specified classes must be `@WebService` annotated and paths must be unique
      */
-    construct(HostInfo route, WebApp app) {
-        Catalog catalog = buildCatalog(app);
+    construct(HostInfo route, WebApp app, Map<Class<WebService>, WebService.Constructor> extras = []) {
+        Catalog catalog = buildCatalog(app, extras);
 
         this.route          = route;
         this.catalog        = catalog;

--- a/lib_xenia/src/main/x/xenia/SystemService.x
+++ b/lib_xenia/src/main/x/xenia/SystemService.x
@@ -4,9 +4,6 @@ import SessionImpl.Match_;
 
 import web.Header;
 import web.HttpStatus;
-import web.WebService;
-
-import web.codecs.Registry;
 
 import web.responses.SimpleResponse;
 

--- a/manualTests/src/main/x/webTests/Hello.x
+++ b/manualTests/src/main/x/webTests/Hello.x
@@ -41,7 +41,11 @@ module Hello
         HostInfo route   = hostOf(routeString);
         HostInfo binding = hostOf(bindString);
 
-        xenia.createServer(this, route=route, binding=binding);
+        @Inject Directory curDir;
+        Directory dataDir = curDir.dirFor("data");
+
+        WebService.Constructor constructor = () -> new ExtraFiles(dataDir);
+        xenia.createServer(this, route=route, binding=binding, extras=[ExtraFiles=constructor]);
 
         String portSuffix = route.httpPort == 80 ? "" : $":{route.httpPort}";
         String uri        = $"http://{route.host}{portSuffix}";
@@ -62,6 +66,17 @@ module Hello
 
     Authenticator createAuthenticator() {
         return new DigestAuthenticator(new FixedRealm("Hello", ["admin"="addaya"]));
+    }
+
+    /**
+     * This service allows accessing files in the "data" directory.
+     */
+    @WebService("/data")
+    service ExtraFiles
+            incorporates StaticContent {
+        construct(Directory extra){
+            construct StaticContent(path, extra);
+        }
     }
 
     package inner {


### PR DESCRIPTION
HttpHandler was designed for "declarative" endpoint discovery, driven by the reflection on WebServices and their methods declarations. As a result of that design all WebServices had to have default constructors and be a part of the compilation unit of the corresponding WebApp. This change removes those limitations by a allowing to:

    a) declare WebServices with non-default constructors 
    b) use WebServices that are external to the underlying WebApp