### PR TITLE
Introduce native Container API to freeze time; make the console debugger to freeze all containers

### DIFF
--- a/doc/todo-list.txt
+++ b/doc/todo-list.txt
@@ -1,16 +1,11 @@
 - CP: implement RTServer.backTrace.get() and tls.get(); test it with nginx
 
-- GG: deal with a potential leak at ClassComposition.ensureGetterChain
-
 - CP: how to prevent a DoS attack by a "curl" loop to overwhelm the session cache
 
 - CP: dedicated Realm and/or Authenticator; for OAth and TokenAuth; chaining of Authenticators
     - consider multiple users for the session
 
 - CP: make DigestAuthenticator.NonceTable into a service
-
-- GG: add support for runtime constants that cross the module line; may need to restore the removed
-      delegation logic in ConverterExpression
 
 - CP: a content-type header for FormData has the following format:
     multipart/form-data; boundary=---------------------------1612195806993123533773008794
@@ -38,8 +33,6 @@
     - readBytes() methods need to return the number of bytes read
     - would be nice to have an "eof" indicator
 
-- GG: entering the debugger should stop time
-
 - GG: consider allowing to debug an eval expression (debug eval)
 
 - GG: consider changing Service.callLater() API to
@@ -50,8 +43,6 @@
 
 - add a method to Map API to evaluate the "worst lookup cost" based on the current content
   (Mark's suggestion to evaluated keys' hashCode distribution)
-
-- GG: implement timeout for IO operations (interrupt IO executor threads)
 
 - how to move ecstasy.mgmt package to a separate module? FileTemplate depends on ModuleRepository...
 

--- a/javatools/src/main/java/org/xvm/runtime/DebugConsole.java
+++ b/javatools/src/main/java/org/xvm/runtime/DebugConsole.java
@@ -273,6 +273,21 @@ public final class DebugConsole
      */
     private int enterCommand(Frame frame, int iPC, boolean fRender)
         {
+        // for now, let's freeze *all* containers
+        Container container = frame.f_context.f_container.getNativeContainer();
+        container.freezeTime();
+        try
+            {
+            return enterCommandInternal(frame, iPC, fRender);
+            }
+        finally
+            {
+            container.unfreezeTime();
+            }
+        }
+
+    private int enterCommandInternal(Frame frame, int iPC, boolean fRender)
+        {
         m_frame    = frame;
         m_iPC      = iPC;
         m_stepMode = StepMode.None;

--- a/javatools/src/main/java/org/xvm/runtime/Fiber.java
+++ b/javatools/src/main/java/org/xvm/runtime/Fiber.java
@@ -91,7 +91,7 @@ public class Fiber
         }
 
     /**
-     * @return the current timeout timestamp in milliseconds (using System.currentTimeMillis());
+     * @return the current timeout timestamp in milliseconds (using Container.currentTimeMillis());
      *         zero if there is no timeout
      */
     public long getTimeoutStamp()
@@ -181,13 +181,13 @@ public class Fiber
                 throw new IllegalArgumentException();
 
             case Running:
-                m_nanoStarted = System.nanoTime();
+                m_nanoStarted = f_context.f_container.nanoTime();
                 m_frame = null;
                 break;
 
             case Waiting:
             case Paused:
-                long cNanos = System.nanoTime() - m_nanoStarted;
+                long cNanos = f_context.f_container.nanoTime() - m_nanoStarted;
                 m_nanoStarted = 0;
                 f_context.m_cRuntimeNanos += cNanos;
                 m_frame = f_context.getCurrentFrame();
@@ -236,7 +236,7 @@ public class Fiber
      */
     public boolean isTimedOut()
         {
-        return m_ldtTimeout > 0 && System.currentTimeMillis() > m_ldtTimeout;
+        return m_ldtTimeout > 0 && f_context.f_container.currentTimeMillis() > m_ldtTimeout;
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
+++ b/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
@@ -2177,7 +2177,7 @@ public class ServiceContext
         {
         protected void schedule(long ldtWakeUp)
             {
-            long ldtNow = System.currentTimeMillis();
+            long ldtNow = f_container.currentTimeMillis();
             if (f_ldtScheduled > 0)
                 {
                 if (ldtNow <= f_ldtScheduled && f_ldtScheduled <= ldtWakeUp)

--- a/javatools/src/main/java/org/xvm/runtime/Utils.java
+++ b/javatools/src/main/java/org/xvm/runtime/Utils.java
@@ -256,22 +256,22 @@ public abstract class Utils
             sMsg = sMsg.substring(1);
             }
 
-        ServiceContext ctx;
-        long lFiberId;
+        ServiceContext context;
+        long           lFiberId;
 
         if (frame == null)
             {
-            ctx = ServiceContext.getCurrentContext();
+            context  = ServiceContext.getCurrentContext();
             lFiberId = -1;
             }
         else
             {
-            ctx = frame.f_context;
+            context  = frame.f_context;
             lFiberId = frame.f_fiber.getId();
             }
 
-        System.out.println(new Timestamp(System.currentTimeMillis())
-            + " " + ctx + ", fiber " + lFiberId + ": " + sMsg);
+        System.out.println(new Timestamp(context.f_container.currentTimeMillis())
+            + " " + context + ", fiber " + lFiberId + ": " + sMsg);
         }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
@@ -264,7 +264,8 @@ public class xRTConnector
             long ldtTimeout = frame.f_fiber.getTimeoutStamp();
             if (ldtTimeout > 0)
                 {
-                long cTimeoutMillis = Math.max(1, ldtTimeout - System.currentTimeMillis());
+                long cTimeoutMillis = Math.max(1,
+                                        ldtTimeout - frame.f_context.f_container.currentTimeMillis());
                 if (cTimeoutMillis > Integer.MAX_VALUE)
                     {
                     cTimeoutMillis = Integer.MAX_VALUE;

--- a/javatools/src/main/java/org/xvm/runtime/template/xException.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xException.java
@@ -335,12 +335,14 @@ public class xException
      */
     public static ExceptionHandle makeObscure(Frame frame, String sErr)
         {
-        return makeHandle(frame, s_clzException, "RTError: " + System.currentTimeMillis(), sErr);
+        return makeHandle(frame, s_clzException, "RTError: " +
+                frame.f_context.f_container.currentTimeMillis(), sErr);
         }
 
     public static ExceptionHandle obscureIoException(Frame frame, String sErr)
         {
-        return makeHandle(frame, s_clzIOException, "RTError: " + System.currentTimeMillis(), sErr);
+        return makeHandle(frame, s_clzIOException, "RTError: " +
+                frame.f_context.f_container.currentTimeMillis(), sErr);
         }
 
     public static ExceptionHandle makeHandle(Frame frame, TypeComposition clzEx,

--- a/javatools/src/main/java/org/xvm/runtime/template/xService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xService.java
@@ -267,7 +267,7 @@ public class xService
                         {
                         long cRemains = xNanosTimer.millisFromDuration(frame.popStack());
                         frame.f_fiber.setTimeoutHandle(hArg,
-                                System.currentTimeMillis() + cRemains);
+                                frame.f_context.f_container.currentTimeMillis() + cRemains);
                         return Op.R_NEXT;
                         }
                     case Op.R_CALL:
@@ -275,7 +275,7 @@ public class xService
                             {
                             long cRemains = xNanosTimer.millisFromDuration(frameCaller.popStack());
                             frameCaller.f_fiber.setTimeoutHandle(hArg,
-                                    System.currentTimeMillis() + cRemains);
+                                    frame.f_context.f_container.currentTimeMillis() + cRemains);
                             return Op.R_NEXT;
                             });
                         return Op.R_CALL;

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -1,16 +1,33 @@
 module TestSimple {
     @Inject Console console;
+    @Inject Clock clock;
 
     void run() {
-        @Inject Clock clock;
+        Time time1 = clock.now;
+        assert:debug;
+        Time time2 = clock.now;
+        assert time2 - time1 < Duration.ofSeconds(1);
 
-        Clock.Cancellable cancel = clock.schedule(Duration.ofSeconds(10), &alarm);
-        console.print("Alarm is up");
-
-        cancel(); // this used to blow up at run-time
+        new Tester().testSleep(Duration.ofSeconds(5));
     }
 
-    void alarm() {
-        assert;
+    service Tester() {
+        Int testSleep(Duration duration) {
+            return sleep(duration);
+        }
+    }
+
+    static Int sleep(Duration duration) {
+        @Inject Timer timer;
+        @Future Int done;
+
+        timer.schedule(duration, () ->
+            {
+            console.print($"Wake up after {timer.elapsed} sec");
+            done = 17;
+            });
+        timer.start();
+        assert:debug;
+        return done;
     }
 }


### PR DESCRIPTION
When you used the Console Debugger for stepping through Ecstasy code, it used to be extremely hard to investigate any timer related logic, since stopping in the debugger didn't prevent the alarms to go off based on the wall clock.

This change allows the debugger to "freeze" time for all containers, dramatically simplifying such a debugging.