### PR TITLE
Add lifecycle support to ResourceProvider

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -2465,6 +2465,7 @@ public class ConstantPool
     public SignatureConstant sigToString()       {SignatureConstant c = m_sigToString;       if (c == null) {m_sigToString       = c = getSignature("Object",    "toString",  0)                        ;} return c;}
     public SignatureConstant sigEquals()         {SignatureConstant c = m_sigEquals;         if (c == null) {m_sigEquals         = c = getSignature("Object",    "equals",    3)                        ;} return c;}
     public SignatureConstant sigCompare()        {SignatureConstant c = m_sigCompare;        if (c == null) {m_sigCompare        = c = getSignature("Orderable", "compare",   3)                        ;} return c;}
+    public SignatureConstant sigClose()          {SignatureConstant c = m_sigClose;          if (c == null) {m_sigClose          = c = getSignature("Closeable", "close",     1)                        ;} return c;}
     public SignatureConstant sigValidator()      {SignatureConstant c = m_sigValidator;      if (c == null) {m_sigValidator      = c = ensureSignatureConstant("assert", NO_TYPES, NO_TYPES)            ;} return c;}
 
 
@@ -4202,6 +4203,7 @@ public class ConstantPool
         m_sigToString       = null;
         m_sigEquals         = null;
         m_sigCompare        = null;
+        m_sigClose          = null;
         m_sigValidator      = null;
         m_infoPlaceholder   = null;
 
@@ -4256,6 +4258,7 @@ public class ConstantPool
     private transient SignatureConstant m_sigToString;
     private transient SignatureConstant m_sigEquals;
     private transient SignatureConstant m_sigCompare;
+    private transient SignatureConstant m_sigClose;
     private transient SignatureConstant m_sigValidator;
     private transient TypeInfo          m_infoPlaceholder;
 

--- a/javatools/src/main/java/org/xvm/runtime/NestedContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/NestedContainer.java
@@ -35,13 +35,15 @@ public class NestedContainer
      *
      * @param containerParent  the parent container
      * @param idModule         the module id
+     * @param hProvider        a resource provider supplied by the parent container
      * @param listShared       a list ids for shared modules
      */
     public NestedContainer(Container containerParent, ModuleConstant idModule,
-                           List<ModuleConstant> listShared)
+                           ObjectHandle hProvider, List<ModuleConstant> listShared)
         {
         super(containerParent.f_runtime, containerParent, idModule);
 
+        f_hProvider  = hProvider;
         f_listShared = listShared;
         }
 
@@ -88,10 +90,7 @@ public class NestedContainer
                         {
                         DeferredCallHandle hDeferred = new DeferredCallHandle(frame.m_frameNext);
                         hDeferred.addContinuation(frameCaller ->
-                            {
-                            frameCaller.pushStack(validateResource(frameCaller, container, key));
-                            return Op.R_NEXT;
-                            });
+                            frameCaller.pushStack(validateResource(frameCaller, container, key)));
                         return hDeferred;
                         }
 
@@ -156,6 +155,11 @@ public class NestedContainer
 
 
     // ----- data fields ---------------------------------------------------------------------------
+
+    /**
+     * The resource provider object (it's known to be "Closeable").
+     */
+    public final ObjectHandle f_hProvider;
 
     /**
      * List of shared modules.

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
@@ -241,18 +241,18 @@ public class xContainerLinker
                                        ModuleStructure moduleApp, ObjectHandle hProvider, int iReturn)
         {
         NestedContainer containerNested = new NestedContainer(container,
-                moduleApp.getIdentityConstant(), Collections.emptyList());
-        return new CollectResources(containerNested, hProvider, iReturn).doNext(frame);
+                moduleApp.getIdentityConstant(), hProvider, Collections.emptyList());
+        return new CollectResources(containerNested, iReturn).doNext(frame);
         }
 
     public static class CollectResources
                 implements Frame.Continuation
         {
-        public CollectResources(NestedContainer container, ObjectHandle hProvider, int iReturn)
+        public CollectResources(NestedContainer container, int iReturn)
             {
             this.container = container;
             this.aKeys     = container.collectInjections().toArray(InjectionKey.NO_INJECTIONS);
-            this.hProvider = hProvider;
+            this.hProvider = container.f_hProvider;
             this.iReturn   = iReturn;
             }
 

--- a/lib_ecstasy/src/main/x/ecstasy.x
+++ b/lib_ecstasy/src/main/x/ecstasy.x
@@ -148,21 +148,6 @@ module ecstasy.xtclang.org {
             extends IllegalArgument(text, cause);
 
     /**
-     * The interface associated with objects that are automatically closed by the `using` and
-     * `try`-with-resources blocks.
-     */
-    interface Closeable {
-        /**
-         * This method is invoked to mark the end of the use of an object. The object may release
-         * its resources at this point, and may subsequently be cantankerous and/or unusable as a
-         * result.
-         *
-         * @param e  (optional) an exception that occurred that triggered the call to `close()`
-         */
-        void close(Exception? cause = Null);
-    }
-
-    /**
      * `Shareable` is a type that represents an object that can be passed across a service boundary,
      * from the realm of one service, passed into a different service. Specifically, it is only
      * possible to pass an immutable object or a service proxy across a service boundary; the exact

--- a/lib_ecstasy/src/main/x/ecstasy/Closeable.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Closeable.x
@@ -1,0 +1,28 @@
+/**
+ * This interface is implemented by classes that desire a notification of an end-of-lifecycle
+ * event. The two common patterns associated with this interface are:
+ *
+ * * Objects that need to be automatically closed at the conclusion of a `using` or
+ *   `try`-with-resources block, e.g. [Timeout];
+ * * Objects that represent resources that need to be released or otherwise cleaned up when the
+ *   holding object will no longer be used, e.g. a `ServerSocket`.
+ *
+ * Generally, all implementations of [close()] should be idempotent.
+ */
+interface Closeable {
+    /**
+     * This method is invoked to mark the end of the use of an object. The object should release
+     * its resources at this point.
+     *
+     * After the completion of the `close()` method, the object should no longer be used.
+     * Subsequent attempts to use the object may result in undefined behavior.
+     *
+     * It is recommended that an implementation of this method be idempotent, such that
+     * calls to `close()` after the first one will not have any effect.
+     *
+     * @param cause  (optional) the exception within a `using` or `try`-with-resources block
+     *               that triggered the call to `close()`, or `Null` if  the call represents a
+     *               normal lifecycle completion
+     */
+    void close(Exception? cause = Null);
+}

--- a/lib_ecstasy/src/main/x/ecstasy/mgmt/ResourceProvider.x
+++ b/lib_ecstasy/src/main/x/ecstasy/mgmt/ResourceProvider.x
@@ -1,7 +1,9 @@
 /**
  * Represents the source of injected resources.
  */
-interface ResourceProvider {
+interface ResourceProvider
+        extends Closeable {
+
     import annotations.InjectedRef.Options;
 
     /**
@@ -21,4 +23,15 @@ interface ResourceProvider {
      * exception, possibly causing the termination of the container.
      */
     Supplier getResource(Type type, String name);
+
+    /**
+     * At the point that the container (for which this ResourceProvider exists) is shut down or
+     * killed, this method will be invoked to allow closing any resources that this provider has
+     * supplied to that container.
+     *
+     * Common implementations of this method are expected to invoke the `close()` method on all
+     * previously supplied resources that implement the [Closeable] interface.
+     */
+    @Override
+    void close(Exception? cause = Null) {}
 }


### PR DESCRIPTION
Currently, the API for ResourceProvider which is used to control injections into a newly created Container doesn't have any lifecycle events. It becomes a problem when a custom ResourceProvider injects a lifecycle aware (Closeable) resource into a child container. When that container is "killed", the resources may leak, since no one properly "closes" them.

This change addresses the issue my making the ResourceProvider to extend Closeable and guaranteeing a RT call to close() when the container goes away.

Cameron suggested a bit more elaborate extension to the ResourceProvider API:

```
/**
 * At the point that the container (for which this ResourceProvider exists) is shut down or
 * killed, this method will be invoked and passed a list of all resources previously supplied
 * that implements the [Closeable] interface.
 *
 * The default implementation of this method invokes the `close()` method on each of those
 * resources.
 *
 * @param resources  each resource previously supplied by this provider that implements the
 *                   [Closeable] interface 
 */
void releaseResources(List<Closeable> resources) = resources.forEach(close);
```

That would make the implementor's job easier, but requires more work by the native code. I'm going forward with an easier a fix that puts onus on the ResourceProvider implementation to collect all necessary resources, but we may change it in the future.