### PR TITLE
Ref and Tuple updates

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ClassStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ClassStructure.java
@@ -998,6 +998,13 @@ public class ClassStructure
                     return true;
                     }
                 }
+            else if (getFormat() == Format.INTERFACE)
+                {
+                if (contrib.getComposition() == Composition.Extends && contrib.getTypeConstant().isTuple())
+                    {
+                    return true;
+                    }
+                }
             }
         return false;
         }

--- a/javatools/src/main/java/org/xvm/compiler/Token.java
+++ b/javatools/src/main/java/org/xvm/compiler/Token.java
@@ -165,7 +165,19 @@ public class Token
         }
 
     /**
-     * If the token is an identifier that is also a context sensitive keyword, obtain that keyword.
+     * Determine the alternative identity of the token, if any, assuming that the token were to be
+     * used in a context-sensitive manner.
+     *
+     * @return the context-sensitive identity of the token, if the token is an "identifier" whose
+     *         name also is a context-sensitive keyword
+     */
+    public Id getContextSensitiveId()
+        {
+        return m_id == Id.IDENTIFIER ? Id.valueByContextSensitiveText(m_oValue.toString()) : null;
+        }
+
+    /**
+     * If the token is an identifier that is also a context-sensitive keyword, obtain that keyword.
      *
      * @return a keyword token that represents the same text as this identifier token
      */
@@ -564,9 +576,9 @@ public class Token
         BREAK        ("break"          ),
         CASE         ("case"           ),
         CATCH        ("catch"          ),
-        CLASS        ("class"          ),
+        CLASS        ("class"          , true),
         CONDITIONAL  ("conditional"    ),
-        CONST        ("const"          ),
+        CONST        ("const"          , true),
         CONSTRUCT    ("construct"      ),
         CONTINUE     ("continue"       ),
         DEFAULT      ("default"        ),
@@ -575,7 +587,7 @@ public class Token
         DO           ("do"             ),
         ELSE         ("else"           ),
         EMBEDDED     ("embedded"       , true),
-        ENUM         ("enum"           ),
+        ENUM         ("enum"           , true),
         EXTENDS      ("extends"        , true),
         FINALLY      ("finally"        ),
         FOR          ("for"            ),
@@ -586,24 +598,24 @@ public class Token
         IMPORT       ("import"         ),
         INCORPORATES ("incorporates"   , true),
         INJECT       ("inject"         , true),
-        INTERFACE    ("interface"      ),
+        INTERFACE    ("interface"      , true),
         INTO         ("into"           , true),
         IS           ("is"             ),
-        MIXIN        ("mixin"          ),
-        MODULE       ("module"         ),
+        MIXIN        ("mixin"          , true),
+        MODULE       ("module"         , true),
         NEW          ("new"            ),
         OPTIONAL     ("optional"       , true),
         OUTER        ("outer"          , true, true),
-        PACKAGE      ("package"        ),
+        PACKAGE      ("package"        , true),
         PREFER       ("prefer"         , true),
         PRIVATE      ("private"        ),
         PROTECTED    ("protected"      ),
         PUBLIC       ("public"         ),
         REQUIRED     ("required"       , true),
         RETURN       ("return"         ),
-        SERVICE      ("service"        ),
+        SERVICE      ("service"        , true),
         STATIC       ("static"         ),
-        STRUCT       ("struct"         ),
+        STRUCT       ("struct"         , true),
         SUPER        ("super"          , true, true),
         SWITCH       ("switch"         ),
         THIS         ("this"           , true, true),

--- a/javatools/src/main/java/org/xvm/compiler/ast/ParenthesizedExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ParenthesizedExpression.java
@@ -3,6 +3,14 @@ package org.xvm.compiler.ast;
 
 import java.lang.reflect.Field;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.xvm.asm.ErrorListener;
+
+import org.xvm.asm.constants.TypeConstant;
+import org.xvm.asm.constants.UnionTypeConstant;
+
 
 /**
  * Used for parenthesized expressions.
@@ -18,6 +26,138 @@ public class ParenthesizedExpression
 
         m_lStartPos = lStartPos;
         m_lEndPos   = lEndPos;
+        }
+
+
+    // ----- Expression compilation ----------------------------------------------------------------
+
+    @Override
+    public TypeFit testFit(Context ctx, TypeConstant typeRequired, boolean fExhaustive,
+                           ErrorListener errs)
+        {
+        TypeFit fitTuple = testTupleFit(ctx, typeRequired, fExhaustive, null);
+        TypeFit fitValue = super.testFit(ctx, typeRequired, fExhaustive, null);
+        return fitValue.betterOf(fitTuple);
+        }
+
+    /**
+     * Given a required type, determine the fit of this expression if it were a tuple literal.
+     *
+     * @param typeRequired the required type, or null
+     *
+     * @return the fit of this expression assuming it were a tuple literal
+     */
+    private TypeFit testTupleFit(Context ctx, TypeConstant typeRequired, boolean fExhaustive,
+                                 ErrorListener errs)
+        {
+        TypeConstant typeTuple = mightBeTuple(typeRequired);
+        if (typeTuple != null)
+            {
+            // if the use of this expression needs a Tuple, then the parentheses can be assumed to
+            // define a Tuple literal of a single element
+            List<TypeConstant> listElements = typeTuple.getTupleParamTypes();
+            if (listElements == null || listElements.isEmpty())
+                {
+                // the required type is `Tuple` or `Tuple<>`, which any Tuple will satisfy
+                return TypeFit.Fit;
+                }
+            else if (listElements.size() == 1)
+                {
+                // the parenthesized expression `expr` would be the single element of the tuple
+                TypeConstant typeElement = listElements.getFirst();
+                return expr.testFit(ctx, typeElement, fExhaustive, errs);
+                }
+            }
+        return TypeFit.NoFit;
+        }
+
+    /**
+     * Given a required type, determine if a tuple could fit the required type.
+     *
+     * @param typeRequired the required type, or null
+     *
+     * @return the tuple type, or null
+     */
+    private static TypeConstant mightBeTuple(TypeConstant typeRequired)
+        {
+        if (typeRequired == null)
+            {
+            return null;
+            }
+
+        // this logic mirrors the logic in TupleExpression
+        TypeConstant typeTuple = null;
+        if (typeRequired.isTuple())
+            {
+            typeTuple = typeRequired;
+            }
+        else if (typeRequired instanceof UnionTypeConstant typeUnion)
+            {
+            typeTuple = typeUnion.extractTuple();
+            }
+
+        if (typeTuple != null)
+            {
+            List<TypeConstant> elementTypes = typeTuple.getTupleParamTypes();
+            if (elementTypes == null || elementTypes.size() <= 1)
+                {
+                return typeTuple;
+                }
+            }
+        return null;
+        }
+
+    @Override
+    public TypeFit testFitMulti(Context ctx, TypeConstant[] atypeRequired, boolean fExhaustive,
+                                ErrorListener errs)
+        {
+        return atypeRequired.length == 1
+                ? testFit(ctx, atypeRequired[0], fExhaustive, errs)
+                : super.testFitMulti(ctx, atypeRequired, fExhaustive, errs);
+        }
+
+    protected Expression validate(Context ctx, TypeConstant typeRequired, ErrorListener errs)
+        {
+        if (typeRequired != null)
+            {
+            TypeFit fitTuple = testTupleFit(ctx, typeRequired, true, null);
+            TypeFit fitValue = super.testFit(ctx, typeRequired, true, null);
+            if (fitTuple.betterThan(fitValue))
+                {
+                // this expression is actually a tuple literal, which means the delegated expression
+                // is the first and only element of the tuple
+                TypeConstant typeTuple = mightBeTuple(typeRequired);
+                assert typeTuple != null;
+                List<TypeConstant> listElements = typeTuple.getTupleParamTypes();
+                TypeConstant typeElementRequired = null;
+                if (listElements != null && !listElements.isEmpty())
+                    {
+                    assert listElements.size() == 1;
+                    typeElementRequired = listElements.getFirst();
+                    }
+
+                // replace this parenthesized expression with an actual tuple expression containing
+                // the one element `(expr)`
+                TupleExpression exprTuple = new TupleExpression(null, new ArrayList<>(List.of(expr)),
+                        getStartPosition(), getEndPosition());
+                exprTuple.adopt(expr);
+                replaceThisWith(exprTuple);
+                return exprTuple.validate(ctx, typeRequired, errs);
+                }
+            }
+
+        return super.validate(ctx, typeRequired, errs);
+        }
+
+    protected Expression validateMulti(Context ctx, TypeConstant[] atypeRequired, ErrorListener errs)
+        {
+        if (atypeRequired != null && atypeRequired.length == 1)
+            {
+            // handle the possible tuple
+            return validate(ctx, atypeRequired[0], errs);
+            }
+
+        return super.validateMulti(ctx, atypeRequired, errs);
         }
 
 

--- a/javatools_bridge/src/main/x/_native/ConstHelper.x
+++ b/javatools_bridge/src/main/x/_native/ConstHelper.x
@@ -56,7 +56,7 @@ class ConstHelper {
             return o.toString();
         } catch (Exception e) {
             String msg = e.message;
-            return $"? ({&e.actualClass.name}{msg.size == 0 ? "" : $": {msg}"})";
+            return $"? ({&e.class.name}{msg.size == 0 ? "" : $": {msg}"})";
         }
     }
 

--- a/javatools_bridge/src/main/x/_native/fs/OSFileNode.x
+++ b/javatools_bridge/src/main/x/_native/fs/OSFileNode.x
@@ -68,10 +68,12 @@ const OSFileNode
 
     // ----- equality support ----------------------------------------------------------------------
 
+    @Override
     static <CompileType extends OSFileNode> Int64 hashCode(CompileType value) {
         return String.hashCode(value.pathString);
     }
 
+    @Override
     static <CompileType extends OSFileNode> Boolean equals(CompileType node1, CompileType node2) {
         return node1.pathString == node2.pathString &&
                node1.is(OSFile) == node2.is(OSFile);

--- a/javatools_bridge/src/main/x/_native/mgmt/ContainerControl.x
+++ b/javatools_bridge/src/main/x/_native/mgmt/ContainerControl.x
@@ -4,21 +4,19 @@ class ContainerControl
         extends RTServiceControl
         implements Container.Control {
     // Container.Control
-
-    @Override @RO Container.Status status                                   .get() {TODO("Native");}
-    @Override Container.Control.Goal targetOptimization                     .get() {TODO("Native");}
-    @Override Dec schedulingPriority                                        .get() {TODO("Native");}
-    @Override void limitThreads(Int max)                                           {TODO("Native");}
-    @Override void limitCompute(Duration max, function void() maxCpuExceeded)      {TODO("Native");}
-    @Override void limitMemory(Int max, function void() maxRamExceeded)            {TODO("Native");}
-    @Override Tuple invoke(String methodName, Tuple args=Tuple:(),
-                           Service? runWithin=Null)                                {TODO("Native");}
-    @Override @RO TypeSystem innerTypeSystem                                .get() {TODO("Native");}
-    @Override @RO Service? mainService                                      .get() {TODO("Native");}
-    @Override @RO Container[] nestedContainers                              .get() {TODO("Native");}
-    @Override @RO Service[] nestedServices                                  .get() {TODO("Native");}
-    @Override void pause()                                                         {TODO("Native");}
-    @Override void resume()                                                        {TODO("Native");}
-    @Override void store(FileStore filestore)                                      {TODO("Native");}
-    @Override void load(FileStore filestore)                                       {TODO("Native");}
+    @Override @RO Container.Status status                                      .get() {TODO("Native");}
+    @Override Container.Control.Goal targetOptimization                        .get() {TODO("Native");}
+    @Override Dec schedulingPriority                                           .get() {TODO("Native");}
+    @Override void limitThreads(Int max)                                              {TODO("Native");}
+    @Override void limitCompute(Duration max, function void() maxCpuExceeded)         {TODO("Native");}
+    @Override void limitMemory(Int max, function void() maxRamExceeded)               {TODO("Native");}
+    @Override Tuple invoke(String methodName, Tuple args=(), Service? runWithin=Null) {TODO("Native");}
+    @Override @RO TypeSystem innerTypeSystem                                   .get() {TODO("Native");}
+    @Override @RO Service? mainService                                         .get() {TODO("Native");}
+    @Override @RO Container[] nestedContainers                                 .get() {TODO("Native");}
+    @Override @RO Service[] nestedServices                                     .get() {TODO("Native");}
+    @Override void pause()                                                            {TODO("Native");}
+    @Override void resume()                                                           {TODO("Native");}
+    @Override void store(FileStore filestore)                                         {TODO("Native");}
+    @Override void load(FileStore filestore)                                          {TODO("Native");}
 }

--- a/lib_cli/src/main/x/cli/Runner.x
+++ b/lib_cli/src/main/x/cli/Runner.x
@@ -45,7 +45,7 @@ static service Runner {
 
         if (args.size == 0) {
             if (description.empty) {
-                description = &app.actualClass.name;
+                description = &app.class.name;
             }
 
             if (!suppressWelcome) {
@@ -281,7 +281,7 @@ static service Runner {
                 Int         allCount = params.size;
                 Int         argCount = parts-1;
                 if (argCount <= allCount) {
-                    Tuple args = Tuple:();
+                    Tuple args = ();
 
                     // collect the specified values
                     for (Int i : 1 ..< parts) {
@@ -333,7 +333,7 @@ static service Runner {
                     console.print($"  Number of arguments should be between {reqCount} and {allCount}");
                 }
             } catch (Exception e) {
-                console.print($"  Error: {e.message.empty ? &e.actualType : e.message}");
+                console.print($"  Error: {e.message.empty ? &e.type : e.message}");
             }
         } else {
             console.print($"  Unknown command: {head.quoted()}");

--- a/lib_cli/src/main/x/cli/Scanner.x
+++ b/lib_cli/src/main/x/cli/Scanner.x
@@ -5,10 +5,10 @@ class Scanner {
     static Map<String, CmdInfo> buildCatalog(TerminalApp app, Object[] extras = []) {
         Map<String, CmdInfo> cmdInfos = new ListMap();
 
-        scanCommands(() -> app, &app.actualClass, cmdInfos);
+        scanCommands(() -> app, &app.class, cmdInfos);
         if (!extras.empty) {
             extras.forEach(extra ->
-                scanCommands(() -> extra, &extra.actualClass, cmdInfos));
+                scanCommands(() -> extra, &extra.class, cmdInfos));
         }
         scanClasses(app.classes, cmdInfos);
         return cmdInfos;

--- a/lib_ecstasy/src/main/x/ecstasy/Comparable.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Comparable.x
@@ -27,13 +27,13 @@ interface Comparable {
         }
 
         // if they're both of the same runtime type, then use that type
-        Type shared = thisRef.actualType;
-        if (shared == thatRef.actualType) {
+        Type shared = thisRef.type;
+        if (shared == thatRef.type) {
             return this.as(shared.DataType) == that.as(shared.DataType);
         }
 
         // otherwise, verify that they are of the same actual class, and use that class' public type
-        shared = thisRef.actualClass.PublicType;
+        shared = thisRef.class.PublicType;
         return this.is(shared.DataType)? == that.is(shared.DataType)? : False;
     }
 }

--- a/lib_ecstasy/src/main/x/ecstasy/Const.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Const.x
@@ -15,11 +15,13 @@ interface Const
      * Note: if the `equals` function returns "True" for two distinct objects, this function must
      *       yield the same hash value for both objects.
      */
+    @Override
     static <CompileType extends Const> Int64 hashCode(CompileType value);
 
     /**
      * The default implementation of comparison-for-equality for Const implementations is to
      * compare each of the fields for equality.
      */
+    @Override
     static <CompileType extends Const> Boolean equals(CompileType value1, CompileType value2);
 }

--- a/lib_ecstasy/src/main/x/ecstasy/Enum.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Enum.x
@@ -49,6 +49,7 @@ interface Enum
     /**
      * Calculate a hash code for the specified Enum value.
      */
+    @Override
     static <CompileType extends Enum> Int64 hashCode(CompileType value) {
         return value.enumeration.hashCode() + value.ordinal.toInt64();
     }
@@ -56,6 +57,7 @@ interface Enum
     /**
      * Compare two enumerated values that belong to the same enumeration purposes of ordering.
      */
+    @Override
     static <CompileType extends Enum> Ordered compare(CompileType value1, CompileType value2) {
         return value1.ordinal <=> value2.ordinal;
     }
@@ -63,6 +65,7 @@ interface Enum
     /**
      * Compare two enumerated values that belong to the same enumeration for equality.
      */
+    @Override
     static <CompileType extends Enum> Boolean equals(CompileType value1, CompileType value2) {
         return value1.ordinal == value2.ordinal;
     }

--- a/lib_ecstasy/src/main/x/ecstasy/Exception.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Exception.x
@@ -23,7 +23,7 @@ const Exception {
 
     @Override
     String toString() {
-        String name       = &this.actualClass.name;
+        String name       = &this.class.name;
         String stackTrace = formatStackTrace();
         return formatExceptionString(name, stackTrace);
     }

--- a/lib_ecstasy/src/main/x/ecstasy/Freezable.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Freezable.x
@@ -43,11 +43,11 @@ interface Freezable {
      * @param inPlace  (optional) specify that the object should make itself immutable if it can,
      *                 instead of creating a new immutable copy of itself
      *
-     * @return True iff the object is Freezable and must be frozen, False iff the object reference
-     *         is already frozen (or a service)
+     * @return `True` iff the object is [Freezable] and must be frozen; `False` iff the object
+     *         reference is already immutable or a service
      *
-     * @throws NotShareable if the object is not already immutable (i.e. it has not yet been frozen),
-     *         is not a `service`, and is not `Freezable`
+     * @throws NotShareable  if the object is not already immutable (i.e. it has not yet been
+     *         frozen), is not a `service`, and is not `Freezable`
      */
     static <AnyType> AnyType+Shareable frozen(AnyType object, Boolean inPlace=False) {
         if (val notYetFrozen := requiresFreeze(object)) {

--- a/lib_ecstasy/src/main/x/ecstasy/Object.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Object.x
@@ -1,14 +1,16 @@
 /**
- * This class represents the capabilities that are common to every Ecstasy object. This class is the
- * single inheritance root for the Ecstasy type system; in other words, "everything is an object",
- * and every object is "of a class" that extends this Object class.
+ * This interface represents the capabilities that are common to every Ecstasy object. In Ecstasy,
+ * "everything is an object", and every class is an implementation of this [Object] interface.
  *
- * An object is reachable through a reference, and an object reference **always** includes the
- * public portion of Object.
+ * An object can only be accessed and manipulated via a reference to that object, and every object reference will
+ * contain _at least_ the methods of the [Object] interface. In other words, every reference will
+ * have at least the methods [toString], [equals](Comparable.equals(Comparable)), and
+ * [makeImmutable], as well as the [equals](Comparable.equals(CompileType, CompileType)) function
+ * from the [Comparable] functional interface.
  *
  * Additional meta-information about the object is available through:
  * * The reference to the object, represented by the [Ref] interface;
- * * The [Type] of the object reference, which is provided by [Ref.Referent] and [Ref.actualType];
+ * * The [Type] of the object reference, which is provided by [Ref.Referent] and [Ref.type];
  *   and
  * * The [Class] of the object, which is accessible via the Type, unless the type has been
  *   masked by [Ref.maskAs<AsType>()].
@@ -16,9 +18,12 @@
 interface Object
         extends Comparable {
     /**
-     * By default, comparing any two objects will only result in equality if they are the
-     * same object, or if they are two constant objects with identical values.
+     * [Object] equality is _reference equality_: Two [Object]s are equal iff the reference to each
+     * [Object] is equal. Generally, this will mean that comparing any two [Object]s will result
+     * in equality only if they are the same [Object] instance, but more correctly two [Object]s are
+     * equal iff the two [Object]s share the same [reference Identity](Ref.Identity).
      */
+    // TODO GG: @Override
     static <CompileType extends Object> Boolean equals(CompileType o1, CompileType o2) {
         return &o1 == &o2;
     }
@@ -41,6 +46,9 @@ interface Object
 
     /**
      * Make this object immutable.
+     *
+     * @throws Unsupported  if an attempt is made to invoke this method on an object that exists in
+     *                      a different service
      */
     immutable Object makeImmutable() {
         this:struct.freeze();

--- a/lib_ecstasy/src/main/x/ecstasy/Range.x
+++ b/lib_ecstasy/src/main/x/ecstasy/Range.x
@@ -320,8 +320,8 @@ const Range<Element extends Orderable>
         return firstExclusive.toInt64() + 2 + lastExclusive.toInt64()
             + (Element.is(Type<Stringable>)
                 ? first.estimateStringLength() + last.estimateStringLength()
-                : (first.is(Stringable) ? first.estimateStringLength() : 8)
-                    + (last.is(Stringable) ? last.estimateStringLength() : 8));
+                : (first.is(Stringable)?.estimateStringLength() : 8)
+                    + (last.is(Stringable)?.estimateStringLength() : 8));
     }
 
     @Override

--- a/lib_ecstasy/src/main/x/ecstasy/annotations/ConditionalTuple.x
+++ b/lib_ecstasy/src/main/x/ecstasy/annotations/ConditionalTuple.x
@@ -1,9 +1,17 @@
 /**
- * The ConditionalTuple annotation represents a tuple whose first field is a Boolean, and access to
- * any further fields, and any modification, is only permitted if the first field Boolean is True.
+ * The [ConditionalTuple] annotation represents a [Tuple] whose first element is a [Boolean], and
+ * access to any further elements and the ability to perform any modifications is subject to the
+ * first element being the [Boolean] value `True`.
  */
 annotation ConditionalTuple
         into Tuple<Boolean> {
+    /**
+     * The number of elements in the [ConditionalTuple], which is always `1` when the first element
+     * contains a [Boolean] `False` value.
+     */
+    @Override
+    @RO Int size.get() = this[0] ? super() : 1;
+
     @Override
     @Op("[]") Object getElement(Int index) {
         assert index == 0 || super(0) == True;

--- a/lib_ecstasy/src/main/x/ecstasy/collections/Array.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/Array.x
@@ -317,7 +317,7 @@ class Array<Element>
 
         if (delegate.mutability == Constant) {
             // the underlying delegate is already frozen
-            assert &delegate.isImmutable;
+            assert delegate.is(immutable);
             mutability = Constant;
             return this.makeImmutable();
         }
@@ -938,6 +938,7 @@ class Array<Element>
      * @return True iff the arrays have the same size, and for each index _i_, the element at that
      *         index from each array is equal
      */
+    @Override
     static <CompileType extends Array> Boolean equals(CompileType value1, CompileType value2) {
         Int size = value1.size;
         if (value2.size != size) {
@@ -1139,9 +1140,7 @@ class Array<Element>
     private static mixin HashableArray<Element extends Hashable>
             into Array<Element>
             implements Hashable {
-        /**
-         * Calculate a hash code for a given array.
-         */
+        @Override
         static <CompileType extends HashableArray> Int64 hashCode(CompileType array) {
             Int64 hash = 0;
             for (CompileType.Element el : array) {

--- a/lib_ecstasy/src/main/x/ecstasy/collections/Collection.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/Collection.x
@@ -1162,6 +1162,7 @@ interface Collection<Element>
     /**
      * Two collections are equal iff they are they contain the same values.
      */
+    @Override
     static <CompileType extends Collection>
             Boolean equals(CompileType collection1, CompileType collection2) {
         // they must be of the same arity

--- a/lib_ecstasy/src/main/x/ecstasy/collections/List.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/List.x
@@ -1288,6 +1288,7 @@ interface List<Element>
      * Two lists are equal iff they are of the same size, and they contain the same values, in the
      * same order.
      */
+    @Override
     static <CompileType extends List> Boolean equals(CompileType list1, CompileType list2) {
         if (Int size1 := list1.knownSize(),
             Int size2 := list2.knownSize()) {

--- a/lib_ecstasy/src/main/x/ecstasy/collections/OrderedSet.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/OrderedSet.x
@@ -93,6 +93,7 @@ interface OrderedSet<Element extends Orderable>
      *
      * @return True iff the sets are equal, according to the definition of an ordered set
      */
+    @Override
     static <CompileType extends OrderedSet> Boolean equals(CompileType set1, CompileType set2) {
         // some simple optimizations: two empty sets are equal, and two sets of different sizes are
         // not equal

--- a/lib_ecstasy/src/main/x/ecstasy/collections/OrderedSetSlice.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/OrderedSetSlice.x
@@ -64,7 +64,7 @@ class OrderedSetSlice<Element extends Orderable>
                 ? (set.prev, set.next)
                 : (set.next, set.prev);
     } finally {
-        if (&set.isImmutable || &set.isService) {
+        if (set.is(immutable) || set.is(service)) {
             makeImmutable();
         }
     }

--- a/lib_ecstasy/src/main/x/ecstasy/collections/VirtualHasher.x
+++ b/lib_ecstasy/src/main/x/ecstasy/collections/VirtualHasher.x
@@ -10,7 +10,7 @@ const VirtualHasher<Value extends Hashable>
         implements Hasher<Value> {
     @Override
     Int64 hashOf(Value value) {
-        Type actualType = &value.actualType;
+        Type actualType = &value.type;
 
         return virtualHash(value.as(actualType.DataType));
 

--- a/lib_ecstasy/src/main/x/ecstasy/fs/FileNode.x
+++ b/lib_ecstasy/src/main/x/ecstasy/fs/FileNode.x
@@ -169,6 +169,7 @@ interface FileNode
      * Two file nodes are equal iff they belong to the same store, have the same path and both are
      * files or both are directories.
      */
+    @Override
     static <CompileType extends FileNode> Boolean equals(CompileType node1, CompileType node2) {
         return node1.&store == node2.&store && node1.path == node2.path &&
                node1.is(File) == node2.is(File);

--- a/lib_ecstasy/src/main/x/ecstasy/io/ConsoleLog.x
+++ b/lib_ecstasy/src/main/x/ecstasy/io/ConsoleLog.x
@@ -1,16 +1,17 @@
 import text.Log;
 
 /**
- * A Log implementation that delegates to a Console.
+ * A [Log] implementation that delegates to a [Console].
  *
- * @param console  the Console to log to
+ * @param console  the [Console] to log to
  */
 class ConsoleLog(Console console)
         implements Log {
     construct(Console console) {
         this.console = console;
     } finally {
-        if (&console.isService || &console.isImmutable) {
+        if (console.is(Shareable)) {
+            console = Freezable.frozen(console, inPlace=True);
             makeImmutable();
         }
     }

--- a/lib_ecstasy/src/main/x/ecstasy/lang/src/ast/NamedTypeExpression.x
+++ b/lib_ecstasy/src/main/x/ecstasy/lang/src/ast/NamedTypeExpression.x
@@ -51,7 +51,7 @@ const NamedTypeExpression(Token[]?          moduleNames,
         }
 
         // process names
-        Type type = &mod.actualType;
+        Type type = &mod.type;
         Loop: for (Token name : names) {
             if (type := type.childTypes.get(name.valueText)) {
                 // a type exists by that name

--- a/lib_ecstasy/src/main/x/ecstasy/lang/src/ast/TypeExpression.x
+++ b/lib_ecstasy/src/main/x/ecstasy/lang/src/ast/TypeExpression.x
@@ -15,7 +15,7 @@
      * @throws InvalidType  if a type exception occurs and `hideExceptions` is not specified
      */
     conditional Type resolveType(TypeSystem typeSystem, Boolean hideExceptions = False) {
-        Class clz = &this.actualClass;
+        Class clz = &this.class;
         TODO($"clz={clz}");
     }
 }

--- a/lib_ecstasy/src/main/x/ecstasy/maps/Map.x
+++ b/lib_ecstasy/src/main/x/ecstasy/maps/Map.x
@@ -875,6 +875,7 @@ interface Map<Key, Value>
          * Two `Entry` objects are equal iff they contain equal keys, and equal values (or neither
          * exists).
          */
+        @Override
         static <CompileType extends Entry> Boolean equals(CompileType entry1, CompileType entry2) {
             return entry1.key == entry2.key &&
                     entry1.exists ? entry2.exists && entry1.value == entry2.value : !entry2.exists;

--- a/lib_ecstasy/src/main/x/ecstasy/maps/OrderedMap.x
+++ b/lib_ecstasy/src/main/x/ecstasy/maps/OrderedMap.x
@@ -86,6 +86,7 @@ interface OrderedMap<Key extends Orderable, Value>
      * the value associated with each key in the first `OrderedMap` is equal to the value associated
      * with the same key in the second `OrderedMap`.
      */
+    @Override
     static <CompileType extends OrderedMap> Boolean equals(CompileType map1, CompileType map2) {
         // some simple optimizations: two empty maps are equal, and two maps of different sizes are
         // not equal

--- a/lib_ecstasy/src/main/x/ecstasy/maps/OrderedMapSlice.x
+++ b/lib_ecstasy/src/main/x/ecstasy/maps/OrderedMapSlice.x
@@ -64,7 +64,7 @@ class OrderedMapSlice<Key extends Orderable, Value>
                 ? (orig.prev, orig.next)
                 : (orig.next, orig.prev);
     } finally {
-        if (&orig.isImmutable || &orig.isService) {
+        if (orig.is(immutable) || orig.is(service)) {
             makeImmutable();
         }
     }

--- a/lib_ecstasy/src/main/x/ecstasy/maps/SkiplistMap.x
+++ b/lib_ecstasy/src/main/x/ecstasy/maps/SkiplistMap.x
@@ -1806,7 +1806,7 @@ class SkiplistMap<Key extends Orderable, Value>
 
         @Override
         void dump(Log log, String desc) {
-            log.add($"{desc}={&this.actualClass.name}<{Element}> valueOffset={valueOffset}, height={height}");
+            log.add($"{desc}={&this.class.name}<{Element}> valueOffset={valueOffset}, height={height}");
         }
 
         // ----- internal ---------------------------------------------------------------------
@@ -1942,7 +1942,7 @@ class SkiplistMap<Key extends Orderable, Value>
 
         @Override
         void dump(Log log, String desc) {
-            log.add($"{desc}={&this.actualClass.name}<{Element}>, actualStore:");
+            log.add($"{desc}={&this.class.name}<{Element}>, actualStore:");
             actualStore.dump(log, desc);
         }
 
@@ -2037,7 +2037,7 @@ class SkiplistMap<Key extends Orderable, Value>
 
         @Override
         void dump(Log log, String desc) {
-            log.add($"{desc}={&this.actualClass.name}<{Element}>, enumeration={enumeration}, actualStore:");
+            log.add($"{desc}={&this.class.name}<{Element}>, enumeration={enumeration}, actualStore:");
             actualStore.dump(log, desc);
         }
 

--- a/lib_ecstasy/src/main/x/ecstasy/maps/deferred/DeferredMap.x
+++ b/lib_ecstasy/src/main/x/ecstasy/maps/deferred/DeferredMap.x
@@ -336,7 +336,7 @@
             if (original.is(Replicable)) {
                 // it's Replicable but with a different Value type, so rewrite the type with the
                 // correct Value type
-                val origType = &original.actualType;
+                val origType = &original.type;
                 Type[] typeParams;
                 if (typeParams := origType.parameterized()) {
                     typeParams = typeParams.replace(1, Value);

--- a/lib_ecstasy/src/main/x/ecstasy/mgmt/BasicResourceProvider.x
+++ b/lib_ecstasy/src/main/x/ecstasy/mgmt/BasicResourceProvider.x
@@ -12,7 +12,7 @@
  *       ResourceProvider injector = new BasicResourceProvider();
  *
  *       Container container = new Container(template, Lightweight, repository, injector);
- *       container.invoke("run", Tuple:());
+ *       container.invoke("run", ());
  *   }
  */
 service BasicResourceProvider

--- a/lib_ecstasy/src/main/x/ecstasy/mgmt/Container.x
+++ b/lib_ecstasy/src/main/x/ecstasy/mgmt/Container.x
@@ -428,7 +428,7 @@ service Container
          * @throws IllegalState  if the container is in the `Dead` state, or if `runWithin` is
          *                       specified but not a service within this container
          */
-        Tuple invoke(String methodName, Tuple args = Tuple:(), Service? runWithin = Null);
+        Tuple invoke(String methodName, Tuple args = (), Service? runWithin = Null);
 
         /**
          * Get the `TypeSystem` for services running inside this container.

--- a/lib_ecstasy/src/main/x/ecstasy/numbers/Nibble.x
+++ b/lib_ecstasy/src/main/x/ecstasy/numbers/Nibble.x
@@ -327,6 +327,7 @@ const Nibble(Bit[] bits)
     /**
      * Calculate a hash code for the specified Enum value.
      */
+    @Override
     static <CompileType extends Nibble> Int64 hashCode(CompileType value) {
         return value.toInt64();
     }
@@ -334,6 +335,7 @@ const Nibble(Bit[] bits)
     /**
      * Compare two enumerated values that belong to the same enumeration purposes of ordering.
      */
+    @Override
     static <CompileType extends Nibble> Ordered compare(CompileType value1, CompileType value2) {
         return value1.toUInt8() <=> value2.toUInt8();
     }
@@ -341,6 +343,7 @@ const Nibble(Bit[] bits)
     /**
      * Compare two enumerated values that belong to the same enumeration for equality.
      */
+    @Override
     static <CompileType extends Nibble> Boolean equals(CompileType value1, CompileType value2) {
         return value1.toUInt8() == value2.toUInt8();
     }

--- a/lib_ecstasy/src/main/x/ecstasy/numbers/Number.x
+++ b/lib_ecstasy/src/main/x/ecstasy/numbers/Number.x
@@ -552,8 +552,8 @@
 
     @Override
     static <CompileType extends Number> Ordered compare(CompileType value1, CompileType value2) {
-        Type<Number> type1 = &value1.actualType;
-        Type<Number> type2 = &value2.actualType;
+        Type<Number> type1 = &value1.type;
+        Type<Number> type2 = &value2.type;
         if (type1 == type2) {
             return value1.as(type1.DataType) <=> value2.as(type1.DataType);
         }

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/Class.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/Class.x
@@ -14,8 +14,8 @@ import reflect.ClassTemplate.Composition;
  *   Class.
  * * From inside an object, the Class of the object is `this:class`. From outside of the object, the
  *   class may be obtained from the object's type iff the type is _classy_; for example, one can
- *   obtain the Class for an object `o`: `Class c = &o.actualClass;`. However, an object that is
- *   injected into a container may hide the _classy_ `actualType` and only expose an interface type,
+ *   obtain the Class for an object `o`: `Class c = &o.class;`. However, an object that is
+ *   injected into a container may hide the _classy_ `type` and only expose an interface type,
  *   which results in the class of the injected object being hidden from the code running inside the
  *   container.
  * * Since _everything is an object_, it follows that everything -- all objects -- were created,
@@ -349,7 +349,7 @@ const Class<PublicType, ProtectedType extends PublicType,
         Allocator? alloc = allocateStruct;
         assert baseTemplate.singleton && alloc != Null;
         PublicType instance = instantiate(alloc(Null));
-        assert &instance.isConst || &instance.isService;
+        assert instance.is(const) || instance.is(service);
         return instance;
     }
 

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/Module.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/Module.x
@@ -15,7 +15,7 @@ interface Module
      * The fully qualified name of the module, such as "ecstasy.xtclang.org".
      */
     @RO String qualifiedName.get() {
-        return &this.actualClass.name;
+        return &this.class.name;
     }
 
     /**

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/Package.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/Package.x
@@ -28,12 +28,12 @@ interface Package
 
     @Override
     Int estimateStringLength() {
-        return &this.actualClass.name.size;
+        return &this.class.name.size;
     }
 
     @Override
     Appender<Char> appendTo(Appender<Char> buf) {
-        return &this.actualClass.name.appendTo(buf);
+        return &this.class.name.appendTo(buf);
     }
 
 
@@ -41,7 +41,7 @@ interface Package
 
     @Override
     static <CompileType extends Package> Int64 hashCode(CompileType value) {
-        return &value.actualClass.name.hashCode();
+        return &value.class.name.hashCode();
     }
 
     @Override

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/Struct.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/Struct.x
@@ -1,38 +1,43 @@
 /**
- * A Struct is a simple container of values, each of which is referred to as a _field_.
+ * A [Struct] is a simple container of values, each of which is represented by a [Property] of the
+ * [Struct], and referred to as a _field_.
  *
- * Struct is not intended to be implemented by the developer; rather, it is a means by which the
- * runtime exposes the underlying state of an object to the developer. For example, the `new`
- * operator begins by allocating a Struct that will be used to collect all of the state for the
- * object that is being created, first by passing that Struct to the `construct()` function, and
- * then using the resulting state in the Struct to initialize the new object. Furthermore, an
- * object has a `this:struct` reference to its own internal state.
+ * [Struct] is not intended to be implemented by the developer; rather, it is a means by which the
+ * runtime exposes the underlying and internal state of an object to the developer. For example, the
+ * `new` operator begins by allocating a [Struct] that will be used to collect all of the state for
+ * the object that is being created, first by passing that Struct to the class' constructor named
+ * `construct()` (optionally with parameters), and then using the resulting state in the [Struct] to
+ * initialize the new object. Furthermore, an object has a `this:struct` reference to its own
+ * internal state, and that [Struct] can be [obtained via an object reference](Ref.revealStruct()).
  *
- * Note that this interface has no properties; that is purposeful. Since this interface is merged
- * with the properties declared by the class being constructed, any property declared here could
- * collide with a property declared by that class -- a condition which must be avoided.
+ * Note that this interface declares no properties, and awkwardly uses methods where one would
+ * expect to see properties; this is not an accident: Since this interface is
+ * merged with the properties declared by the class which it represents, any property declared here
+ * could collide with a property declared by that class -- a condition which must be avoided.
  */
 interface Struct {
     /**
-     * Represents the mutability of the structure. Once the property has been set to False, the
-     * Struct is no longer mutable, and as a result, the property cannot be set to True.
+     * A method (not a property) that indicates the mutability of the [Struct]. Once a [Struct] has
+     * been [frozen](freeze), the result from this method will be `False`, and any attempt to store
+     * a new value in a property (i.e. "field") of the structure will result in a [ReadOnly]
+     * exception.
      *
-     * @return True iff the Struct is mutable, which indicates if the object references held in its
-     *         fields can be modified
+     * @return `True` iff the [Struct] is mutable, which indicates that the object references held
+     *         in the [Struct]'s fields can be replaced with other references
      */
     Boolean isMutable();
 
     /**
-     * If this Struct is mutable (as indicated by the result of the `isMutable()` method), then this
-     * method will make the Struct immutable. Making the Struct of an object immutable has the
-     * effect of making that object immutable.
+     * If this [Struct] is mutable (as indicated by the result of [isMutable()]), then this method
+     * will make the [Struct] immutable. Since the [Struct] represents the state of the object,
+     * making the [Struct] of an object immutable has the effect of making that object immutable.
      *
-     * If this Struct is already immutable, this has no effect.
+     * If this [Struct] is already immutable, then this method has no effect.
      *
-     * @return this Struct, but in an immutable form
+     * @return this [Struct], but in an immutable form
      *
-     * @throws Unsupported  if the Struct is the structure of a Service; a Service cannot be made
-     *         immutable
+     * @throws Unsupported  if the [Struct] is the structure of a `service` (services cannot be made
+     *         immutable) or of any mutable object that is not within the current service
      */
     immutable Struct freeze();
 
@@ -46,5 +51,5 @@ interface Struct {
      *
      * @return the size of this structure, in bytes
      */
-    Int calcByteLength();
+    Int calcByteSize();
 }

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/Type.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/Type.x
@@ -397,7 +397,7 @@ interface Type<DataType, OuterType>
      * Test whether the specified object is an instance of this type.
      */
     Boolean isInstance(Object o) {
-        return &o.actualType.isA(this);
+        return &o.type.isA(this);
     }
 
     /**
@@ -406,7 +406,7 @@ interface Type<DataType, OuterType>
     DataType cast(Object o) {
         return isInstance(o)
                 ? o.as(DataType)
-                : throw new InvalidType($"Type mismatch (actualType={&o.actualType}, this={this}");
+                : throw new InvalidType($"Type mismatch (type={&o.type}, this={this}");
     }
 
     /**
@@ -888,17 +888,20 @@ interface Type<DataType, OuterType>
 
     // ----- Comparable, Hashable, and Orderable ---------------------------------------------------
 
+    @Override
     static <CompileType extends Type> Int64 hashCode(CompileType value) {
         return value.methods   .hashCode()
              ^ value.properties.hashCode();
     }
 
+    @Override
     static <CompileType extends Type> Boolean equals(CompileType value1, CompileType value2) {
         // the definition for type equality is fairly simple: each of the two types must be
         // type-compatible with the other
         return value1.isA(value2) && value2.isA(value1);
     }
 
+    @Override
     static <CompileType extends Type> Ordered compare(CompileType value1, CompileType value2) {
         if (value1 == value2) {
             return Equal;
@@ -964,7 +967,7 @@ interface Type<DataType, OuterType>
                     return True, new Hasher<DataType>() {
                         @Override
                         Int64 hashOf(Value value) {
-                            if (&value.actualType.isA(t1)) {
+                            if (&value.type.isA(t1)) {
                                 assert Hasher<t1.DataType> hasher := t1.DataType.hashed();
                                 return hasher.hashOf(value.as(t1.DataType));
                             } else {
@@ -975,8 +978,8 @@ interface Type<DataType, OuterType>
 
                         @Override
                         Boolean areEqual(Value value1, Value value2) {
-                            Type actualType1 = &value1.actualType;
-                            Type actualType2 = &value2.actualType;
+                            Type actualType1 = &value1.type;
+                            Type actualType2 = &value2.type;
 
                             if (actualType1.isA(t1) && actualType2.isA(t1)) {
                                 assert Hasher<t1.DataType> hasher := t1.DataType.hashed();

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/TypeSystem.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/TypeSystem.x
@@ -100,7 +100,7 @@ const TypeSystem {
         while (!parser.eof) {
             ImportStatement stmt = parser.parseImportStatement();
             Module?         mod  = mackModule;
-            Type            type = &mod.actualType;
+            Type            type = &mod.type;
             for (Token name : stmt.names) {
                 assert type := type.childTypes.get(name.valueText);
             }
@@ -198,7 +198,7 @@ const TypeSystem {
      */
     conditional Type typeForName(String name, Boolean hideExceptions = False) {
         if (name == "") {
-            return True, &primaryModule.actualType;
+            return True, &primaryModule.type;
         }
 
         if (CacheEntry entry ?= lookupCache[name]) {
@@ -239,7 +239,7 @@ const TypeSystem {
         if (failure == Null && exception != Null) {
             failure = $"Type name contains unparsable element(s): {name.quoted()}";
             if (exception.text == Null) {
-                failure += &exception.actualClass.name;
+                failure += &exception.class.name;
             } else {
                 failure += ": " + exception.text;
             }

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/TypeTemplate.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/TypeTemplate.x
@@ -403,16 +403,19 @@ interface TypeTemplate
 
     // ----- Comparable, Hashable, and Orderable ---------------------------------------------------
 
+    @Override
     static <CompileType extends TypeTemplate> Int64 hashCode(CompileType value) {
         TODO
     }
 
+    @Override
     static <CompileType extends TypeTemplate> Boolean equals(CompileType value1, CompileType value2) {
         // the definition for type equality is fairly simple: each of the two types must be
         // type-compatible with the other
         return value1.isA(value2) && value2.isA(value1);
     }
 
+    @Override
     static <CompileType extends TypeTemplate> Ordered compare(CompileType value1, CompileType value2) {
         if (value1 == value2) {
             return Equal;

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/Version.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/Version.x
@@ -618,6 +618,7 @@ const Version
 
     // ----- Hashable and Comparable ---------------------------------------------------------------
 
+    @Override
     static <CompileType extends Version> Int64 hashCode(CompileType version) {
         Version? parent = version.parent;
         return parent == Null
@@ -631,6 +632,7 @@ const Version
      * other words, version "1.2.1" is identical only to version "1.2.1" (which is identical to
      * version "1.2.1.0").
      */
+    @Override
     static <CompileType extends Version> Boolean equals(CompileType version1, CompileType version2) {
         switch (version1.size <=> version2.size) {
         case Lesser:
@@ -645,10 +647,7 @@ const Version
         }
     }
 
-    /**
-     * The existence of a real implementation of comparison for Orderable instances will be checked
-     * by the run-time.
-     */
+    @Override
     static <CompileType extends Version> Ordered compare(CompileType version1, CompileType version2) {
         switch (version1.size <=> version2.size) {
         case Lesser:

--- a/lib_ecstasy/src/main/x/ecstasy/temporal/Time.x
+++ b/lib_ecstasy/src/main/x/ecstasy/temporal/Time.x
@@ -170,6 +170,7 @@ const Time(Int128 epochPicos, TimeZone timezone = UTC)
     /**
      * Compare two Time values for order.
      */
+    @Override
     static <CompileType extends Time> Ordered compare(CompileType value1, CompileType value2) {
         assert value1.timezone.isNoTZ == value2.timezone.isNoTZ;
         return value1.epochPicos <=> value2.epochPicos;
@@ -178,6 +179,7 @@ const Time(Int128 epochPicos, TimeZone timezone = UTC)
     /**
      * Compare two Time values for equality.
      */
+    @Override
     static <CompileType extends Time> Boolean equals(CompileType value1, CompileType value2) {
         assert value1.timezone.isNoTZ == value2.timezone.isNoTZ;
         return value1.epochPicos == value2.epochPicos;

--- a/lib_json/src/main/x/json/DocInput.x
+++ b/lib_json/src/main/x/json/DocInput.x
@@ -187,7 +187,7 @@ interface DocInput<ParentInput extends (ElementInput | FieldInput)?>
         return $|{array ? "An array" : "A value"} of "{requiredType}" required\
                 |{{if (name != Null) {$.append(" for ").append(name.quoted());}}}\
                 |{{if (pointer != "") {$.append(" at ").append(pointer.quoted());}}}\
-                |, but {doc == Null ? "no value" : &doc.actualType.toString().quoted()} found
+                |, but {doc == Null ? "no value" : &doc.type.toString().quoted()} found
                 ;
     }
 }

--- a/lib_json/src/main/x/json/ElementOutput.x
+++ b/lib_json/src/main/x/json/ElementOutput.x
@@ -90,7 +90,7 @@ interface ElementOutput<ParentOutput extends (ElementOutput | FieldOutput)?>
             return add(Null);
         }
 
-        val type = &value.actualType;
+        val type = &value.type;
         if (type != mapping.Serializable) {
             // the "mapping.Serializable" type could be narrower than "Serializable";
             // we should not pass "Serializable" to the "narrow()" method, which expects a matching

--- a/lib_json/src/main/x/json/JsonArrayBuilder.x
+++ b/lib_json/src/main/x/json/JsonArrayBuilder.x
@@ -152,7 +152,7 @@ class JsonArrayBuilder
                 set(index, value);
                 break;
             default:
-                assert as $"Cannot merge a {&value.actualType} into a {&existing.actualType}";
+                assert as $"Cannot merge a {&value.type} into a {&existing.type}";
             }
         }
     }

--- a/lib_json/src/main/x/json/JsonPatch.x
+++ b/lib_json/src/main/x/json/JsonPatch.x
@@ -98,7 +98,7 @@ annotation JsonPatch
             case JsonObject: applyAddToObject(target, path, value, options);
             case JsonArray:  applyAddToArray(target, path, value, options);
             case Primitive:  applyAddToPrimitive(target, path, value);
-            default:         assert as $"Invalid JSON type {&target.actualType}";
+            default:         assert as $"Invalid JSON type {&target.type}";
         };
     }
 
@@ -202,7 +202,7 @@ annotation JsonPatch
             case JsonObject: applyRemoveFromObject(target, path, options);
             case JsonArray:  applyRemoveFromArray(target, path, options);
             case Primitive:  applyRemoveFromPrimitive(target, path);
-            default:         assert as "invalid JSON type {&doc.actualType}";
+            default:         assert as "invalid JSON type {&doc.type}";
         };
     }
 
@@ -310,7 +310,7 @@ annotation JsonPatch
             case JsonObject: applyReplaceToObject(target, path, value, options);
             case JsonArray:  applyReplaceToArray(target, path, value, options);
             case Primitive:  applyReplaceToPrimitive(target, path, value);
-            default:         assert as $"Invalid JSON type {&target.actualType}";
+            default:         assert as $"Invalid JSON type {&target.type}";
         };
     }
 
@@ -520,6 +520,7 @@ annotation JsonPatch
 
         // ----- equality support ------------------------------------------------------------------
 
+        @Override
         static <CompileType extends Operation> Boolean equals(CompileType value1, CompileType value2) {
             if (value1.op != value2.op) {
                 return False;

--- a/lib_json/src/main/x/json/ObjectInputStream.x
+++ b/lib_json/src/main/x/json/ObjectInputStream.x
@@ -281,7 +281,7 @@ class ObjectInputStream(Schema schema, Parser parser)
 
                 throw new IllegalJSON(
                         $"Type mismatch for JSON pointer \"{pointer}\" from node \"{this.pointer}\""
-                        + $"; required type={Serializable}, actual type={&value.actualType}");
+                        + $"; required type={Serializable}, actual type={&value.type}");
             }
 
             throw new IllegalJSON($"Missing value for JSON pointer \"{pointer}\" from node"
@@ -1052,7 +1052,7 @@ class ObjectInputStream(Schema schema, Parser parser)
                     this.loadNext();
                     return True, dereference(pointer);
                 } else if (pointer != Null) {
-                    throw new IllegalJSON($"Pointer type {&pointer.actualType} from node"
+                    throw new IllegalJSON($"Pointer type {&pointer.type} from node"
                             + $" \"{this.pointer}\"; String expected");
                 }
             }

--- a/lib_json/src/main/x/json/ObjectOutputStream.x
+++ b/lib_json/src/main/x/json/ObjectOutputStream.x
@@ -634,7 +634,7 @@ class ObjectOutputStream(Schema schema, Writer writer)
                 return value.size < 80;
             }
 
-            return &value.actualClass.isSingleton();
+            return &value.class.isSingleton();
         }
     }
 

--- a/lib_json/src/main/x/json/Schema.x
+++ b/lib_json/src/main/x/json/Schema.x
@@ -52,9 +52,9 @@ const Schema
         // verify that the type system is the TypeSystem that includes this class, or a TypeSystem
         // that derives from the TypeSystem that includes this class
         if (typeSystem == Null) {
-            typeSystem = &this.actualType.typeSystem;
+            typeSystem = &this.type.typeSystem;
         } else {
-            assert typeSystem == &this.actualType.typeSystem || &this.actualClass.pathWithin(typeSystem);
+            assert typeSystem == &this.type.typeSystem || &this.class.pathWithin(typeSystem);
         }
 
         // use the module version if no version is specified

--- a/lib_json/src/main/x/json/mappings/LiteralMapping.x
+++ b/lib_json/src/main/x/json/mappings/LiteralMapping.x
@@ -20,7 +20,7 @@ const LiteralMapping<Serializable extends Doc>
             return value.toFPLiteral().as(Serializable);
         }
 
-        throw new IllegalJSON($"Type expected={Serializable}; actual={&value.actualType}");
+        throw new IllegalJSON($"Type expected={Serializable}; actual={&value.type}");
     }
 
     @Override

--- a/lib_json/src/main/x/json/mappings/Narrowable.x
+++ b/lib_json/src/main/x/json/mappings/Narrowable.x
@@ -34,7 +34,7 @@ annotation Narrowable<Serializable>
 
     @Override
     void write(ElementOutput out, Serializable value) {
-        Type<Serializable> type = &value.actualType;
+        Type<Serializable> type = &value.type;
         if (type != Serializable) {
             Schema schema = out.schema;
             if (schema.enableMetadata) {

--- a/lib_json/src/main/x/json/mappings/ReflectionMapping.x
+++ b/lib_json/src/main/x/json/mappings/ReflectionMapping.x
@@ -62,8 +62,8 @@ const ReflectionMapping<Serializable, StructType extends Struct>(
     void write(ElementOutput out, Serializable value) {
         Schema schema = out.schema;
 
-        assert StructType structure := &value.revealAs(StructType) as
-                $"Value of type \"{&value.actualType}\" doesn't belong to this TypeSystem";
+        assert StructType structure := &value.revealStruct() as
+                $"Value of type \"{&value.type}\" doesn't belong to this Service and/or TypeSystem";
 
         using (FieldOutput fieldOutput = out.openObject()) {
             for (PropertyMapping<StructType> field : fields) {

--- a/lib_json/src/main/x/json/mappings/TupleMapping.x
+++ b/lib_json/src/main/x/json/mappings/TupleMapping.x
@@ -20,7 +20,7 @@ const TupleMapping<Serializable extends Tuple>(Mapping[] valueMappings)
     @Override
     Serializable read(ElementInput in) {
         Schema schema = in.schema;
-        Tuple  tuple  = Tuple:();
+        Tuple  tuple  = ();
 
         using (FieldInput mapInput = in.openObject()) {
             using (ElementInput entriesInput = mapInput.openArray("e")) {

--- a/lib_jsondb/src/main/x/jsondb/Client.x
+++ b/lib_jsondb/src/main/x/jsondb/Client.x
@@ -1035,7 +1035,7 @@ service Client<Schema extends RootSchema> {
                     }
                 } catch (Exception e) {
                     this.Client.log($|An exception occurred while evaluating Validator \
-                                     |"{&validator.actualClass.displayName}": {e}
+                                     |"{&validator.class.displayName}": {e}
                                      );
                     return False;
                 }
@@ -1059,7 +1059,7 @@ service Client<Schema extends RootSchema> {
                     }
                 } catch (Exception e) {
                     this.Client.log($|An exception occurred while processing Rectifier \
-                                     |"{&rectifier.actualClass.displayName}": {e}
+                                     |"{&rectifier.class.displayName}": {e}
                                      );
                     return False;
                 }
@@ -1083,7 +1083,7 @@ service Client<Schema extends RootSchema> {
                     }
                 } catch (Exception e) {
                     this.Client.log($|An exception occurred while processing Distributor \
-                                     |"{&distributor.actualClass.displayName}": {e}
+                                     |"{&distributor.class.displayName}": {e}
                                      );
                     return False;
                 }

--- a/lib_jsondb/src/main/x/jsondb/TxManager.x
+++ b/lib_jsondb/src/main/x/jsondb/TxManager.x
@@ -1087,7 +1087,7 @@ service TxManager<Schema extends RootSchema>(Catalog<Schema> catalog)
             Int              writeId  = rec.writeId;
             for (Int storeId : storeIds) {
                 @Future Tuple<> storeOne = storeFor(storeId).commit(writeId);
-                storeAll = storeAll?.and(&storeOne, (_, _) -> Tuple:()) : &storeOne;
+                storeAll = storeAll?.and(&storeOne, (_, _) -> ()) : &storeOne;
             }
             assert storeAll != Null;
 
@@ -2018,7 +2018,7 @@ service TxManager<Schema extends RootSchema>(Catalog<Schema> catalog)
             FutureVar<Tuple<>>? commitAll = Null;
             for (Int storeId : enlisted) {
                 Tuple<> commitOne = storeFor(storeId).commit^(writeId);
-                commitAll = commitAll?.and(&commitOne, (_, _) -> Tuple:()) : &commitOne;
+                commitAll = commitAll?.and(&commitOne, (_, _) -> ()) : &commitOne;
             }
             assert commitAll != Null;
             commitAll.whenComplete((t, e) -> {
@@ -2118,7 +2118,7 @@ service TxManager<Schema extends RootSchema>(Catalog<Schema> catalog)
                     Tuple<> result = storeFor(storeId).rollback^(writeId);
                     &result.handle(e -> {
                         log($"Exception occurred while rolling back transaction {idString} in store {storeId}: {e}");
-                        return Tuple:();
+                        return ();
                     });
                 }
 

--- a/lib_jsondb/src/main/x/jsondb/tools/ModuleGenerator.x
+++ b/lib_jsondb/src/main/x/jsondb/tools/ModuleGenerator.x
@@ -584,7 +584,7 @@ class ModuleGenerator(String moduleName) {
                                 }
                             }
                         }
-                        properties += Tuple:(prop, category);
+                        properties += (prop, category);
                         continue NextProperty;
                     }
                 }
@@ -680,7 +680,7 @@ class ModuleGenerator(String moduleName) {
      * Obtain a display value for the specified constant.
      */
     String displayValue(Object value) {
-        Type typeActual = &value.actualType;
+        Type typeActual = &value.type;
         if (typeActual.is(Type<String>)) {
             return value.as(String).quoted();
         }

--- a/lib_sec/src/main/x/sec/Subject.x
+++ b/lib_sec/src/main/x/sec/Subject.x
@@ -260,8 +260,8 @@ import ecstasy.maps.HasherMap;
                         ? each.locators.contains(locator)
                         : locator.any(l -> each.locators.contains(l)))) {
                 modified = True;
-                subject  = subject.with(
-                                credentials=subject.credentials.replace(Each.count, each.revoke()));
+                subject  = subject.with(credentials=
+                        subject.credentials.replace(Each.count, each.revoke()));
             }
         }
         return modified, subject;

--- a/lib_web/src/main/x/web/Registry.x
+++ b/lib_web/src/main/x/web/Registry.x
@@ -198,7 +198,7 @@ service Registry
             return findMediaType(content.name);
         }
 
-        Type type = &content.actualType;
+        Type type = &content.type;
 
         if (jsonSchema.findMapping(type)) {
             // there's a Json schema for this type, so it's convertible (serializable) as Json

--- a/lib_web/src/main/x/web/requests/SimpleRequest.x
+++ b/lib_web/src/main/x/web/requests/SimpleRequest.x
@@ -24,7 +24,7 @@ class SimpleRequest
             if (mediaType == Null) {
                 if (!(mediaType := client.registry.inferMediaType(content))) {
                     throw new IllegalArgument($|Unable to find MediaType for \
-                                               |"{&content.actualType}"
+                                               |"{&content.type}"
                                              );
                 }
             }
@@ -127,7 +127,7 @@ class SimpleRequest
             return this;
         }
 
-        Type type = &content.actualType;
+        Type type = &content.type;
         if (Codec codec := client.registry.findCodec(mediaType, type)) {
             this.bytes = codec.encode(content);
             return this;

--- a/lib_webcli/src/main/x/webcli.x
+++ b/lib_webcli/src/main/x/webcli.x
@@ -358,7 +358,7 @@ module webcli.xtclang.org {
             } catch (TimedOut e) {
                 return $"Request timed out after {requestTimeout.seconds} sec", ConnectionTimedOut;
             } catch (IOException e) {
-                return ($"Error: {e.message.empty ? &e.actualType : e.message}", ServiceUnavailable);
+                return ($"Error: {e.message.empty ? &e.type : e.message}", ServiceUnavailable);
             }
             HttpStatus status = response.status;
             if (status == OK) {

--- a/lib_xenia/src/main/x/xenia/Catalog.x
+++ b/lib_xenia/src/main/x/xenia/Catalog.x
@@ -364,7 +364,7 @@ const Catalog(WebApp webApp, WebServiceInfo[] services, Class[] sessionAnnos) {
         private void collectExtras(ExtrasAware extraAware, ClassInfo[] classInfos,
                                    Class[] sessionAnnos, Set<String> declaredPaths) {
             for ((Duplicable+WebService) extra : extraAware.extras) {
-                Class<WebService> clz  = &extra.actualClass.as(Class<WebService>);
+                Class<WebService> clz  = &extra.class.as(Class<WebService>);
                 String            path = extra.path;
                 path = validatePath(path, declaredPaths, clz);
                 classInfos += new ClassInfo(path, clz, () -> extra.duplicate());
@@ -494,7 +494,7 @@ const Catalog(WebApp webApp, WebServiceInfo[] services, Class[] sessionAnnos) {
     private static WebServiceInfo[] collectEndpoints(WebApp app, ClassInfo[] classInfos) {
         typedef MediaType|MediaType[] as MediaTypes;
 
-        Class       clzWebApp          = &app.actualClass;
+        Class       clzWebApp          = &app.class;
         TrustLevel  appTrustLevel      = clzWebApp.is(LoginRequired) ? clzWebApp.security : None;
         Boolean     appTls             = clzWebApp.is(HttpsRequired);
         Boolean     appRedirectTls     = clzWebApp.is(HttpsRequired) && clzWebApp.autoRedirect;

--- a/lib_xenia/src/main/x/xenia/ChainBundle.x
+++ b/lib_xenia/src/main/x/xenia/ChainBundle.x
@@ -194,7 +194,7 @@ service ChainBundle {
         handle = binders.empty
             ? ((request) -> respond(request, boundMethod()))
             : ((request) -> {
-                Tuple values = Tuple:();
+                Tuple values = ();
                 for (ParameterBinder bind : binders) {
                     values = bind(request, values);
                 }
@@ -649,7 +649,7 @@ service ChainBundle {
      * Convert the specified value into the specified type using the specified format (optional).
      */
     private Object convertValue(UriTemplate.Value value, Type type, String? formatName) {
-        if (&value.actualType.isA(type)) {
+        if (&value.type.isA(type)) {
             return value;
         }
 
@@ -703,7 +703,7 @@ service ChainBundle {
                     } catch (ecstasy.TypeMismatch e) {
                         throw new IllegalState($|Incoming data type for parameter "{name}" does not \
                                                 |match its type "{paramType.DataType}"; \
-                                                |actualType is "{e.text}"
+                                                |actual type is "{e.text}"
                                               );
                     }
                     if (String formatName ?= param.format) {

--- a/lib_xenia/src/main/x/xenia/SessionImpl.x
+++ b/lib_xenia/src/main/x/xenia/SessionImpl.x
@@ -163,7 +163,7 @@ service SessionImpl
     /**
      * The value representing a "default result" for "void" event handlers.
      */
-    static Tuple<> Void = Tuple:();
+    static Tuple<> Void = ();
 
     /**
      * Internal recording of events related to the session, maintained for security and debugging

--- a/lib_xml/src/main/x/xml/Parser.x
+++ b/lib_xml/src/main/x/xml/Parser.x
@@ -738,7 +738,8 @@ class Parser(Boolean ignoreProlog       = False,
         }
 
         assert lastNode != Null;
-        assert val lastNodeRW := &lastNode.revealAs((protected Node));
+        assert (protected Node) lastNodeRW := &lastNode.as(Ref<Node>).revealAs((protected Node));
+        // TODO GG assert val lastNodeRW := &lastNode.revealAs((protected Node));
         lastNodeRW.next_ = newNode;
         return firstNode, newNode;
     }

--- a/lib_xml/src/main/x/xml/Part.x
+++ b/lib_xml/src/main/x/xml/Part.x
@@ -82,7 +82,7 @@ interface Part
             case Instruction: value.hashCode();
             case Comment:     value.hashCode();
             case Document:    value.hashCode();
-            default:          assert as $"Unsupported type: {&value.actualType}";
+            default:          assert as $"Unsupported type: {&value.type}";
         };
     }
 
@@ -97,7 +97,7 @@ interface Part
             case Instruction: value2.is(Instruction) && value1 == value2;
             case Comment:     value2.is(Comment    ) && value1 == value2;
             case Document:    value2.is(Document   ) && value1 == value2;
-            default:          assert as $"Unsupported type: {&value1.actualType}";
+            default:          assert as $"Unsupported type: {&value1.type}";
         };
     }
 }

--- a/lib_xml/src/main/x/xml/impl/DocumentNode.x
+++ b/lib_xml/src/main/x/xml/impl/DocumentNode.x
@@ -196,7 +196,7 @@ class DocumentNode(ElementNode root)
     @Override
     protected (Node cur, UInt32 mods) replaceNode(Int index, Node? prev, Node? cur, Part part) {
         assert:bounds cur != Null;
-        assert:arg Node node := allowsChild(part) as "Type not allowed: {&part.actualType}";
+        assert:arg Node node := allowsChild(part) as "Type not allowed: {&part.type}";
 
         switch (cur.is(_), node.is(_)) {
         case (ElementNode, ElementNode):
@@ -228,13 +228,13 @@ class DocumentNode(ElementNode root)
         case (_, CommentNode):
             return super(index, prev, cur, part);
         default:
-            assert as $"Unsupported replacement from {&cur.actualClass} to {&node.actualClass}";
+            assert as $"Unsupported replacement from {&cur.class} to {&node.class}";
         }
     }
 
     @Override
     protected (Node cur, UInt32 mods) insertNode(Int index, Node? prev, Node? cur, Part part) {
-        assert:arg Node node := allowsChild(part) as "Type not allowed: {&part.actualType}";
+        assert:arg Node node := allowsChild(part) as "Type not allowed: {&part.type}";
         switch (node.is(_)) {
         case ElementNode:
             assert as "Only one root Element is permitted on a Document";
@@ -267,7 +267,7 @@ class DocumentNode(ElementNode root)
         case CommentNode:
             return super(index, prev, cur);
         default:
-            assert as $"Unsupported node: {&cur.actualClass}";
+            assert as $"Unsupported node: {&cur.class}";
         }
     }
 

--- a/lib_xml/src/main/x/xml/impl/ElementNode.x
+++ b/lib_xml/src/main/x/xml/impl/ElementNode.x
@@ -895,6 +895,7 @@ class ElementNode
         Int get() {
             Int count = counts_ & Mask;
             if (count == Ones) {
+                // TODO CP optimize
                 count = parts.filter(n -> n.is(ContentNode)).size;
                 if (count < Ones) {
                     set(count);

--- a/lib_xml/src/main/x/xml/impl/Node.x
+++ b/lib_xml/src/main/x/xml/impl/Node.x
@@ -287,7 +287,7 @@ mixin Node
             case Instruction: equalsCaseInsens(part.target, "xml") ? new XmlDeclNode(part) : new InstructionNode(part);
             case Comment:     new CommentNode(part);
             case Document:    new DocumentNode(part);
-            default:          assert as $"Unsupported type: {&part.actualType}";
+            default:          assert as $"Unsupported type: {&part.type}";
         };
     }
 

--- a/manualTests/src/main/x/archive/addressDB_imdb/module.x
+++ b/manualTests/src/main/x/archive/addressDB_imdb/module.x
@@ -106,7 +106,7 @@ module AddressBookDB_imdb
             // ----- DBObject interface ------------------------------------------------------------
 
             @Override
-            Tuple dbInvoke(String | Function fn, Tuple args = Tuple:(), (Duration|Time)? when = Null)
+            Tuple dbInvoke(String | Function fn, Tuple args = (), (Duration|Time)? when = Null)
                 {
                 if (fn == "addContact" && when == Null)
                     {

--- a/manualTests/src/main/x/archive/addressDB_json/module.x
+++ b/manualTests/src/main/x/archive/addressDB_json/module.x
@@ -53,7 +53,7 @@ module AddressBookDB_jsondb
                 enableMetadata   = True,
                 enablePointers   = True,
                 enableReflection = True,
-                typeSystem       = &this.actualType.typeSystem,
+                typeSystem       = &this.type.typeSystem,
                 );
         }
 
@@ -140,7 +140,7 @@ module AddressBookDB_jsondb
             // ----- DBObject interface ------------------------------------------------------------
 
             @Override
-            Tuple dbInvoke(String | Function fn, Tuple args = Tuple:(), (Duration|Time)? when = Null)
+            Tuple dbInvoke(String | Function fn, Tuple args = (), (Duration|Time)? when = Null)
                 {
                 if (fn == "addPhone" && when == Null)
                     {

--- a/manualTests/src/main/x/archive/sock-shop/socks-cart-api.x
+++ b/manualTests/src/main/x/archive/sock-shop/socks-cart-api.x
@@ -208,7 +208,7 @@ module SockShopCartApi
                 {
                 @Inject Console console;
                 console.print("Shutting down");
-                result=Tuple:();
+                result=();
                 }
             });
 
@@ -224,7 +224,7 @@ module SockShopCartApi
                 {
                 @Inject Console console;
                 console.print("Webserver has stopped");
-                result.set(Tuple:());
+                result.set(());
                 }
             }
 

--- a/manualTests/src/main/x/archive/sock-shop/socks-catalog-api.x
+++ b/manualTests/src/main/x/archive/sock-shop/socks-catalog-api.x
@@ -200,7 +200,7 @@ module SockShopCatalogApi
                 {
                 @Inject Console console;
                 console.print("Shutting down");
-                result=Tuple:();
+                result=();
                 }
             });
 
@@ -216,7 +216,7 @@ module SockShopCatalogApi
                 {
                 @Inject Console console;
                 console.print("Webserver has stopped");
-                result.set(Tuple:());
+                result.set(());
                 }
             }
 

--- a/manualTests/src/main/x/archive/sock-shop/socks-user-api.x
+++ b/manualTests/src/main/x/archive/sock-shop/socks-user-api.x
@@ -274,7 +274,7 @@ module SockShopUserApi
                 {
                 @Inject Console console;
                 console.print("Shutting down");
-                result=Tuple:();
+                result=();
                 }
             });
 
@@ -290,7 +290,7 @@ module SockShopUserApi
                 {
                 @Inject Console console;
                 console.print("Webserver has stopped");
-                result.set(Tuple:());
+                result.set(());
                 }
             }
 

--- a/manualTests/src/main/x/container.x
+++ b/manualTests/src/main/x/container.x
@@ -20,14 +20,14 @@ module TestContainer {
             Container container =
                 new Container(template, Lightweight, repository, SimpleResourceProvider);
 
-            container.invoke("run", Tuple:(depth+1));
+            container.invoke("run", (depth+1));
         } else {
             // run TestSimple
             ModuleTemplate   template = repository.getResolvedModule("TestSimple");
             ResourceProvider injector = new BasicResourceProvider();
 
             Container container = new Container(template, Lightweight, repository, injector);
-            container.invoke("run", Tuple:());
+            container.invoke("run", ());
 
             // run TestContained
             contained.run();

--- a/manualTests/src/main/x/crypto.x
+++ b/manualTests/src/main/x/crypto.x
@@ -73,7 +73,7 @@ module TestCrypto {
         console.print(cert);
 
         assert CryptoPassword pwd := keystore.getPassword(pwdName);
-        console.print($"{pwd}; type={&pwd.actualType}");
+        console.print($"{pwd}; type={&pwd.type}");
 
         store.delete();
     }

--- a/manualTests/src/main/x/dbTests/CounterTest.x
+++ b/manualTests/src/main/x/dbTests/CounterTest.x
@@ -49,7 +49,7 @@ module CounterTest {
             try {
                 connection.close();
             } catch (Exception ignore) {}
-            result=Tuple:();
+            result=();
         });
         return result;
     }

--- a/manualTests/src/main/x/files.x
+++ b/manualTests/src/main/x/files.x
@@ -137,7 +137,7 @@ module TestFiles {
 
                 console.print($"[{this:service}]: tmpDir={tmpDir}");
                 cancel();
-                done = Tuple:();
+                done = ();
             });
         });
 

--- a/manualTests/src/main/x/innerouter.x
+++ b/manualTests/src/main/x/innerouter.x
@@ -112,13 +112,13 @@ module TestInnerOuter {
                     compare(CompileType value1, CompileType value2) {
                 @Inject Console console;
 
-                console.print($"CompileType={CompileType}");
-                console.print($"CompileType.OuterType={CompileType.OuterType}");
-                console.print($"CompileType.OuterType.Element={CompileType.OuterType.Element}");
-                console.print($"value1={value1}");
-                console.print($"value1.outer={value1.outer}");
-                console.print($"value1.outer.name={value1.outer.name}");
-                console.print($"value1.&outer.actualType={value1.&outer.actualType}");
+                console.print($"{CompileType=}");
+                console.print($"{CompileType.OuterType=}");
+                console.print($"{CompileType.OuterType.Element=}");
+                console.print($"{value1=}");
+                console.print($"{value1.outer=}");
+                console.print($"{value1.outer.name=}");
+                console.print($"{value1.&outer.type=}");
 
                 return (value1.e <=> value2.e).reversed;
             }

--- a/manualTests/src/main/x/json/json_test.x
+++ b/manualTests/src/main/x/json/json_test.x
@@ -9,7 +9,7 @@ module json_test.xtclang.org {
 
     void run() {
         console.print("JSON tests");
-        Class<Package> clz  = &this.actualClass.as(Class<Package>);
+        Class<Package> clz  = &this.class.as(Class<Package>);
         (Int passed, Int failed) = runTests(clz);
         console.print("JSON tests completed");
         console.print($"Passed: {passed}");

--- a/manualTests/src/main/x/json/json_test/JsonBuilderTest.x
+++ b/manualTests/src/main/x/json/json_test/JsonBuilderTest.x
@@ -65,7 +65,7 @@ class JsonBuilderTest {
                 assert copy == source;
                 break;
             default:
-                assert as $"source and copy are different types source={&source.actualType} copy={&copy.actualType}";
+                assert as $"source and copy are different types source={&source.type} copy={&copy.type}";
         }
     }
 

--- a/manualTests/src/main/x/maps.x
+++ b/manualTests/src/main/x/maps.x
@@ -197,6 +197,7 @@ module TestMaps {
 
         // test very bad hashing
         const Point(Int x) {
+            @Override
             static <CompileType extends Point> Int64 hashCode(CompileType value) {
                 return 100 + value.x.toInt64() % 3;
             }
@@ -224,7 +225,7 @@ module TestMaps {
     }
 
     void testMapIteration(Map<String, Int> map) {
-        console.print($"\n** testMapIteration({&map.actualType.underlyingTypes[0]})");
+        console.print($"\n** testMapIteration({&map.type.underlyingTypes[0]})");
 
         map.put("hello", 1);
         map.put("goodbye", 2);
@@ -293,12 +294,12 @@ module TestMaps {
             Map<String, String> mapNew;
             try {
                 mapNew = map.put("1", "a");
-                assert mapNew != map as $"Invalid modification for {&map.actualType}";
+                assert mapNew != map as $"Invalid modification for {&map.type}";
             } catch (ReadOnly e) {}
 
             try {
                 mapNew = map.put("2", "b");
-                assert mapNew != map as $"Invalid insert for {&map.actualType}";
+                assert mapNew != map as $"Invalid insert for {&map.type}";
             } catch (ReadOnly e) {}
         }
 
@@ -468,7 +469,7 @@ module TestMaps {
     }
 
     void testConcurrentProcess(Map<Int, Int> map) {
-        console.print($"\n** testConcurrentProcess({&map.actualClass.name})");
+        console.print($"\n** testConcurrentProcess({&map.class.name})");
         map.put(0, 0);
 
         @Volatile Int count = 0;

--- a/manualTests/src/main/x/prop.x
+++ b/manualTests/src/main/x/prop.x
@@ -260,8 +260,7 @@ module TestProps {
             }
 
             void validateImmutable(Var<String[]> var) {
-                assert var.is(immutable);
-                assert !var.assigned || var.isImmutable;
+                assert !var.assigned || var.is(immutable);
                 try {
                     var.set([""]);
                     assert;

--- a/manualTests/src/main/x/runner.x
+++ b/manualTests/src/main/x/runner.x
@@ -45,7 +45,7 @@ module Runner {
 
             buffer.print($"++++++ Loading module: {moduleName} +++++++\n");
             using (new Timeout(Duration:1m)) {
-                @Future Tuple result = container.invoke("run", Tuple:());
+                @Future Tuple result = container.invoke("run", ());
                 return (&result, buffer);
             }
         } catch (Exception e) {

--- a/manualTests/src/main/x/timeouts.x
+++ b/manualTests/src/main/x/timeouts.x
@@ -79,7 +79,7 @@ module TestTimeouts {
                 } else {
                     console.print("Failed to timeout");
                 }
-                done = Tuple:();
+                done = ();
             });
             return done;
         }
@@ -98,7 +98,7 @@ module TestTimeouts {
                 } else {
                     console.print("Failed to timeout");
                 }
-                done = Tuple:();
+                done = ();
             });
             return done;
         }
@@ -144,7 +144,7 @@ module TestTimeouts {
             @Inject Timer timer;
             @Future Tuple done;
             timer.start();
-            timer.schedule(duration, () -> {done = Tuple:();});
+            timer.schedule(duration, () -> {done = ();});
 
             return done;
         }

--- a/manualTests/src/main/x/tuple.x
+++ b/manualTests/src/main/x/tuple.x
@@ -100,7 +100,7 @@ module TestTuples {
         console.print("\n** testMutability()");
 
         Tuple<Int, String, Char> t1 = (1, "big", '?');
-        Tuple t1a = Tuple:().add(Int:1).add("big").add('?');
+        Tuple t1a = ().add(Int:1).add("big").add('?');
         assert t1a == t1;
 
         Tuple<Int, String, Char> t2 = t1.replace(1, "small");
@@ -112,7 +112,7 @@ module TestTuples {
         Tuple t4 = t2.slice(1..2); // "small", ?
         assert t4 == t3;
 
-        Tuple t5 = Tuple:(1.toInt()).addAll(t4); // 1, "small", ?
+        Tuple t5 = (1.toInt(),).addAll(t4); // 1, "small", ?
         assert t5 == t2;
     }
 }

--- a/tck/src/main/x/tck/services/Utils.x
+++ b/tck/src/main/x/tck/services/Utils.x
@@ -16,7 +16,7 @@ class Utils {
         void simulate(Duration duration) {
             @Inject Clock clock;
             @Future Tuple done;
-            clock.schedule(duration, () -> {done = Tuple:();});
+            clock.schedule(duration, () -> {done = ();});
 
             return done;
         }

--- a/tck/src/main/x/tck/tuples/Basic.x
+++ b/tck/src/main/x/tck/tuples/Basic.x
@@ -45,7 +45,7 @@ class Basic {
         assert t1 == t2;
 
         Tuple<Int, String, Char> t3 = (1, "big", '?');
-        Tuple t4 = Tuple:().add(Int:1).add("big").add('?');
+        Tuple t4 = ().add(Int:1).add("big").add('?');
         assert t3 == t4;
     }
 


### PR DESCRIPTION
Updated BNF and Ecstasy compiler to support more natural Tuple syntax, and trailing commas in most list-oriented constructs. Updated core library interfaces, implementations, and documentation for Ref and Tuple.