### PR TITLE
[Work in progress] Optimize FiberQueue for large number of fibers

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
+++ b/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
@@ -2405,7 +2405,7 @@ public class ServiceContext
     /**
      * The queue of suspended fibers.
      */
-    private final FiberQueue f_queueSuspended = new FiberQueue(this);
+    protected final FiberQueue f_queueSuspended = new FiberQueue(this);
 
     /**
      * The reentrancy policy. Must be the same names as in natural Service.Synchronicity.


### PR DESCRIPTION
Dima wrote a stress test for HttpClient/HttpServer and it showed a huge contention at FiberQueue.isAnyNonConcurrentWaiting() method and ServiceContext.getStatus(). 

This is an attempt to improve the algorithms.