### PR TITLE
Simplify multi-value conversion AST production

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/Register.java
+++ b/javatools/src/main/java/org/xvm/asm/Register.java
@@ -881,11 +881,16 @@ public class Register
         @Override
         public ExprAST getRegisterAST()
             {
-            NarrowedExprAST astNarrowed = m_astNarrowed;
+            ExprAST astNarrowed = m_astNarrowed;
             if (astNarrowed == null)
                 {
-                astNarrowed = m_astNarrowed = new NarrowedExprAST(
-                        Register.this.getRegisterAST(), getType());
+                TypeConstant typeNarrowed = getType();
+                TypeConstant typeOrig     = getOriginalType();
+                ExprAST      astOrig      = Register.this.getRegisterAST();
+
+                astNarrowed = m_astNarrowed = typeNarrowed.equals(typeOrig)
+                    ? astOrig
+                    : new NarrowedExprAST(astOrig, typeNarrowed);
                 }
             return astNarrowed;
             }
@@ -921,9 +926,9 @@ public class Register
         private boolean m_fInPlace = false;
 
         /**
-         * Cached NarrowedExprAST.
+         * Cached ExprAST for shadow register (could be the same as for the original register).
          */
-        private NarrowedExprAST m_astNarrowed;
+        private ExprAST m_astNarrowed;
         }
 
 

--- a/javatools/src/main/java/org/xvm/asm/ast/ConvertExprAST.java
+++ b/javatools/src/main/java/org/xvm/asm/ast/ConvertExprAST.java
@@ -35,6 +35,15 @@ public class ConvertExprAST
         this.convMethods = convMethods;
     }
 
+    public ConvertExprAST(ExprAST expr, TypeConstant type, MethodConstant convMethod) {
+        super(expr);
+
+        assert type != null && convMethod != null;
+
+        this.types       = new TypeConstant[] {type};
+        this.convMethods = new MethodConstant[] {convMethod};
+    }
+
     public Constant[] getConvMethods() {
         return convMethods;
     }

--- a/javatools/src/main/java/org/xvm/asm/ast/StmtExprAST.java
+++ b/javatools/src/main/java/org/xvm/asm/ast/StmtExprAST.java
@@ -15,7 +15,6 @@ import static org.xvm.asm.ast.BinaryAST.NodeType.StmtExpr;
 import static org.xvm.util.Handy.indentLines;
 
 
-
 /**
  * A statement expression.
  */

--- a/javatools/src/main/java/org/xvm/compiler/ast/AssignmentStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/AssignmentStatement.java
@@ -813,8 +813,14 @@ public class AssignmentStatement
                     fCompletes &= rvalue.isCompletable();
                     }
 
+                // for now, we only "unwrap" rvalue if it's a ConvertExpression; if necessary, we
+                // should create a corresponding abstract method on Expression an implement
+                // as required
                 astLVal   = combineLValueAST(astLVal, lvalueExpr.getExprAST(ctx));
-                astAssign = new AssignAST(astLVal, Operator.Asn, rvalue.getExprAST(ctx));
+                astAssign = rvalue instanceof ConvertExpression exprConv &&
+                            !exprConv.isSingle() && !exprConv.isConstant()
+                        ? exprConv.unwrapConverAST(ctx, astLVal)
+                        : new AssignAST(astLVal, Operator.Asn, rvalue.getExprAST(ctx));
                 break;
                 }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
@@ -1797,8 +1797,7 @@ public class InvocationExpression
             Register regFn = code.createRegister(typeFn, fTargetOnStack);
             code.add(new Invoke_01(argFn, idConv, regFn));
             argFn = regFn;
-            astFn = new ConvertExprAST(astFn,
-                        new TypeConstant[]{typeFn}, new MethodConstant[]{idConv});
+            astFn = new ConvertExprAST(astFn, typeFn, idConv);
             }
 
         TypeConstant[] atypeParams = pool.extractFunctionParams(typeFn);

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -2,56 +2,15 @@ module TestSimple {
     @Inject Console console;
 
     void run() {
-        console.print(new test1.Base1<String>().add("hello1"));
-        console.print(new test1.Base2<String>().add("hello2"));
-
-        console.print("test2");
-        console.print(new test2.Base1<String>().add("hello1"));
-        console.print(new test2.Base2<String>().add("hello2"));
+        console.print(test());
     }
 
-    // a number of things below used to fail to compile (those are excerpts from the tck)
-    package test1 {
-        mixin MixIn<ElementM> into Base1<ElementM> | Base2<ElementM> {
-            @Override String add(ElementM e) = $"MX[{e=} " + super(e) + " ]MX";
-        }
-
-        class Super1<Element> {
-            String add(Element e) = $"S[{e=}]S";
-        }
-
-        class Base1<ElementM> extends Super1<ElementM> incorporates MixIn<ElementM> {
-            @Override String add(ElementM e) = $"B[{e=} " + super(e) + " ]B";
-        }
-
-        class Super2<Element> {
-            String add(Element e) = $"s[{e=}]s";
-        }
-
-        class Base2<ElementM> extends Super2<ElementM> incorporates MixIn<ElementM> {
-            @Override String add(ElementM e) = $"b[{e=} " + super(e) + " ]b";
-        }
+    Int test() {
+        (Int year, _, Int day, _) = calcDate();
+        return year;
     }
 
-    package test2 {
-        mixin MixIn<ElementM> into Base1<ElementM> | Base2<ElementM> {
-            @Override String add(ElementM e) = $"MX[{e=} " + super(e) + " ]MX";
-        }
-
-        class Super1<ElementS1> {
-            String add(ElementS1 e) = $"S[{e=}]S";
-        }
-
-        class Base1<ElementB1> extends Super1<ElementB1> incorporates MixIn<ElementB1> {
-            @Override String add(ElementB1 e) = $"B[{e=} " + super(e) + " ]B";
-        }
-
-        class Super2<ElementS2> {
-            String add(ElementS2 e) = $"s[{e=}]s";
-        }
-
-        class Base2<ElementB2> extends Super2<ElementB2> incorporates MixIn<ElementB2> {
-            @Override String add(ElementB2 e) = $"b[{e=} " + super(e) + " ]b";
-        }
+    static (Int32 year, Int32 month, Int32 day, Int32 dayOfYear) calcDate() {
+        return 2024, 9, 16, 276;
     }
 }


### PR DESCRIPTION
Consider a function:

    (Int32, Int32) f() {...}

that is being used like this:

    (Int x, Int y) = f();

For such a call, we used to produce a BAST tree that combined a ConvertAST with a multi-return CallAST, which was hard to process by the back-end compiler. This change simplifies the BAST production by splitting the call and conversion, basically turning the code above into this:

    (Int32 tmpX, Int32 tmpY) = f();
    Int x = tmpX.toInt64();
    Int y = tmpY.toInt64();
    