### PR TITLE
Fix Json serialization for Tuples of enum values

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
@@ -676,16 +676,16 @@ public class IntersectionTypeConstant
         Relation rel2 = typeRight.calculateRelation(thisLeft2);
 
         // since Enum values cannot be extended, an Enum value type cannot be combined with any
-        // other type and an intersection with a formal type doesn't actually narrow that Enum value type;
-        // this obviously applies to Nullable
-        if (typeRight.isEnumValue())
+        // other type and an intersection with a formal type doesn't actually narrow that Enum value
+        // type; this obviously applies to Nullable
+        if (isEnumOrNullable(typeRight))
             {
-            if (thisLeft1.isEnumValue() && thisLeft2.isFormalType())
+            if (isEnumOrNullable(thisLeft1) && thisLeft2.isFormalType())
                 {
                 // Nullable + Element <= Nullable (if Element's constraint is trivial)
                 return rel1.worseOf(typeRight.calculateRelation(thisLeft2.resolveConstraints()));
                 }
-            if (thisLeft1.isFormalType() && thisLeft2.isEnumValue())
+            if (thisLeft1.isFormalType() && isEnumOrNullable(thisLeft2))
                 {
                 // Element + Lesser <= Lesser (if Element's constraint is trivial)
                 return rel2.worseOf(typeRight.calculateRelation(thisLeft1.resolveConstraints()));
@@ -693,6 +693,11 @@ public class IntersectionTypeConstant
             }
 
         return rel1.worseOf(rel2);
+        }
+
+    private boolean isEnumOrNullable(TypeConstant type)
+        {
+        return type.isEnumValue() || type.isOnlyNullable();
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -376,12 +376,9 @@ public class ParameterizedTypeConstant
                 }
             }
 
-        if (fDiff)
-            {
-            return getConstantPool().
-                    ensureParameterizedTypeConstant(constResolved, aconstResolved);
-            }
-        return this;
+        return fDiff
+                ? getConstantPool().ensureParameterizedTypeConstant(constResolved, aconstResolved)
+                : this;
         }
 
     @Override
@@ -409,12 +406,9 @@ public class ParameterizedTypeConstant
                 }
             }
 
-        if (fDiff)
-            {
-            return getConstantPool().
-                    ensureParameterizedTypeConstant(constUnderlying, aconstResolved);
-            }
-        return this;
+        return fDiff
+                ? getConstantPool().ensureParameterizedTypeConstant(constUnderlying, aconstResolved)
+                : this;
         }
 
     @Override
@@ -812,6 +806,34 @@ public class ParameterizedTypeConstant
             }
 
         return result;
+        }
+
+    @Override
+    public TypeConstant widenEnumValueTypes()
+        {
+        TypeConstant   constUnderlying = m_constType;
+        boolean        fDiff           = false;
+        TypeConstant[] aconstOriginal  = m_atypeParams;
+        TypeConstant[] aconstResolved  = aconstOriginal;
+
+        for (int i = 0, c = aconstOriginal.length; i < c; ++i)
+            {
+            TypeConstant constParamOriginal = aconstOriginal[i];
+            TypeConstant constParamResolved = constParamOriginal.widenEnumValueTypes();
+            if (constParamOriginal != constParamResolved)
+                {
+                if (aconstResolved == aconstOriginal)
+                    {
+                    aconstResolved = aconstOriginal.clone();
+                    }
+                aconstResolved[i] = constParamResolved;
+                fDiff = true;
+                }
+            }
+
+        return fDiff
+                ? getConstantPool().ensureParameterizedTypeConstant(constUnderlying, aconstResolved)
+                : this;
         }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -385,7 +385,6 @@ public class ParameterizedTypeConstant
     public TypeConstant resolveDynamicConstraints(Register register)
         {
         TypeConstant constUnderlying = m_constType;
-        boolean      fDiff           = false;
 
         assert !constUnderlying.isDynamicType();
 
@@ -402,13 +401,12 @@ public class ParameterizedTypeConstant
                     aconstResolved = aconstOriginal.clone();
                     }
                 aconstResolved[i] = constParamResolved;
-                fDiff = true;
                 }
             }
 
-        return fDiff
-                ? getConstantPool().ensureParameterizedTypeConstant(constUnderlying, aconstResolved)
-                : this;
+        return aconstResolved == aconstOriginal
+                ? this
+                : getConstantPool().ensureParameterizedTypeConstant(constUnderlying, aconstResolved);
         }
 
     @Override
@@ -812,7 +810,6 @@ public class ParameterizedTypeConstant
     public TypeConstant widenEnumValueTypes()
         {
         TypeConstant   constUnderlying = m_constType;
-        boolean        fDiff           = false;
         TypeConstant[] aconstOriginal  = m_atypeParams;
         TypeConstant[] aconstResolved  = aconstOriginal;
 
@@ -827,13 +824,12 @@ public class ParameterizedTypeConstant
                     aconstResolved = aconstOriginal.clone();
                     }
                 aconstResolved[i] = constParamResolved;
-                fDiff = true;
                 }
             }
 
-        return fDiff
-                ? getConstantPool().ensureParameterizedTypeConstant(constUnderlying, aconstResolved)
-                : this;
+        return aconstResolved == aconstOriginal
+                ? this
+                : getConstantPool().ensureParameterizedTypeConstant(constUnderlying, aconstResolved);
         }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
@@ -528,6 +528,19 @@ public abstract class RelationalTypeConstant
         return false;
         }
 
+    @Override
+    public TypeConstant widenEnumValueTypes()
+        {
+        TypeConstant constOriginal1 = m_constType1;
+        TypeConstant constOriginal2 = m_constType2;
+        TypeConstant constResolved1 = constOriginal1.widenEnumValueTypes();
+        TypeConstant constResolved2 = constOriginal2.widenEnumValueTypes();
+
+        return constResolved1 == constOriginal1 && constResolved2 == constOriginal2
+                ? this
+                : simplifyOrClone(getConstantPool(), constResolved1, constResolved2);
+        }
+
 
     // ----- TypeInfo support ----------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
@@ -1574,6 +1574,14 @@ public class TerminalTypeConstant
                   this.getDefiningConstant().equals(getConstantPool().clzType());
         }
 
+    @Override
+    public TypeConstant widenEnumValueTypes()
+        {
+        return isEnumValue() && !isOnlyNullable()
+                ? getSingleUnderlyingClass(false).getNamespace().getType()
+                : this;
+        }
+
 
     // ----- TypeInfo support ----------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -524,8 +524,7 @@ public abstract class TypeConstant
     public boolean isEnumValue()
         {
         return isExplicitClassIdentity(false) &&
-                    getExplicitClassFormat() == Component.Format.ENUMVALUE
-               || isOnlyNullable();
+               getExplicitClassFormat() == Component.Format.ENUMVALUE;
         }
 
     /**
@@ -1668,6 +1667,18 @@ public abstract class TypeConstant
                 isExplicitClassIdentity(true) &&
                 isSingleUnderlyingClass(false) &&
                 getSingleUnderlyingClass(false).isNestMateOf(idClass);
+        }
+
+    /**
+     * If the type is an enum value (except Null), widen it to its parent Enumeration.
+     *
+     * @return a widened type or this type if this type does not represent an enum value
+     */
+    public TypeConstant widenEnumValueTypes()
+        {
+        return isModifyingType()
+                ? cloneSingle(getConstantPool(), getUnderlyingType().widenEnumValueTypes())
+                : this;
         }
 
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -534,8 +534,16 @@ public class NameExpression
 
         if (m_arg instanceof Register reg)
             {
-            TypeConstant typeOld = reg.getType();
-            TypeConstant typeNew = aTypes[0];
+            // if the R-value type is an enum value (except Null), widen it to its parent
+            // Enumeration before merging with the L-value, but don't go beyond declared type
+            TypeConstant typeOld  = reg.getType();
+            TypeConstant typeNew  = aTypes[0];
+            TypeConstant typeWide = typeNew.widenEnumValueTypes();
+
+            if (typeWide != typeNew && typeWide.isA(reg.getOriginalType()))
+                {
+                typeNew = typeWide;
+                }
 
             if (fCond)
                 {

--- a/javatools/src/main/java/org/xvm/compiler/ast/TupleExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TupleExpression.java
@@ -396,6 +396,13 @@ public class TupleExpression
 
                     typeField = exprNew.getType();
 
+                    // if the result is an enum value, use the enumeration type instead (unless
+                    // it's exactly what is required)
+                    if (!typeField.equals(typeReq))
+                        {
+                        typeField = typeField.widenEnumValueTypes();
+                        }
+
                     if (i == 0 || aFieldVals != null)
                         {
                         Constant constVal = exprNew.toConstant();

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
@@ -813,14 +813,20 @@ public class xTuple
                     assert i > 0 && ahValue[0] == xBoolean.FALSE;
                     return type;
                     }
-                TypeConstant typeVal = hValue.getType();
-                if (!typeVal.equals(atypeOrig[i]))
+                TypeConstant typeVal  = hValue.getType();
+                TypeConstant typeOrig = atypeOrig[i];
+                if (!typeVal.equals(typeOrig))
                     {
-                    if (atypeActual == null)
+                    // if the value is an enum value, use the enumeration type instead
+                    TypeConstant typeResolved = typeVal.widenEnumValueTypes();
+                    if (typeResolved != typeOrig)
                         {
-                        atypeActual = atypeOrig.clone();
+                        if (atypeActual == null)
+                            {
+                            atypeActual = atypeOrig.clone();
+                            }
+                        atypeActual[i] = typeResolved;
                         }
-                    atypeActual[i] = typeVal;
                     }
                 }
             return super.augmentType(atypeActual == null

--- a/lib_json/src/main/x/json/mappings/TupleMapping.x
+++ b/lib_json/src/main/x/json/mappings/TupleMapping.x
@@ -49,9 +49,4 @@ const TupleMapping<Serializable extends Tuple>(Mapping[] valueMappings)
             }
         }
     }
-
-    @Override
-    <SubType extends Serializable> conditional Mapping<SubType> narrow(Schema schema, Type<SubType> type) {
-        return False;
-    }
 }

--- a/manualTests/src/main/x/IO.x
+++ b/manualTests/src/main/x/IO.x
@@ -400,11 +400,11 @@ module TestIO {
 
         Schema schema = Schema.DEFAULT;
 
-        Tuple<Int, String> tuple = (1, "a");
+        Tuple<Boolean, String> tuple = (True, "a");
         testSer(schema, "tuple", tuple);
         testSer(schema, "tuple", new Test(tuple));
 
-        const Test(Tuple<Int, String> tuple);
+        const Test(Tuple<Boolean, String> tuple);
     }
 
     void testMap() {

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -1,9 +1,50 @@
 module TestSimple {
     @Inject Console console;
 
+    package json import json.xtclang.org;
+    import json.*;
+
     void run() {
-        if (False) { // this used to fail to compile
-            console.print("");
-        }
+
+        Schema schema = Schema.DEFAULT;
+
+        test1(schema, True);
+        test2(schema);
+        test3(schema, Num.values[1]);
+        test4(schema);
+    }
+
+    void test1(Schema schema, Boolean f) {
+       Tuple<Int, Boolean> tuple = (1, f);
+       testSer(schema, "tuple", tuple); // used to fail the deserialization
+    }
+
+    void test2(Schema schema) {
+       Tuple<Int, Boolean> tuple = (1, True);
+       testSer(schema, "tuple", tuple); // used to fail the deserialization
+    }
+
+    void test3(Schema schema, Num n) {
+       Tuple<Int, Num> tuple = (1, n);
+       testSer(schema, "tuple", tuple); // used to fail the deserialization
+    }
+
+    void test4(Schema schema) {
+       Tuple<Int, Num> tuple = (1, Two);
+       testSer(schema, "tuple", tuple); // used to fail the deserialization
+    }
+
+    enum Num {One, Two, Three}
+
+    private <Ser> void testSer(Schema schema, String name, Ser val) {
+        StringBuffer buf = new StringBuffer();
+        schema.createObjectOutput(buf).write(val);
+
+        String s = buf.toString();
+        console.print($"JSON {name} written out={s}");
+
+        Ser val2 = schema.createObjectInput(s.toReader()).read<Ser>();
+        console.print($"read {name} back in={val2}");
     }
 }
+


### PR DESCRIPTION
Fix serialization of tuples containing enum values, such as:
    
    Tuple<Int, Boolean> tuple = (1, True)

Prior to this change json serialization would blow up at run time.