### PR TITLE
Enforce immutability of an immutable not const type

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/AbstractDependantChildTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/AbstractDependantChildTypeConstant.java
@@ -199,7 +199,7 @@ public abstract class AbstractDependantChildTypeConstant
         }
 
     @Override
-    public boolean isConstant()
+    public boolean isConst()
         {
         return getChildStructure().isConst();
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -176,6 +176,12 @@ public class DifferenceTypeConstant
         }
 
     @Override
+    public boolean isConst()
+        {
+        return m_constType1.isConst();
+        }
+
+    @Override
     public boolean isOnlyNullable()
         {
         // difference types are never nullable

--- a/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
@@ -5,7 +5,6 @@ import java.io.DataInput;
 import java.io.IOException;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -302,6 +301,12 @@ public class IntersectionTypeConstant
         }
 
     @Override
+    public boolean isConst()
+        {
+        return m_constType1.isConst() || m_constType2.isConst();
+        }
+
+    @Override
     public boolean containsGenericParam(String sName)
         {
         return m_constType1.containsGenericParam(sName)
@@ -453,10 +458,8 @@ public class IntersectionTypeConstant
                 info2.getType().getValueString(), type2.getValueString());
             }
 
-        for (Iterator<Map.Entry<Object, ParamInfo>> iter = map2.entrySet().iterator(); iter.hasNext();)
+        for (Map.Entry<Object, ParamInfo> entry : map2.entrySet())
             {
-            Map.Entry<Object, ParamInfo> entry = iter.next();
-
             Object nid = entry.getKey();
 
             ParamInfo param1 = map1.get(nid);

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -927,20 +927,6 @@ public class ParameterizedTypeConstant
         }
 
     @Override
-    public boolean isConstant()
-        {
-        for (TypeConstant type : m_atypeParams)
-            {
-            if (!type.isConstant())
-                {
-                return false;
-                }
-            }
-
-        return super.isConstant();
-        }
-
-    @Override
     public boolean isNullable()
         {
         assert !m_constType.isNullable();

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyClassTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyClassTypeConstant.java
@@ -238,7 +238,7 @@ public class PropertyClassTypeConstant
         }
 
     @Override
-    public boolean isConstant()
+    public boolean isConst()
         {
         return false;
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/RecursiveTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/RecursiveTypeConstant.java
@@ -234,7 +234,7 @@ public class RecursiveTypeConstant
         }
 
     @Override
-    public boolean isConstant()
+    public boolean isConst()
         {
         return false;
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/RelationalTypeConstant.java
@@ -208,13 +208,6 @@ public abstract class RelationalTypeConstant
         }
 
     @Override
-    public boolean isConstant()
-        {
-        return m_constType1.isConstant()
-            && m_constType2.isConstant();
-        }
-
-    @Override
     public boolean isOnlyNullable()
         {
         return m_constType1.isOnlyNullable()

--- a/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
@@ -1526,13 +1526,13 @@ public class TerminalTypeConstant
         }
 
     @Override
-    public boolean isConstant()
+    public boolean isConst()
         {
         if (!isSingleDefiningConstant())
             {
             // this can only happen if this type is a Typedef referring to a relational type
             TypedefConstant constId = (TypedefConstant) ensureResolvedConstant();
-            return constId.getReferredToType().isConstant();
+            return constId.getReferredToType().isConst();
             }
 
         Constant constant = getDefiningConstant();

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -687,12 +687,11 @@ public abstract class TypeConstant
         }
 
     /**
-     * @return true iff this TypeConstant is <b>not</b> auto-narrowing, and is not a reference to a
-     *         type parameter, and its type parameters, if any, are also each a constant type
+     * @return true iff this TypeConstant is a "const" type
      */
-    public boolean isConstant()
+    public boolean isConst()
         {
-        return getUnderlyingType().isConstant();
+        return getUnderlyingType().isConst();
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeSequenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeSequenceTypeConstant.java
@@ -137,7 +137,7 @@ public class TypeSequenceTypeConstant
         }
 
     @Override
-    public boolean isConstant()
+    public boolean isConst()
         {
         return false;
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/UnionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/UnionTypeConstant.java
@@ -109,12 +109,12 @@ public class UnionTypeConstant
             {
             setMatching = new HashSet<>();
             }
-        testExtdends(m_constType1, typeMatch, setMatching);
-        testExtdends(m_constType2, typeMatch, setMatching);
+        testExtends(m_constType1, typeMatch, setMatching);
+        testExtends(m_constType2, typeMatch, setMatching);
         return setMatching;
         }
 
-    private void testExtdends(TypeConstant type, TypeConstant typeMatch, Set<TypeConstant> setSuper)
+    private void testExtends(TypeConstant type, TypeConstant typeMatch, Set<TypeConstant> setSuper)
         {
         if (type.resolveTypedefs() instanceof UnionTypeConstant typeUnion)
             {
@@ -401,6 +401,12 @@ public class UnionTypeConstant
         {
         assert isSingleUnderlyingClass(fAllowInterface);
         return m_constType1.getSingleUnderlyingClass(fAllowInterface);
+        }
+
+    @Override
+    public boolean isConst()
+        {
+        return m_constType1.isConst() && m_constType2.isConst();
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/UnresolvedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/UnresolvedTypeConstant.java
@@ -210,9 +210,9 @@ public class UnresolvedTypeConstant
         }
 
     @Override
-    public boolean isConstant()
+    public boolean isConst()
         {
-        return isTypeResolved() && getResolvedType().isConstant();
+        return isTypeResolved() && getResolvedType().isConst();
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -436,7 +436,8 @@ public abstract class ClassTemplate
      */
     protected int postValidate(Frame frame, ObjectHandle hStruct)
         {
-        if (hStruct.getType().isImmutabilitySpecified())
+        TypeConstant type = hStruct.getType().removeAccess();
+        if (!type.isConst() && type.isImmutable())
             {
             hStruct.makeImmutable();
             }

--- a/javatools/src/main/java/org/xvm/runtime/template/xException.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xException.java
@@ -122,14 +122,14 @@ public class xException
 
     public static ExceptionHandle notFreezableProperty(Frame frame, String sProp, TypeConstant type)
         {
-        String sDesc = type.isConstant() ? "const" : "an immutable";
+        String sDesc = type.isConst() ? "const" : "an immutable";
         return makeHandle(frame, "Property \"" + sProp + "\" on " + sDesc + " \"" +
                 type.removeAccess().getValueString() + "\" is not freezable");
         }
 
     public static ExceptionHandle immutableObjectProperty(Frame frame, String sProp, TypeConstant type)
         {
-        String sDesc = type.isConstant() ? "const" : "an immutable";
+        String sDesc = type.isConst() ? "const" : "an immutable";
         return makeHandle(frame, s_clzReadOnly,
                 "Attempt to modify property \"" + sProp + "\" on " + sDesc + " \"" +
                     type.removeAccess().getValueString() + '"');

--- a/lib_ecstasy/src/main/x/ecstasy/io/TextPosition.x
+++ b/lib_ecstasy/src/main/x/ecstasy/io/TextPosition.x
@@ -4,7 +4,7 @@
  * producing and consuming position data to efficiently do so.
  */
 interface TextPosition
-        extends immutable Orderable
+        extends Orderable
         extends Hashable {
     /**
      * The character offset within the reader, starting with zero.

--- a/lib_json/src/main/x/json/Lexer.x
+++ b/lib_json/src/main/x/json/Lexer.x
@@ -216,9 +216,7 @@ class Lexer
     // ----- Markable ------------------------------------------------------------------------------
 
     @Override
-    immutable Object mark() {
-        return reader.position;
-    }
+    immutable Object mark() = reader.position.as(immutable);
 
     @Override
     void restore(immutable Object mark, Boolean unmark = False) {

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -1,19 +1,25 @@
 module TestSimple {
     @Inject Console console;
 
-    import ecstasy.SharedContext;
-
     void run() {
-        using(sharedStringOne.withValue("stringOne")) {
-            using(new Timeout(Duration:0.01S)) { // small timeout used to cause RT error
-                using(sharedStringTwo.withValue("stringTwo")) {
-                    console.print(sharedStringOne.hasValue().as(Tuple));
-                    console.print(sharedStringTwo.hasValue().as(Tuple));
-                }
-            }
-        }
+        StringWriter w = new StringWriter(17);
+        w.offset = 5; // this must blow at runtime (used to be allowed)
     }
 
-    static SharedContext<String> sharedStringOne = new SharedContext("sharedStringOne");
-    static SharedContext<String> sharedStringTwo = new SharedContext("sharedStringTwo");
+    interface TextPosition
+            extends immutable Hashable {
+        @RO Int offset;
+    }
+
+    class StringWriter(Int offset)
+            implements TextPosition {
+
+        @Override
+        String toString() = $"Writer at {offset=}";
+
+        static <CompileType extends StringWriter> Int64 hashCode(CompileType value) {
+            return value.offset.toInt64();
+        }
+
+    }
 }


### PR DESCRIPTION
It's possible for a class or interface to be declared as immutable, for example:

    interface TextPosition
            extends immutable Hashable {
    }

If a class implements such an interface, the runtime must enforce a newly constructed object immutability before it becomes "visible".
