### PR TITLE
Add CertificateManager.extractKey() API

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
@@ -143,8 +143,8 @@ public class xRTCertificateManager
 
         runSilentCommand(
                 "keytool", "-delete",
-                "-alias", hName.getStringValue(),
-                "-keystore", hPath.getStringValue(),
+                "-alias",     hName.getStringValue(),
+                "-keystore",  hPath.getStringValue(),
                 "-storepass", hPwd.getStringValue()
                 );
 
@@ -182,9 +182,9 @@ public class xRTCertificateManager
                         "--staging",
                         "--webroot",
                         "--webroot-path", sCertsPath,
-                        "--config-dir",   sCertsPath + "/config",
-                        "--work-dir",     sCertsPath + "/work",
-                        "--logs-dir",     sCertsPath + "/logs",
+                        "--config-dir",   sCertsPath + File.separator + "config",
+                        "--work-dir",     sCertsPath + File.separator + "work",
+                        "--logs-dir",     sCertsPath + File.separator + "logs",
                         "--register-unsafely-without-email",
                         "-d", sDomain);
                 if (iResult == Op.R_NEXT)
@@ -218,9 +218,9 @@ public class xRTCertificateManager
             runCommand(frame, "yes\nyes",
                         "certbot", "remove",
                         "--staging",
-                        "--config-dir", sCertsPath + "/config",
-                        "--work-dir",   sCertsPath + "/work",
-                        "--logs-dir",   sCertsPath + "/logs",
+                        "--config-dir", sCertsPath + File.separator + "config",
+                        "--work-dir",   sCertsPath + File.separator + "work",
+                        "--logs-dir",   sCertsPath + File.separator + "logs",
                         "--cert-name",  hName.getStringValue(),
                         "--reason",     "unspecified"
                       );
@@ -228,8 +228,8 @@ public class xRTCertificateManager
 
         runSilentCommand(
                 "keytool", "-delete",
-                "-alias", hName.getStringValue(),
-                "-keystore", hPath.getStringValue(),
+                "-alias",     hName.getStringValue(),
+                "-keystore",  hPath.getStringValue(),
                 "-storepass", hPwd.getStringValue()
                 );
         return Op.R_NEXT;
@@ -253,15 +253,15 @@ public class xRTCertificateManager
 
         runSilentCommand(
                 "keytool", "-delete",
-                "-alias", hName.getStringValue(),
-                "-keystore", hPath.getStringValue(),
+                "-alias",     hName.getStringValue(),
+                "-keystore",  hPath.getStringValue(),
                 "-storepass", hPwd.getStringValue()
                 );
         return runNoInputCommand(frame,
                 "keytool", "-genseckey", "-keyalg", "AES", "-keysize", "256",
-                "-alias", hName.getStringValue(),
+                "-alias",     hName.getStringValue(),
                 "-storetype", "PKCS12",
-                "-keystore", hPath.getStringValue(),
+                "-keystore",  hPath.getStringValue(),
                 "-storepass", hPwd.getStringValue()
                 );
         }
@@ -279,8 +279,8 @@ public class xRTCertificateManager
 
         runSilentCommand(
                 "keytool", "-delete",
-                "-alias", hName.getStringValue(),
-                "-keystore", hPath.getStringValue(),
+                "-alias",     hName.getStringValue(),
+                "-keystore",  hPath.getStringValue(),
                 "-storepass", hPwd.getStringValue()
                 );
         return runCommand(frame, hPwdValue.getStringValue(),
@@ -358,6 +358,10 @@ public class xRTCertificateManager
 
     private int runCommand(Frame frame, String sInput, String... cmd)
         {
+        // *** IMPORTANT SECURITY NOTE***:
+        //  ProcessBuilder does not invoke a shell by default, and we should never take the command
+        //  itself (i.e. cmd[0]) from a passed-in argument, which then removes the risk of a shell
+        //  injection attack.
         ProcessBuilder builder = new ProcessBuilder(cmd);
         try
             {

--- a/javatools_bridge/src/main/x/_native/crypto/RTCertificateManager.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTCertificateManager.x
@@ -32,6 +32,11 @@ service RTCertificateManager
     }
 
     @Override
+    Byte[] extractKey(File keystore, Password pwd, String name) {
+        return extractKeyImpl(getPath(keystore), pwd, name);
+    }
+
+    @Override
     void changeStorePassword(File keystore, Password pwd, Password newPassword) {
         changeStorePasswordImpl(getPath(keystore), pwd, newPassword);
     }
@@ -56,6 +61,9 @@ service RTCertificateManager
         {TODO("Native");}
 
     private void createPasswordImpl(String path, Password pwd, String name, String pwdValue)
+        {TODO("Native");}
+
+    private Byte[] extractKeyImpl(String path, Password pwd, String name)
         {TODO("Native");}
 
     private void changeStorePasswordImpl(String path, Password pwd, Password newPwd)

--- a/lib_crypto/src/main/x/crypto/CertificateManager.x
+++ b/lib_crypto/src/main/x/crypto/CertificateManager.x
@@ -72,6 +72,23 @@ interface CertificateManager {
     void createPassword(File keystore, Password pwd, String name, String pwdValue);
 
     /**
+     * Extract a key (private or secret).
+     *
+     * Note: unlike [KeyStore] methods that return [CryptoKey] objects which do not expose the
+     * underlying crypto material, this method is an exception and should be used with extreme
+     * caution.
+     *
+     * @param keystore  the file object representing the store ('PKCS12' type)
+     * @param pwd       the password for the keystore
+     * @param name      the name the key is known by the KeyStore
+     *
+     * @return the content of the key in DER format
+     *
+     * @throws IOException if anything goes wrong
+     */
+    Byte[] extractKey(File keystore, Password pwd, String name);
+
+    /**
      * Change the keystore password.
      *
      * @param keystore  the file object representing the store ('PKCS12' type)

--- a/manualTests/src/main/x/crypto.x
+++ b/manualTests/src/main/x/crypto.x
@@ -2,6 +2,7 @@ module TestCrypto {
     @Inject Console console;
 
     package crypto import crypto.xtclang.org;
+    package web import web.xtclang.org;
 
     import crypto.*;
 
@@ -59,6 +60,19 @@ module TestCrypto {
 
         PrivateKey privateKeyM = new PrivateKey("test-copy", "DES", 8, random.bytes(8));
         testDecryptor(algorithms, "DES", privateKeyM, BIG_TEXT);
+
+        if (False) {
+            Byte[] bytes = manager.extractKey(store, password, pairName);
+            console.print("-----BEGIN PRIVATE KEY-----");
+            String sKey = web.codecs.Base64Format.Instance.encode(bytes);
+            Int    size = sKey.size;
+            for (Int start = 0; start < size; ) {
+                Int end = size.minOf(start+64);
+                console.print(sKey[start ..< end]);
+                start = end;
+            }
+            console.print("-----END PRIVATE KEY-----");
+        }
 
         assert CryptoPassword pwd := keystore.getPassword(pwdName);
         console.print($"{pwd}; type={&pwd.actualType}");


### PR DESCRIPTION
All the KeyStore API was intentionally design in such a way that if if you ask for a private key [of a key pair] or a symmetrical [secret] key, you would get an object that **could** be used as such a secret, but a developer would have no way to extract/expose the actual key material. Now, for the reverse proxy management project, we came to a requirement to get access/propagate that vulnerable data outside of the single machine boundaries.

The KeyStore [injectable] interface is meant to be read only, and all the keystore mutations are contained in the CertificateManager [injectable] interface. This change adds an API to the latter that allows the developer (at this time most likely just us as developers of the platform) to extract the raw key material from the keystore.