### PR TITLE
Remove unnecessary type declarations

### DIFF
--- a/manualTests/src/main/x/json/json_test/JsonArrayTest.x
+++ b/manualTests/src/main/x/json/json_test/JsonArrayTest.x
@@ -14,7 +14,7 @@ class JsonArrayTest {
         JsonArray array = json.arrayBuilder()
             .add("foo")
             .build();
-        assert array == Array<Doc>:["foo"];
+        assert array == ["foo"];
     }
 
     @Test
@@ -24,7 +24,7 @@ class JsonArrayTest {
             .add("two")
             .add("three")
             .build();
-        assert array == Array<Doc>:["one", "two", "three"];
+        assert array == ["one", "two", "three"];
     }
 
     @Test
@@ -32,7 +32,7 @@ class JsonArrayTest {
         JsonArray array = json.arrayBuilder()
             .addAll(["one", "two", "three"])
             .build();
-        assert array == Array<Doc>:["one", "two", "three"];
+        assert array == ["one", "two", "three"];
     }
 
     @Test
@@ -41,9 +41,9 @@ class JsonArrayTest {
             .add(json.objectBuilder().add("one", 1).add("two", 2).add("three", 3).add("four", 4))
             .add(json.objectBuilder().add("five", 5).add("six", 6))
             .build();
-        assert array == Array<Doc>:[
-                Map<String, Doc>:["one"=1, "two"=2, "three"=3, "four"=4],
-                Map<String, Doc>:["five"=5, "six"=6]
+        assert array == [
+                ["one"=1, "two"=2, "three"=3, "four"=4],
+                ["five"=5, "six"=6]
                 ];
     }
 
@@ -55,6 +55,6 @@ class JsonArrayTest {
             .add("three")
             .set(1, "TWO")
             .build();
-        assert array == Array<Doc>:["one", "TWO", "three"];
+        assert array == ["one", "TWO", "three"];
     }
 }

--- a/manualTests/src/main/x/json/json_test/JsonBuilderTest.x
+++ b/manualTests/src/main/x/json/json_test/JsonBuilderTest.x
@@ -23,32 +23,32 @@ class JsonBuilderTest {
 
     @Test
     void shouldCopySimpleObject() {
-        JsonObject object = hideCompileType(Map<String, Doc>:["one"=11, "two"=22, "three"=33]);
+        JsonObject object = hideCompileType(["one"=11, "two"=22, "three"=33]);
         JsonObject result = JsonBuilder.deepCopy(object);
         assertDeepCopy(object, result);
     }
 
     @Test
     void shouldCopySimpleArray() {
-        JsonArray array  = hideCompileType(Array<Doc>:[1, 2, 3]);
+        JsonArray array  = hideCompileType([1, 2, 3]);
         JsonArray result = JsonBuilder.deepCopy(array);
         assertDeepCopy(array, result);
     }
 
     @Test
     void shouldCopyComplexObject() {
-        JsonObject child  = Map<String, Doc>:["one"=11, "two"=22, "three"=33];
-        JsonArray  array  = Array<Doc>:[1, 2, 3];
-        JsonObject object = Map<String, Doc>:["one"=child, "two"=array, "three"=33];
+        JsonObject child  = ["one"=11, "two"=22, "three"=33];
+        JsonArray  array  = [1, 2, 3];
+        JsonObject object = ["one"=child, "two"=array, "three"=33];
         JsonObject result = JsonBuilder.deepCopy(object);
         assertDeepCopy(object, result);
     }
 
     @Test
     void shouldCopyComplexArray() {
-        JsonArray  child  = Array<Doc>:[1, 2, 3];
-        JsonObject object = Map<String, Doc>:["one"=11, "two"=22, "three"=33];
-        JsonArray  array  = Array<Doc>:[child, object];
+        JsonArray  child  = [1, 2, 3];
+        JsonObject object = ["one"=11, "two"=22, "three"=33];
+        JsonArray  array  = [child, object];
         JsonArray  result = JsonBuilder.deepCopy(array);
         assertDeepCopy(array, result);
     }
@@ -94,23 +94,23 @@ class JsonBuilderTest {
 
     @Test
     void shouldMergeSimpleObjectIntoObject() {
-        JsonObject target = Map:["a"="b"];
-        JsonObject source = Map:["c"="d"];
+        JsonObject target = ["a"="b"];
+        JsonObject source = ["c"="d"];
         JsonObject result = new JsonObjectBuilder(target).deepMerge(source).build();
-        assert result == Map:["a"="b", "c"="d"];
+        assert result == ["a"="b", "c"="d"];
     }
 
     @Test
     void shouldMergeComplexObjectIntoObject() {
-        JsonObject target = Map:["a"="b"];
-        JsonObject source = Map:["c"=Map<String, Doc>:["one"="two"]];
+        JsonObject target = ["a"="b"];
+        JsonObject source = ["c"=["one"="two"]];
         JsonObject result = new JsonObjectBuilder(target).deepMerge(source).build();
-        assert result == Map<String, Doc>:["a"="b", "c"=Map<String, Doc>:["one"="two"]];
+        assert result == Map<String, Doc>:["a"="b", "c"=["one"="two"]];
     }
 
     @Test
     void shouldMergeArrayIntoObject() {
-        JsonObject target = Map:["a"="b"];
+        JsonObject target = ["a"="b"];
         JsonArray  source = [1, 2, 3];
         JsonObject result = new JsonObjectBuilder(target).deepMerge(source).build();
         assert result == Map<String, Doc>:["a"="b", "0"=1, "1"=2, "2"=3];
@@ -118,40 +118,40 @@ class JsonBuilderTest {
 
     @Test
     void shouldMergeObjectWithObjectIntoObjectWithExistingObject() {
-        JsonObject target = Map:["a"="b", "c"=Map<String, Doc>:["one"=1, "two"=2]];
-        JsonObject source = Map:["c"=Map<String, Doc>:["two"=22, "three"=3]];
+        JsonObject target = ["a"="b", "c"=["one"=1, "two"=2]];
+        JsonObject source = ["c"=["two"=22, "three"=3]];
         JsonObject result = new JsonObjectBuilder(target).deepMerge(source).build();
-        assert result == Map<String, Doc>:["a"="b", "c"=Map<String, Doc>:["one"=1, "two"=22, "three"=3]];
+        assert result == Map<String, Doc>:["a"="b", "c"=["one"=1, "two"=22, "three"=3]];
     }
 
     @Test
     void shouldMergeObjectWithObjectIntoObjectWithExistingArray() {
-        JsonObject target = Map:["a"="b", "c"=Array<Doc>:["one", "two", "three"]];
-        JsonObject source = Map:["c"=Map<String, Doc>:["0"="one-updated", "2"="three-updated"]];
+        JsonObject target = ["a"="b", "c"=["one", "two", "three"]];
+        JsonObject source = ["c"=["0"="one-updated", "2"="three-updated"]];
         JsonObject result = new JsonObjectBuilder(target).deepMerge(source).build();
-        assert result == Map<String, Doc>:["a"="b", "c"=Array<Doc>:["one-updated", "two", "three-updated"]];
+        assert result == Map<String, Doc>:["a"="b", "c"=["one-updated", "two", "three-updated"]];
     }
 
     @Test
     void shouldMergeObjectWithObjectIntoObjectWithExistingComplexArray() {
-        JsonObject objOrig0     = Map<String, Doc>:["one"=1, "two"=2];
-        JsonObject objOrig1     = Map<String, Doc>:["three"=3, "four"=4, "five"=5];
-        JsonObject objOrig2     = Map<String, Doc>:["six"=6, "seven"=7];
-        JsonObject target       = Map<String, Doc>:["a"="b", "c"=Array<Doc>:[objOrig0, objOrig1, objOrig2]];
-        JsonObject objUpdate1   = Map<String, Doc>:["four"=44];
-        JsonObject objExpected1 = Map<String, Doc>:["three"=3, "four"=44, "five"=5];
-        JsonObject source       = Map<String, Doc>:["c"=Map<String, Doc>:["1"=objUpdate1]];
+        JsonObject objOrig0     = ["one"=1, "two"=2];
+        JsonObject objOrig1     = ["three"=3, "four"=4, "five"=5];
+        JsonObject objOrig2     = ["six"=6, "seven"=7];
+        JsonObject target       = ["a"="b", "c"=[objOrig0, objOrig1, objOrig2]];
+        JsonObject objUpdate1   = ["four"=44];
+        JsonObject objExpected1 = ["three"=3, "four"=44, "five"=5];
+        JsonObject source       = ["c"=["1"=objUpdate1]];
         JsonObject result       = new JsonObjectBuilder(target).deepMerge(source).build();
         Doc        c            = result["c"];
         assert c.is(Array<Doc>);
-        assert c == Array<Doc>:[objOrig0, objExpected1, objOrig2];
-        //assert result == Map<String, Doc>:["a"="b", "c"=Array<Doc>:[objOrig0, objExpected1, objOrig2]];
+        assert c == Doc[]:[objOrig0, objExpected1, objOrig2];
+        //assert result == ["a"="b", "c"=[objOrig0, objExpected1, objOrig2]];
     }
 
     @Test
     void shouldNotMergeObjectWithObjectWithNonIntKeysIntoObjectWithExistingArray() {
-        JsonObject        target  = Map<String, Doc>:["a"="b", "c"=Array<Doc>:["one", "two", "three"]];
-        JsonObject        source  = Map<String, Doc>:["c"=Map<String, Doc>:["0"="one-updated", "three"="three-updated"]];
+        JsonObject        target  = ["a"="b", "c"=["one", "two", "three"]];
+        JsonObject        source  = ["c"=["0"="one-updated", "three"="three-updated"]];
         JsonObjectBuilder builder = new JsonObjectBuilder(target);
         try {
             builder.deepMerge(source);
@@ -160,13 +160,13 @@ class JsonBuilderTest {
             // expected
         }
         // target should be unchanged
-        assert target == Map<String, Doc>:["a"="b", "c"=Array<Doc>:["one", "two", "three"]];
+        assert target == Map<String, Doc>:["a"="b", "c"=["one", "two", "three"]];
     }
 
     @Test
     void shouldNotMergeObjectWithObjectWithOutOfRangeKeysIntoObjectWithExistingArray() {
-        JsonObject        target  = Map<String, Doc>:["a"="b", "c"=Array<Doc>:["one", "two", "three"]];
-        JsonObject        source  = Map<String, Doc>:["c"=Map<String, Doc>:["0"="one-updated", "3"="four"]];
+        JsonObject        target  = ["a"="b", "c"=["one", "two", "three"]];
+        JsonObject        source  = ["c"=["0"="one-updated", "3"="four"]];
         JsonObjectBuilder builder = new JsonObjectBuilder(target);
         try {
             builder.deepMerge(source);
@@ -175,14 +175,14 @@ class JsonBuilderTest {
             // expected
         }
         // target should be unchanged
-        assert target == Map<String, Doc>:["a"="b", "c"=Array<Doc>:["one", "two", "three"]];
+        assert target == Map<String, Doc>:["a"="b", "c"=["one", "two", "three"]];
     }
 
     @Test
     void shouldMergeObjectWithPrimitiveIntoObjectWithExistingPrimitive() {
-        JsonObject target = Map:["a"="b", "c"="d"];
-        JsonObject source = Map:["c"="updated"];
+        JsonObject target = ["a"="b", "c"="d"];
+        JsonObject source = ["c"="updated"];
         JsonObject result = new JsonObjectBuilder(target).deepMerge(source).build();
-        assert result == Map:["a"="b", "c"="updated"];
+        assert result == ["a"="b", "c"="updated"];
     }
 }

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchAddTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchAddTest.x
@@ -119,7 +119,7 @@ class JsonPatchAddTest {
         JsonPatch patch  = JsonPatch.builder().add("/-2", "new").build();
         Doc       result = patch.apply(array, new JsonPatch.Options(supportNegativeIndices = True));
         assert result.is(JsonArray);
-        assert result == Array<Doc>:["one", "new", "two", "three"];
+        assert result == ["one", "new", "two", "three"];
     }
 
     @Test
@@ -161,7 +161,7 @@ class JsonPatchAddTest {
         assert result.is(JsonObject);
         assert result.size == 1;
         assert result["one"].is(JsonArray);
-        assert result["one"].as(JsonArray) == Array<Doc>:["one", "added", "two", "three"];
+        assert result["one"].as(JsonArray) == ["one", "added", "two", "three"];
     }
 
     @Test
@@ -173,7 +173,7 @@ class JsonPatchAddTest {
         assert result.is(JsonObject);
         assert result.size == 1;
         assert result["one"].is(JsonArray);
-        assert result["one"].as(JsonArray) == Array<Doc>:["one", "two", "added", "three"];
+        assert result["one"].as(JsonArray) == ["one", "two", "added", "three"];
     }
 
     @Test
@@ -187,7 +187,7 @@ class JsonPatchAddTest {
                          |}
                          ;
 
-        JsonObject          value    = Map:["a"="b"];
+        JsonObject          value    = ["a"="b"];
         JsonPatch.Operation expected = new JsonPatch.Operation(Add, JsonPointer.from("/one/two"), value);
         assertOperation(jsonOp, expected);
     }

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchCopyTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchCopyTest.x
@@ -249,7 +249,7 @@ class JsonPatchCopyTest {
         JsonPatch  patch  = JsonPatch.builder().copy("/1", "/-").build();
         Doc        result = patch.apply(target);
         assert result.is(JsonArray);
-        assert result == Array<Doc>:[1, 2, 3, 4, 2];
+        assert result == [1, 2, 3, 4, 2];
     }
 
     @Test
@@ -258,6 +258,6 @@ class JsonPatchCopyTest {
         JsonPatch  patch  = JsonPatch.builder().copy("/1", "/3").build();
         Doc        result = patch.apply(target);
         assert result.is(JsonArray);
-        assert result == Array<Doc>:[1, 2, 3, 2, 4, 5];
+        assert result == [1, 2, 3, 2, 4, 5];
     }
 }

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchMoveTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchMoveTest.x
@@ -35,7 +35,9 @@ class JsonPatchMoveTest {
         JsonObject child  = json.objectBuilder().add("foo", 1234).build();
         JsonObject target = json.objectBuilder().add("one", child).add("three", 33).build();
         JsonPatch  patch  = JsonPatch.builder().move("/one", "/two").build();
-        Doc        result = Map<String, Doc>:["two"=child, "three"=33];
+        Doc        result = patch.apply(target);
+        assert result.is(JsonObject);
+        assert result == Map<String, Doc>:["two"=child, "three"=33];
     }
 
     @Test
@@ -192,7 +194,7 @@ class JsonPatchMoveTest {
         JsonPatch  patch  = JsonPatch.builder().move("/1", "/-").build();
         Doc        result = patch.apply(target);
         assert result.is(JsonArray);
-        assert result == Array<Doc>:[1, 3, 4, 2];
+        assert result == [1, 3, 4, 2];
     }
 
     @Test
@@ -201,7 +203,7 @@ class JsonPatchMoveTest {
         JsonPatch  patch  = JsonPatch.builder().move("/1", "/3").build();
         Doc        result = patch.apply(target);
         assert result.is(JsonArray);
-        assert result == Array<Doc>:[1, 3, 4, 2, 5];
+        assert result == [1, 3, 4, 2, 5];
     }
 
     @Test

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchOperationTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchOperationTest.x
@@ -11,9 +11,9 @@ class JsonPatchOperationTest {
     @Test
     void shouldBeEqualOperationsWithJsonObjectValue() {
         JsonPatch.Operation op1 = new JsonPatch.Operation(Add, JsonPointer.from("/one/two"),
-                Map:["a"="b"], JsonPointer.from("/three/four"));
+                ["a"="b"], JsonPointer.from("/three/four"));
         JsonPatch.Operation op2 = new JsonPatch.Operation(Add, JsonPointer.from("/one/two"),
-                Map:["a"="b"], JsonPointer.from("/three/four"));
+                ["a"="b"], JsonPointer.from("/three/four"));
         assert op1 == op2;
     }
 

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchRemoveTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchRemoveTest.x
@@ -108,7 +108,7 @@ class JsonPatchRemoveTest {
                          |}
                          ;
 
-        JsonObject          value    = Map:["a"="b"];
+        JsonObject          value    = ["a"="b"];
         JsonPatch.Operation expected = new JsonPatch.Operation(Remove, JsonPointer.from("/one/two"));
         assertOperation(jsonOp, expected);
     }

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchReplaceTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchReplaceTest.x
@@ -151,7 +151,7 @@ class JsonPatchReplaceTest {
                          |}
                          ;
 
-        JsonObject          value    = Map:["a"="b"];
+        JsonObject          value    = ["a"="b"];
         JsonPatch.Operation expected = new JsonPatch.Operation(Replace, JsonPointer.from("/one/two"), value);
         assertOperation(jsonOp, expected);
     }

--- a/manualTests/src/main/x/json/json_test/patch/JsonPatchTestTest.x
+++ b/manualTests/src/main/x/json/json_test/patch/JsonPatchTestTest.x
@@ -49,7 +49,7 @@ class JsonPatchTestTest {
 
     @Test
     void shouldSucceedTestingObject() {
-        Doc       target = Map<String, Doc>:["one"=1, "two"=2, "three"=3];
+        Doc       target = ["one"=1, "two"=2, "three"=3];
         JsonPatch patch = JsonPatch.builder().test("/two", 2).build();
         Doc       result = patch.apply(target);
         assert result == target;
@@ -57,15 +57,15 @@ class JsonPatchTestTest {
 
     @Test
     void shouldFailTestingObject() {
-        Doc          target = Map<String, Doc>:["one"=1, "two"=2, "three"=3];
+        Doc          target = ["one"=1, "two"=2, "three"=3];
         JsonPatch    patch = JsonPatch.builder().test("/two", 200).build();
         IllegalState error = assertThrows(() -> patch.apply(target));
     }
 
     @Test
     void shouldSucceedTestingChildObject() {
-        Doc       child  = Map<String, Doc>:["one"=1, "two"=2, "three"=3];
-        Doc       target = Map<String, Doc>:["foo"=child];
+        Doc       child  = ["one"=1, "two"=2, "three"=3];
+        Doc       target = ["foo"=child];
         JsonPatch patch = JsonPatch.builder().test("/foo/two", 2).build();
         Doc       result = patch.apply(target);
         assert result == target;
@@ -73,16 +73,16 @@ class JsonPatchTestTest {
 
     @Test
     void shouldFailTestingChildObject() {
-        Doc       child  = Map<String, Doc>:["one"=1, "two"=2, "three"=3];
-        Doc       target = Map<String, Doc>:["foo"=child];
+        Doc       child  = ["one"=1, "two"=2, "three"=3];
+        Doc       target = ["foo"=child];
         JsonPatch patch = JsonPatch.builder().test("/foo/two", 200).build();
         IllegalState error = assertThrows(() -> patch.apply(target));
     }
 
     @Test
     void shouldFailTestingMissingChildObject() {
-        Doc       child  = Map<String, Doc>:["one"=1, "two"=2, "three"=3];
-        Doc       target = Map<String, Doc>:["foo"=child];
+        Doc       child  = ["one"=1, "two"=2, "three"=3];
+        Doc       target = ["foo"=child];
         JsonPatch patch = JsonPatch.builder().test("/foo/four", 4).build();
         IllegalState error = assertThrows(() -> patch.apply(target));
     }
@@ -90,7 +90,7 @@ class JsonPatchTestTest {
     @Test
     void shouldSucceedTestingNullChildObject() {
         Doc       child  = Map<String, Doc>:["one"=1, "two"=Null, "three"=3];
-        Doc       target = Map<String, Doc>:["foo"=child];
+        Doc       target = ["foo"=child];
         JsonPatch patch = JsonPatch.builder().test("/foo/two", Null).build();
         Doc       result = patch.apply(target);
         assert result == target;
@@ -98,8 +98,8 @@ class JsonPatchTestTest {
 
     @Test
     void shouldSucceedTestingNullMissingChildObject() {
-        Doc       child  = Map<String, Doc>:["one"=1, "two"=2, "three"=3];
-        Doc       target = Map<String, Doc>:["foo"=child];
+        Doc       child  = ["one"=1, "two"=2, "three"=3];
+        Doc       target = ["foo"=child];
         JsonPatch patch = JsonPatch.builder().test("/foo/four", Null).build();
         Doc       result = patch.apply(target);
         assert result == target;
@@ -116,7 +116,7 @@ class JsonPatchTestTest {
                          |}
                          ;
 
-        JsonObject          value    = Map:["a"="b"];
+        JsonObject          value    = ["a"="b"];
         JsonPatch.Operation expected = new JsonPatch.Operation(Test, JsonPointer.from("/one/two"), value);
         assertOperation(jsonOp, expected);
     }


### PR DESCRIPTION
I think it's makes the tests look better if we don't have to explicitly specify types for homogenous JsonObject constants