### PR TITLE
Fix native reflection support for foreign types

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
@@ -148,14 +148,18 @@ public class DynamicFormalConstant
             {
             try
                 {
-                // there are some rare instances (e.g. lambdas), when this FTC referes to a register
+                // there are some rare instances (e.g. lambdas), when this FTC refers to a register
                 // from a caller's frame, in which case we need to follow the call chain
                 do
                     {
                     if (getMethod().equals(frame.f_function.getIdentityConstant()))
                         {
-                        ObjectHandle hTarget = frame.getArgument(getRegisterIndex());
-                        return m_constFormal.resolve(hTarget.getType());
+                        ObjectHandle hTarget    = frame.getArgument(getRegisterIndex());
+                        TypeConstant typeTarget = hTarget.getType();
+
+                        return typeTarget.isShared(frame.poolContext())
+                                ? m_constFormal.resolve(typeTarget)
+                                : frame.poolContext().typeObject();
                         }
                     frame = frame.f_framePrev;
                     }

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -7164,7 +7164,7 @@ public abstract class TypeConstant
             }
 
         // don't cache a "foreign" handle
-        return xRTType.makeHandle(container, this, false);
+        return xRTType.makeForeignHandle(this);
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/op/JumpIsA.java
+++ b/javatools/src/main/java/org/xvm/asm/op/JumpIsA.java
@@ -59,7 +59,7 @@ public class JumpIsA
     protected int complete(Frame frame, int iPC, ObjectHandle hValue)
         {
         ObjectHandle[] ahCase  = m_ahCase;
-        TypeConstant   typeVal = hValue.getType();
+        TypeConstant   typeVal = hValue.getUnsafeType();
         for (int i = 0, c = ahCase.length; i < c; ++i)
             {
             if (typeVal.isA(((TypeHandle) ahCase[i]).getDataType()))

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -1119,7 +1119,7 @@ public abstract class ClassTemplate
             }
 
         if (!(hValue instanceof InitializingHandle)
-                && !hValue.getType().isA(field.getType()))
+                && !hValue.getUnsafeType().isA(field.getType()))
             {
             return frame.raiseException(
                 xException.typeMismatch(frame, hValue.getType().getValueString()));

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -468,8 +468,7 @@ public abstract class ClassTemplate
     public int createProxyHandle(Frame frame, ServiceContext ctxTarget, ObjectHandle hTarget,
                                  TypeConstant typeProxy)
         {
-        ClassComposition clzTarget  = (ClassComposition) hTarget.getComposition();
-        TypeConstant     typeTarget = hTarget.getType();
+        TypeConstant typeTarget = hTarget.getType();
         if (!hTarget.isMutable())
             {
             // the only reason we need to create a ProxyHandle for an immutable object is that its
@@ -478,11 +477,12 @@ public abstract class ClassTemplate
             // the proxy to it, since the receiving service may need to cast it to a narrower
             // type that is known within its type system; an example would be passing a module
             // across the container lines that may know to cast it to the WebApp or CatalogMetadata
-            ProxyComposition clzProxy = new ProxyComposition(clzTarget, typeTarget);
-            return frame.assignValue(Op.A_STACK, Proxy.makeHandle(clzProxy, ctxTarget, hTarget));
+            ProxyComposition clzProxy = new ProxyComposition(hTarget.getComposition(), typeTarget);
+            return frame.assignValue(Op.A_STACK, Proxy.makeHandle(clzProxy, ctxTarget, hTarget, false));
             }
 
-        if (typeProxy != null && typeProxy.isInterfaceType())
+        if (typeProxy != null && typeProxy.isInterfaceType() &&
+                hTarget.getComposition() instanceof ClassComposition clzTarget)
             {
             if (typeProxy.containsGenericType(true))
                 {
@@ -493,7 +493,8 @@ public abstract class ClassTemplate
             try
                 {
                 ProxyComposition clzProxy = clzTarget.ensureProxyComposition(typeProxy);
-                return frame.assignValue(Op.A_STACK, Proxy.makeHandle(clzProxy, ctxTarget, hTarget));
+                return frame.assignValue(Op.A_STACK,
+                        Proxy.makeHandle(clzProxy, ctxTarget, hTarget, false));
                 }
             catch (Throwable e)
                 {

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -436,6 +436,10 @@ public abstract class ClassTemplate
      */
     protected int postValidate(Frame frame, ObjectHandle hStruct)
         {
+        if (hStruct.getType().isImmutabilitySpecified())
+            {
+            hStruct.makeImmutable();
+            }
         return Op.R_NEXT;
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/ObjectHandle.java
+++ b/javatools/src/main/java/org/xvm/runtime/ObjectHandle.java
@@ -629,9 +629,8 @@ public abstract class ObjectHandle
                 if (!idModule.isCoreModule())
                     {
                     // even though it's a const, all calls need to be proxied
-                    ProxyComposition clzProxy = new ProxyComposition(
-                            (ClassComposition) getComposition(), typeAs);
-                    return Proxy.makeHandle(clzProxy, owner.getServiceContext(), this);
+                    ProxyComposition clzProxy = new ProxyComposition(getComposition(), typeAs);
+                    return Proxy.makeHandle(clzProxy, owner.getServiceContext(), this, true);
                     }
                 }
 

--- a/javatools/src/main/java/org/xvm/runtime/ProxyComposition.java
+++ b/javatools/src/main/java/org/xvm/runtime/ProxyComposition.java
@@ -18,7 +18,7 @@ public class ProxyComposition
     /**
      * Construct the ProxyComposition for a given "inception" composition and a "proxy" type.
      */
-    public ProxyComposition(ClassComposition clzOrigin, TypeConstant typeProxy)
+    public ProxyComposition(TypeComposition clzOrigin, TypeConstant typeProxy)
         {
         super(clzOrigin);
 
@@ -28,9 +28,9 @@ public class ProxyComposition
     /**
      * @return the original ("inception") composition
      */
-    public ClassComposition getOrigin()
+    public TypeComposition getOrigin()
         {
-        return (ClassComposition) f_clzOrigin;
+        return f_clzOrigin;
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/Runtime.java
+++ b/javatools/src/main/java/org/xvm/runtime/Runtime.java
@@ -1,8 +1,6 @@
 package org.xvm.runtime;
 
 
-import org.xvm.util.concurrent.ConcurrentLinkedBlockingQueue;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -13,6 +11,10 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import java.util.concurrent.atomic.AtomicLong;
+
+import org.xvm.asm.ConstantPool;
+
+import org.xvm.util.concurrent.ConcurrentLinkedBlockingQueue;
 
 
 /**
@@ -78,6 +80,21 @@ public class Runtime
             {
             return new HashSet<>(f_containers.keySet());
             }
+        }
+
+    /**
+     * @return a container that uses the specified ConstantPool; null if not found
+     */
+    public Container findContainer(ConstantPool pool)
+        {
+        for (Container container : f_containers.keySet())
+            {
+            if (container.getConstantPool() == pool)
+                {
+                return container;
+                }
+            }
+        return null;
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
+++ b/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
@@ -1213,11 +1213,11 @@ public class ServiceContext
     /**
      * Send an asynchronous Op-based message to this context with one return value.
      *
-     * @param frame   the caller's frame
-     * @param op      the op to execute
-     * @param iReturn the register id to place the result into
-     * @param typeRet (optional) the expected type of the return value which, if specified, could
-     *                be used to return a proxy
+     * @param frame    the caller's frame
+     * @param op       the op to execute
+     * @param iReturn  the register id to place the result into
+     * @param typeRet  (optional) the expected type of the return value which, if specified, could
+     *                 be used to return a proxy
      *
      * @return one of the {@link Op#R_NEXT}, {@link Op#R_CALL} or {@link Op#R_EXCEPTION} values
      */
@@ -1232,6 +1232,28 @@ public class ServiceContext
         frame.f_fiber.registerRequest(request);
 
         return frame.assignFutureResult(iReturn, request.f_future);
+        }
+
+    /**
+     * Send an asynchronous Op-based message to this context with multiple return values.
+     *
+     * @param frame     the caller's frame
+     * @param op        the op to execute
+     * @param aiReturn  the register ids to place the results into
+     * @param typeRet   (optional) the expected types of the return values which, if specified,
+     *                  could be used to return a proxy
+     *
+     * @return one of the {@link Op#R_NEXT}, {@link Op#R_CALL} or {@link Op#R_EXCEPTION} values
+     */
+    public int sendOpNRequest(Frame frame, Op op, int[] aiReturn, TypeConstant... typeRet)
+        {
+        OpRequest request = new OpRequest(frame, op, aiReturn.length, () -> typeRet);
+
+        addRequest(request, false);
+
+        frame.f_fiber.registerRequest(request);
+
+        return frame.call(frame.createWaitFrame(request.f_future, aiReturn));
         }
 
     /**
@@ -1449,7 +1471,6 @@ public class ServiceContext
             return frame.assignFutureResult(aiReturn[0], cfReturn);
             }
 
-        // TODO replace with: assignFutureResults()
         return frame.call(frame.createWaitFrame(future, aiReturn));
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/Proxy.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/Proxy.java
@@ -89,6 +89,20 @@ public class Proxy
         }
 
     @Override
+    public int invokeNative1(Frame frame, MethodStructure method, ObjectHandle hTarget,
+                             ObjectHandle hArg, int iReturn)
+        {
+        ProxyHandle hProxy = (ProxyHandle) hTarget;
+
+        hTarget = hProxy.f_hTarget;
+
+        return frame.f_context == hProxy.f_context
+            ? hTarget.getTemplate().invokeNative1(frame, method, hTarget, hArg, iReturn)
+            : makeAsyncNativeHandle(hTarget, method).
+                call1(frame, hProxy, new ObjectHandle[]{hArg}, iReturn);
+        }
+
+    @Override
     public int invokeNativeN(Frame frame, MethodStructure method, ObjectHandle hTarget,
                              ObjectHandle[] ahArg, int iReturn)
         {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
@@ -312,7 +312,7 @@ public class xRTFunction
         for (int i = 0; i < cArgs; i++)
             {
             TypeConstant typeParam = hFunc.getParamType(i);
-            TypeConstant typeArg   = ahArg[i].getType();
+            TypeConstant typeArg   = ahArg[i].getUnsafeType();
             if (!typeArg.isA(typeParam))
                 {
                 return frame.raiseException(

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
@@ -446,7 +446,7 @@ public class xRTMethod
     /**
      * @return the TypeComposition for an Array of Method
      */
-    public static TypeComposition ensureArrayComposition(Frame frame, TypeConstant typeTarget) // TODO: use the container
+    public static TypeComposition ensureArrayComposition(Frame frame, TypeConstant typeTarget)
         {
         assert typeTarget != null;
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -198,7 +198,7 @@ public class xRTType
         {
         // a proxy for a non-shareable TypeHandle is a "foreign" handle
         return frame.assignValue(Op.A_STACK,
-            makeHandle(ctxTarget.f_container, ((TypeHandle) hTarget).getUnsafeDataType(), false));
+                makeForeignHandle(((TypeHandle) hTarget).getUnsafeDataType()));
         }
 
     @Override
@@ -1620,6 +1620,14 @@ public class xRTType
         hIter.setField(null, PROP_CALCULATE,  xNullable.NULL);
 
         return hType;
+        }
+
+    /**
+     * @return a "foreign" {@link TypeHandle} that serves as a proxy handle for the specified type.
+     */
+    public static TypeHandle makeForeignHandle(TypeConstant type)
+        {
+        return makeHandle(null, type, false);
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -21,7 +21,6 @@ import org.xvm.asm.constants.ChildInfo;
 import org.xvm.asm.constants.ClassConstant;
 import org.xvm.asm.constants.FormalTypeChildConstant;
 import org.xvm.asm.constants.IdentityConstant;
-import org.xvm.asm.constants.MapConstant;
 import org.xvm.asm.constants.MethodConstant;
 import org.xvm.asm.constants.MethodInfo;
 import org.xvm.asm.constants.PackageConstant;
@@ -31,7 +30,6 @@ import org.xvm.asm.constants.PseudoConstant;
 import org.xvm.asm.constants.RecursiveTypeConstant;
 import org.xvm.asm.constants.RegisterConstant;
 import org.xvm.asm.constants.RelationalTypeConstant;
-import org.xvm.asm.constants.StringConstant;
 import org.xvm.asm.constants.TypeConstant;
 import org.xvm.asm.constants.TypeInfo;
 
@@ -42,11 +40,13 @@ import org.xvm.runtime.ObjectHandle.DeferredCallHandle;
 import org.xvm.runtime.ObjectHandle.DeferredArrayHandle;
 import org.xvm.runtime.ObjectHandle.ExceptionHandle;
 import org.xvm.runtime.ObjectHandle.GenericHandle;
+import org.xvm.runtime.ProxyComposition;
 import org.xvm.runtime.ServiceContext;
 import org.xvm.runtime.TypeComposition;
 import org.xvm.runtime.Utils;
 
 import org.xvm.runtime.template.IndexSupport;
+import org.xvm.runtime.template.Proxy;
 import org.xvm.runtime.template.xBoolean;
 import org.xvm.runtime.template.xConst;
 import org.xvm.runtime.template.xEnum;
@@ -68,8 +68,6 @@ import org.xvm.runtime.template.reflect.xClass.ClassHandle;
 import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
 import org.xvm.runtime.template._native.reflect.xRTMethod.MethodHandle;
 import org.xvm.runtime.template._native.reflect.xRTProperty.PropertyHandle;
-
-import org.xvm.util.ListMap;
 
 
 /**
@@ -204,11 +202,11 @@ public class xRTType
     @Override
     public int getPropertyValue(Frame frame, ObjectHandle hTarget, PropertyConstant idProp, int iReturn)
         {
-        TypeHandle hThis = (TypeHandle) hTarget;
+        TypeHandle hType = (TypeHandle) hTarget;
 
         if (idProp instanceof FormalTypeChildConstant)
             {
-            TypeConstant typeTarget = hThis.getDataType();
+            TypeConstant typeTarget = hType.getDataType();
             TypeConstant typeValue  =
                 "OuterType".equals(idProp.getName()) && typeTarget.isVirtualChild()
                     ? typeTarget.getParentType()
@@ -222,7 +220,7 @@ public class xRTType
 
         if ("DataType".equals(idProp.getName()))
             {
-            TypeConstant typeResult = hThis.getUnsafeDataType();
+            TypeConstant typeResult = hType.getUnsafeDataType();
             return frame.assignValue(iReturn, typeResult.ensureTypeHandle(frame.f_context.f_container));
             }
         return super.getPropertyValue(frame, hTarget, idProp, iReturn);
@@ -530,11 +528,23 @@ public class xRTType
         {
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return Utils.constructListMap(frame, frame.f_context.f_container.resolveClass(ensureListMapType()),
-                    xString.ensureEmptyArray(), ensureEmptyTypeArray(frame.f_context.f_container), iReturn);
+            return getForeignChildTypes(frame, hType, iReturn);
             }
 
+        Container        container  = frame.f_context.f_container;
+        TypeComposition  clzListMap = container.resolveClass(ensureListMapType(container));
+        ObjectHandle[][] aah        = collectChildTypes(frame, hType);
+        StringHandle[]   ahName     = (StringHandle[]) aah[0];
+        TypeHandle[]     ahType     = (TypeHandle[])   aah[1];
+
+        return Utils.constructListMap(frame, clzListMap,
+                xArray.makeStringArrayHandle(ahName),
+                xArray.createImmutableArray(ensureTypeArrayComposition(container), ahType),
+                iReturn);
+        }
+
+    private ObjectHandle[][] collectChildTypes(Frame frame, TypeHandle hType)
+        {
         // bridge from one module to another if necessary
         TypeConstant typeTarget = hType.getDataType();
         if (typeTarget.isSingleUnderlyingClass(false))
@@ -550,18 +560,64 @@ public class xRTType
                 }
             }
 
-        TypeInfo                          infoTarget  = typeTarget.ensureTypeInfo();
-        ConstantPool                      poolCtx     = frame.poolContext();
-        Map<String, ChildInfo>            mapInfos    = infoTarget.getChildInfosByName();
-        Map<StringConstant, TypeConstant> mapResult   = new ListMap<>();
+        TypeInfo                infoTarget = typeTarget.ensureTypeInfo();
+        ConstantPool            poolCtx    = frame.poolContext();
+        Container               container  = frame.f_context.f_container;
+        Map<String, ChildInfo>  mapInfos   = infoTarget.getChildInfosByName();
+        int                     cInfos     = mapInfos.size();
+        StringHandle[]          ahName     = new StringHandle[cInfos];
+        TypeHandle[]            ahType     = new TypeHandle[cInfos];
+        int                     ix         = 0;
         for (String sName : mapInfos.keySet())
             {
-            TypeConstant typeChild = infoTarget.calculateChildType(poolCtx, sName);
-            mapResult.put(poolCtx.ensureStringConstant(sName), typeChild.getType());
+            ahName[ix  ] = xString.makeHandle(sName);
+            ahType[ix++] = infoTarget.calculateChildType(poolCtx, sName).ensureTypeHandle(container);
             }
 
-        MapConstant constResult = poolCtx.ensureMapConstant(ensureListMapType(), mapResult);
-        return frame.assignDeferredValue(iReturn, frame.getConstHandle(constResult));
+        return new ObjectHandle[][]{ahName, ahType};
+        }
+
+    private int getForeignChildTypes(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    Container        container  = frame.f_context.f_container;
+                    TypeHandle       hType      = typeForeign.ensureTypeHandle(container);
+                    ObjectHandle[][] aah        = collectChildTypes(frame, hType);
+                    TypeComposition  clzListMap = container.resolveClass(ensureListMapType(container));
+                    StringHandle[]   ahName     = (StringHandle[]) aah[0];
+                    TypeHandle[]     ahType     = (TypeHandle[])   aah[1];
+
+                    for (int i = 0, c = ahType.length; i < c; i++)
+                        {
+                        ahType[i] = xRTType.makeHandle(null, ahType[i].getDataType(), false);
+                        }
+
+                    return Utils.constructListMap(frame, clzListMap,
+                            xArray.makeStringArrayHandle(ahName),
+                            xArray.createImmutableArray(ensureTypeArrayComposition(container), ahType),
+                            0);
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignChildTypes";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty map
+        return Utils.constructListMap(frame, container.resolveClass(ensureListMapType(container)),
+                xString.ensureEmptyArray(), ensureEmptyTypeArray(container), iReturn);
         }
 
     /**
@@ -571,8 +627,7 @@ public class xRTType
         {
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(iReturn, xRTProperty.ensureEmptyArray(frame.f_context.f_container));
+            return getForeignConstants(frame, hType, iReturn);
             }
 
         TypeConstant                        typeTarget = hType.getDataType();
@@ -591,6 +646,51 @@ public class xRTType
         return makePropertyArray(frame, typeTarget, listInfo, iReturn);
         }
 
+    private int getForeignConstants(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    switch (getPropertyConstants(frame, hType, Op.A_STACK))
+                        {
+                        case Op.R_NEXT:
+                            return createProxyArray(frame, (ArrayHandle) frame.popStack(),
+                                    xRTFunction.INSTANCE.getCanonicalClass(), 0);
+
+                        case Op.R_CALL:
+                            frame.m_frameNext.addContinuation(frameCaller ->
+                                createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
+                                    xRTFunction.INSTANCE.getCanonicalClass(), 0));
+                            return Op.R_CALL;
+
+                        case Op.R_EXCEPTION:
+                            return Op.R_EXCEPTION;
+                        default:
+                            throw new IllegalStateException();
+                        }
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignConstants";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty array
+        return frame.assignValue(iReturn, xRTProperty.ensureEmptyArray(container));
+        }
+
     /**
      * Implements property: constructors.get()
      */
@@ -598,8 +698,7 @@ public class xRTType
         {
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(iReturn, xRTFunction.ensureEmptyArray(frame.f_context.f_container));
+            return getForeignConstructors(frame, hType, iReturn);
             }
 
         // the actual construction process uses a "construct" function as a structural initializer
@@ -696,6 +795,51 @@ public class xRTType
         return frame.assignValue(iReturn, xArray.createImmutableArray(clzArray, ahFunctions));
         }
 
+    private int getForeignConstructors(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    switch (getPropertyConstructors(frame, hType, Op.A_STACK))
+                        {
+                        case Op.R_NEXT:
+                            return createProxyArray(frame, (ArrayHandle) frame.popStack(),
+                                    xRTFunction.INSTANCE.getCanonicalClass(), 0);
+
+                        case Op.R_CALL:
+                            frame.m_frameNext.addContinuation(frameCaller ->
+                                createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
+                                    xRTFunction.INSTANCE.getCanonicalClass(), 0));
+                            return Op.R_CALL;
+
+                        case Op.R_EXCEPTION:
+                            return Op.R_EXCEPTION;
+                        default:
+                            throw new IllegalStateException();
+                        }
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignConstructors";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty array
+        return frame.assignValue(iReturn, xRTFunction.ensureEmptyArray(container));
+        }
+
     /**
      * Implements property: explicitlyImmutable.get()
      */
@@ -722,8 +866,7 @@ public class xRTType
         Container container = frame.f_context.f_container;
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(iReturn, xRTFunction.ensureEmptyArray(container));
+            return getForeignFunctions(frame, hType, iReturn);
             }
 
         TypeConstant                    typeTarget  = hType.getDataType();
@@ -754,6 +897,51 @@ public class xRTType
         return frame.assignValue(iReturn, xArray.createImmutableArray(clzArray, ahFunctions));
         }
 
+    private int getForeignFunctions(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    switch (getPropertyFunctions(frame, hType, Op.A_STACK))
+                        {
+                        case Op.R_NEXT:
+                            return createProxyArray(frame, (ArrayHandle) frame.popStack(),
+                                    xRTFunction.INSTANCE.getCanonicalClass(), 0);
+
+                        case Op.R_CALL:
+                            frame.m_frameNext.addContinuation(frameCaller ->
+                                createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
+                                    xRTFunction.INSTANCE.getCanonicalClass(), 0));
+                            return Op.R_CALL;
+
+                        case Op.R_EXCEPTION:
+                            return Op.R_EXCEPTION;
+                        default:
+                            throw new IllegalStateException();
+                        }
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignFunctions";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty array
+        return frame.assignValue(iReturn, xRTFunction.ensureEmptyArray(container));
+        }
+
     /**
      * Implements property: methods.get()
      */
@@ -761,8 +949,7 @@ public class xRTType
         {
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(iReturn, xRTMethod.ensureEmptyArray(frame.f_context.f_container));
+            return getForeignMethods(frame, hType, iReturn);
             }
 
         TypeConstant            typeTarget  = hType.getDataType();
@@ -791,6 +978,51 @@ public class xRTType
         return frame.assignValue(iReturn, xArray.createImmutableArray(clzArray, ahMethods));
         }
 
+    private int getForeignMethods(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    switch (getPropertyMethods(frame, hType, Op.A_STACK))
+                        {
+                        case Op.R_NEXT:
+                            return createProxyArray(frame, (ArrayHandle) frame.popStack(),
+                                    xRTMethod.INSTANCE.getCanonicalClass(), 0);
+
+                        case Op.R_CALL:
+                            frame.m_frameNext.addContinuation(frameCaller ->
+                                createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
+                                    xRTMethod.INSTANCE.getCanonicalClass(), 0));
+                            return Op.R_CALL;
+
+                        case Op.R_EXCEPTION:
+                            return Op.R_EXCEPTION;
+                        default:
+                            throw new IllegalStateException();
+                        }
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignMethods";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty array
+        return frame.assignValue(iReturn, xRTMethod.ensureEmptyArray(container));
+        }
+
     /**
      * Implements property: properties.get()
      */
@@ -798,8 +1030,7 @@ public class xRTType
         {
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(iReturn, xRTProperty.ensureEmptyArray(frame.f_context.f_container));
+            return getForeignProperties(frame, hType, iReturn);
             }
 
         TypeConstant            typeTarget = hType.getDataType();
@@ -817,6 +1048,51 @@ public class xRTType
             }
 
         return makePropertyArray(frame, typeTarget, listProps, iReturn);
+        }
+
+    private int getForeignProperties(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    switch (getPropertyProperties(frame, hType, Op.A_STACK))
+                        {
+                        case Op.R_NEXT:
+                            return createProxyArray(frame, (ArrayHandle) frame.popStack(),
+                                    xRTProperty.INSTANCE.getCanonicalClass(), 0);
+
+                        case Op.R_CALL:
+                            frame.m_frameNext.addContinuation(frameCaller ->
+                                createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
+                                    xRTProperty.INSTANCE.getCanonicalClass(), 0));
+                            return Op.R_CALL;
+
+                        case Op.R_EXCEPTION:
+                            return Op.R_EXCEPTION;
+                        default:
+                            throw new IllegalStateException();
+                        }
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignProperties";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty array
+        return frame.assignValue(iReturn, xRTProperty.ensureEmptyArray(container));
         }
 
     /**
@@ -863,8 +1139,7 @@ public class xRTType
         Container container = frame.f_context.f_container;
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(iReturn, ensureEmptyTypeArray(container));
+            return getForeignUnderlyingTypes(frame, hType, iReturn);
             }
 
         TypeConstant   typeTarget  = hType.getDataType();
@@ -891,6 +1166,51 @@ public class xRTType
         ObjectHandle hArray = xArray.createImmutableArray(
                                 ensureTypeArrayComposition(container), ahTypes);
         return frame.assignValue(iReturn, hArray);
+        }
+
+    private int getForeignUnderlyingTypes(Frame frame, TypeHandle hType, int iReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    switch (getForeignUnderlyingTypes(frame, hType, Op.A_STACK))
+                        {
+                        case Op.R_NEXT:
+                            return createProxyArray(frame, (ArrayHandle) frame.popStack(),
+                                    xRTProperty.INSTANCE.getCanonicalClass(), 0);
+
+                        case Op.R_CALL:
+                            frame.m_frameNext.addContinuation(frameCaller ->
+                                createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
+                                    xRTProperty.INSTANCE.getCanonicalClass(), 0));
+                            return Op.R_CALL;
+
+                        case Op.R_EXCEPTION:
+                            return Op.R_EXCEPTION;
+                        default:
+                            throw new IllegalStateException();
+                        }
+                    }
+
+                public String toString()
+                    {
+                    return "getForeignUnderlyingTypes";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOp1Request(frame, opCall, iReturn);
+            }
+
+        // cannot find the corresponding container; just return an empty array
+        return frame.assignValue(iReturn, ensureEmptyTypeArray(container));
         }
 
 
@@ -949,8 +1269,7 @@ public class xRTType
         {
         if (hType.isForeign())
             {
-            // TODO GG: ask the type's container to answer
-            return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+            return invokeForeignAnnotated(frame, hType, aiReturn);
             }
 
         TypeConstant typeThis = hType.getDataType();
@@ -986,6 +1305,34 @@ public class xRTType
                     : resolveInvokeAnnotatedArgs(frame, (ClassHandle) hClass, ahArg, aiReturn);
             }
 
+        return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+        }
+
+    private int invokeForeignAnnotated(Frame frame, TypeHandle hType, int[] aiReturn)
+        {
+        TypeConstant typeForeign      = hType.getUnsafeDataType();
+        Container    container        = frame.f_context.f_container;
+        Container    containerForeign = container.f_runtime.findContainer(typeForeign.getConstantPool());
+        if (containerForeign != null)
+            {
+            Op opCall = new Op()
+                {
+                public int process(Frame frame, int iPC)
+                    {
+                    TypeHandle hType = typeForeign.ensureTypeHandle(frame.f_context.f_container);
+
+                    return invokeAnnotated(frame, hType, new int[] {0, 1});
+                    }
+                public String toString()
+                    {
+                    return "invokeForeignAnnotated";
+                    }
+                };
+
+            return containerForeign.ensureServiceContext().sendOpNRequest(frame, opCall, aiReturn);
+            }
+
+        // cannot find the corresponding container
         return frame.assignValue(aiReturn[0], xBoolean.FALSE);
         }
 
@@ -1546,6 +1893,39 @@ public class xRTType
             }
         }
 
+    /**
+     * Convert an array or reflective objects into an array of proxies.
+     */
+    private int createProxyArray(Frame frame, ArrayHandle hArray, TypeComposition clzElement, int iReturn)
+        {
+        TypeConstant    typeElement = clzElement.getType();
+        TypeComposition clzArray    = frame.f_context.f_container.resolveClass(
+                frame.poolContext().ensureArrayType(typeElement));
+        ProxyComposition clzProxy  = new ProxyComposition(clzElement, typeElement);
+
+        int            cValues = (int) hArray.m_hDelegate.m_cSize;
+        ObjectHandle[] ahValue = new ObjectHandle[cValues];
+        for (int i = 0; i < cValues; i++)
+            {
+            switch (hArray.getTemplate().extractArrayValue(frame, hArray, i, Op.A_STACK))
+                {
+                case Op.R_NEXT:
+                    ObjectHandle hElement = frame.popStack();
+                    ahValue[i] = hElement instanceof TypeHandle hType
+                            ? xRTType.makeForeignHandle(hType.getUnsafeType())
+                            : Proxy.makeHandle(clzProxy, frame.f_context, hElement, false);
+                    break;
+
+                case Op.R_EXCEPTION:
+                    return Op.R_EXCEPTION;
+
+                default:
+                    throw new IllegalStateException();
+                }
+            }
+        return frame.assignValue(iReturn, xArray.createImmutableArray(clzArray, ahValue));
+        }
+
 
     // ----- Composition and handle caching --------------------------------------------------------
 
@@ -1574,12 +1954,12 @@ public class xRTType
     /**
      * @return the TypeConstant for {@code immutable ListMap<String, Type>}
      */
-    public static TypeConstant ensureListMapType()
+    public static TypeConstant ensureListMapType(Container container)
         {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null)
             {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.getConstantPool();
 
             type = pool.ensureEcstasyTypeConstant("collections.ListMap");
             type = pool.ensureParameterizedTypeConstant(type, pool.typeString(), pool.typeType());

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
@@ -409,7 +409,7 @@ public class xTuple
             }
 
         TypeComposition clzThis = hThis.getComposition();
-        if (!hValue.getType().isA(clzThis.getType().getParamType((int) lIndex)))
+        if (!hValue.getUnsafeType().isA(clzThis.getType().getParamType((int) lIndex)))
             {
             return frame.raiseException(
                     xException.typeMismatch(frame, hValue.getType().getValueString()));

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
@@ -366,7 +366,7 @@ public class xClass
                 }
 
             Container       container = frame.f_context.f_container;
-            TypeComposition clzMap    = container.resolveClass(xRTType.ensureListMapType());
+            TypeComposition clzMap    = container.resolveClass(xRTType.ensureListMapType(container));
             ConstantPool    pool      = frame.poolContext();
             int iResult;
             if (cParams == 0)

--- a/manualTests/src/main/x/reflect.x
+++ b/manualTests/src/main/x/reflect.x
@@ -58,6 +58,7 @@ module TestReflection {
 
     void testMaskReveal() {
         import ecstasy.fs.Directory;
+        import ecstasy.TypeMismatch;
 
         console.print("\n** testMaskReveal");
 
@@ -75,7 +76,7 @@ module TestReflection {
         try {
             Stringable str = tmpDir.as(Stringable);
             assert;
-        } catch (Exception e) {
+        } catch (TypeMismatch e) {
             console.print($"expected - {e.text}");
         }
 
@@ -91,7 +92,7 @@ module TestReflection {
         try {
             p = str.as(Point);
             assert;
-        } catch (Exception e) {
+        } catch (TypeMismatch e) {
             console.print($"expected - {e.text}");
         }
 


### PR DESCRIPTION
There was a number of "TODO"s at xRTType.java to implement reflection API against "foreign" types (object of type Type, that belong to another container's type system)

This PR implements them.