### PR TITLE
Add support for using multiple version of the same module within single container

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -1086,17 +1086,25 @@ public class ConstantPool
      */
     public ModuleConstant ensureModuleConstant(String sName)
         {
+        return ensureModuleConstant(sName, null);
+        }
+
+    /**
+     * Obtain a Constant that represents the specified module for a specified version.
+     *
+     * @param sName    a fully qualified module name
+     * @param version  a module version
+     *
+     * @return the ModuleConstant for the specified qualified module name and version
+     */
+    public ModuleConstant ensureModuleConstant(String sName, Version version)
+        {
         if (!isValidQualifiedModule(sName))
             {
             throw new IllegalArgumentException("illegal qualified module name: " + quotedString(sName));
             }
 
-        ModuleConstant constant = (ModuleConstant) ensureLocatorLookup(Format.Module).get(sName);
-        if (constant == null)
-            {
-            constant = (ModuleConstant) register(new ModuleConstant(this, sName));
-            }
-        return constant;
+        return (ModuleConstant) register(new ModuleConstant(this, sName, version));
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -2562,6 +2562,28 @@ public class ConstantPool
                 findMethod(sMethod, cParams).getIdentityConstant().getSignature());
         }
 
+    /**
+     * Replace the parent identity for all IdentityConstants that are children of the specified
+     * module.
+     *
+     * This method is absolutely destructive to the integrity of this ConstantPool and should only
+     * be called on a freshly created copy of a FileStructure that would be immediately discarded
+     * after serialization.
+     */
+    void replaceModule(ModuleConstant idOld, ModuleConstant idNew)
+        {
+        for (Constant constant : m_listConst)
+            {
+            if (constant instanceof IdentityConstant id && id.getParentConstant() == idOld)
+                {
+                int nPos = id.getPosition();
+                id = id.replaceParentConstant(idNew);
+                id.setPosition(nPos);
+                m_listConst.set(nPos, id);
+                }
+            }
+        }
+
 
     // ----- XvmStructure methods ------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -270,9 +270,9 @@ public class ConstantPool
         if (set.add(this))
             {
             FileStructure file = getFileStructure();
-            for (String sModule : file.moduleNames())
+            for (ModuleConstant idModule : file.moduleIds())
                 {
-                ModuleStructure moduleFingerprint = file.getModule(sModule);
+                ModuleStructure moduleFingerprint = file.getModule(idModule);
                 if (moduleFingerprint.isFingerprint())
                     {
                     ModuleStructure moduleUpstream = moduleFingerprint.getFingerprintOrigin();
@@ -3023,7 +3023,7 @@ public class ConstantPool
         {
         StringBuilder sb = new StringBuilder();
         sb.append("module=")
-          .append(getFileStructure().getModuleName())
+          .append(getFileStructure().getModuleId().getName())
           .append(", size=")
           .append(m_listConst.size());
 
@@ -4015,9 +4015,8 @@ public class ConstantPool
         Constant[] aconst = new Constant[cBefore];
         int cAfter        = 0;
 
-        for (int i = 0; i < cBefore; i++)
+        for (Constant constant : list)
             {
-            Constant constant = list.get(i);
             if (constant.hasRefs())
                 {
                 aconst[cAfter++] = constant;

--- a/javatools/src/main/java/org/xvm/asm/Constants.java
+++ b/javatools/src/main/java/org/xvm/asm/Constants.java
@@ -33,7 +33,7 @@ public interface Constants
      * will be displayed if there is a version mismatch, which should save some frustration -- since
      * otherwise the resulting error(s) can be very hard to diagnose.
      */
-    int VERSION_MINOR_CUR = 2025_05_05;
+    int VERSION_MINOR_CUR = 2025_05_08;
 
 
     // ----- names ---------------------------------------------------------------------------------

--- a/javatools/src/main/java/org/xvm/asm/FileStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/FileStructure.java
@@ -367,6 +367,25 @@ public class FileStructure
         }
 
     /**
+     * Find a module with the specified name at this FileStructure.
+     *
+     * @param sName  the qualified module name
+     *
+     * @return the specified module or null if not found
+     */
+    public ModuleStructure findModule(String sName)
+        {
+        for (ModuleStructure module : f_moduleByConstant.values())
+            {
+            if (module.getName().equals(sName))
+                {
+                return module;
+                }
+            }
+        return null;
+        }
+
+    /**
      * Link the modules in this FileStructure.
      *
      * @param repository  the module repository to load modules from
@@ -482,9 +501,9 @@ public class FileStructure
      * @return null iff success, otherwise the id of the first module that could not be linked to
      */
     private ModuleConstant linkModules(ModuleRepository repository, FileStructure fileTop,
-                                       Set<String> setFilesDone, boolean fRuntime)
+                                       Set<ModuleConstant> setFilesDone, boolean fRuntime)
         {
-        if (!setFilesDone.add(getModuleId().getName()))
+        if (!setFilesDone.add(getModuleId()))
             {
             return null;
             }
@@ -514,7 +533,8 @@ public class FileStructure
                 return idModule;
                 }
 
-            ModuleStructure moduleUnlinked = repository.loadModule(idModule.getName()); // TODO versions etc.
+            ModuleStructure moduleUnlinked = repository.loadModule(
+                                                idModule.getName(), idModule.getVersion(), !fRuntime);
             if (moduleUnlinked == null)
                 {
                 return idModule;
@@ -547,7 +567,7 @@ public class FileStructure
                     fileTop.addChild(moduleFingerprint);
                     }
 
-                if (!setFilesDone.contains(idModule.getName()))
+                if (!setFilesDone.contains(idModule))
                     {
                     listFilesTodo.add(fileUnlinked); // recurse downstream
                     }
@@ -648,7 +668,7 @@ public class FileStructure
      */
     public boolean containsVersion(Version ver)
         {
-        return getVersionTree().get(ver);
+        return getVersionTree().contains(ver);
         }
 
     /**
@@ -1313,8 +1333,8 @@ public class FileStructure
             return this.m_nMajorVer == that.m_nMajorVer
                     && this.m_nMinorVer == that.m_nMinorVer
                     && this.m_idModule.equals(that.m_idModule)
-                    && this.getChildByNameMap().equals(
-                       that.getChildByNameMap()); // TODO need "childrenEquals()"?
+                    && this.f_vtree.equals(that.f_vtree)
+                    && this.f_moduleByConstant.equals(that.f_moduleByConstant);
             }
 
         return false;

--- a/javatools/src/main/java/org/xvm/asm/ModuleRepository.java
+++ b/javatools/src/main/java/org/xvm/asm/ModuleRepository.java
@@ -103,15 +103,15 @@ public interface ModuleRepository
             }
 
         Version       useVersion = null;
-        FileStructure container  = module.getFileStructure();
-        if (container.containsVersion(version))
+        FileStructure file       = module.getFileStructure();
+        if (file.containsVersion(version))
             {
             useVersion = version;
             }
         else
             {
             // check each version in the module to see if it would work; keep the most appropriate one
-            for (Version possibleVer : container.getVersionTree())
+            for (Version possibleVer : file.getVersionTree())
                 {
                 if (possibleVer.isSubstitutableFor(version))
                     {
@@ -139,12 +139,7 @@ public interface ModuleRepository
                 }
             }
 
-        if (container.getVersionTree().size() > 1)
-            {
-            container.purgeVersionsExcept(useVersion);
-            }
-
-        return module;
+        return file.extractVersion(useVersion);
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/ModuleRepository.java
+++ b/javatools/src/main/java/org/xvm/asm/ModuleRepository.java
@@ -97,9 +97,9 @@ public interface ModuleRepository
     default ModuleStructure loadModule(String sModule, Version version, boolean fExact)
         {
         ModuleStructure module = loadModule(sModule);
-        if (module == null)
+        if (module == null || version == null)
             {
-            return null;
+            return module;
             }
 
         Version       useVersion = null;

--- a/javatools/src/main/java/org/xvm/asm/ModuleStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ModuleStructure.java
@@ -304,12 +304,12 @@ public class ModuleStructure
     /**
      * Specify the ModuleStructure that corresponds to the fingerprint.
      *
-     * @param structModule  the actual ModuleStructure that the fingerprint is based on
+     * @param moduleActual  the actual ModuleStructure that the fingerprint is based on
      */
-    public void setFingerprintOrigin(ModuleStructure structModule)
+    public void setFingerprintOrigin(ModuleStructure moduleActual)
         {
         assert isFingerprint();
-        m_moduleActual = structModule;
+        m_moduleActual = moduleActual;
         }
 
     /**
@@ -422,8 +422,6 @@ public class ModuleStructure
         PackageStructure pkg = m_pkgImport;
         if (pkg == null)
             {
-            assert !isMainModule();
-
             ModuleStructure moduleMain = (ModuleStructure) idMainModule.getComponent();
 
             String sPath = moduleMain.collectDependencies().get(getIdentityConstant());

--- a/javatools/src/main/java/org/xvm/asm/ModuleStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ModuleStructure.java
@@ -61,9 +61,9 @@ public class ModuleStructure
         ModuleConstant idPrimary = xsParent.getFileStructure().getModuleId();
         if (idPrimary != null && !idPrimary.equals(constId))
             {
-            moduletype           = ModuleType.Optional;
-            vtreeImportAllowVers = new VersionTree<>();
-            listImportPreferVers = new ArrayList<>();
+            m_moduletype           = ModuleType.Optional;
+            m_vtreeImportAllowVers = new VersionTree<>();
+            m_listImportPreferVers = new ArrayList<>();
             }
         }
 
@@ -86,7 +86,7 @@ public class ModuleStructure
      */
     public ModuleType getModuleType()
         {
-        return moduletype;
+        return m_moduletype;
         }
 
     /**
@@ -94,7 +94,7 @@ public class ModuleStructure
      */
     public boolean isMainModule()
         {
-        return moduletype == ModuleType.Primary &&
+        return m_moduletype == ModuleType.Primary &&
                 getIdentityConstant().equals(getFileStructure().getModuleId());
         }
 
@@ -107,7 +107,7 @@ public class ModuleStructure
      */
     public boolean isFingerprint()
         {
-        return switch (moduletype)
+        return switch (m_moduletype)
             {
             case Optional, Desired, Required -> true;
             case Primary, Embedded           -> false;
@@ -172,7 +172,7 @@ public class ModuleStructure
     public VersionConstant getVersionConstant()
         {
         assert !isFingerprint();
-        return version;
+        return m_constVersion;
         }
 
     /**
@@ -193,7 +193,7 @@ public class ModuleStructure
         {
         assert !isFingerprint();
         markModified();
-        this.version = getConstantPool().ensureVersionConstant(version);
+        m_constVersion = getConstantPool().ensureVersionConstant(version);
         }
 
     /**
@@ -214,7 +214,7 @@ public class ModuleStructure
     public VersionTree<Boolean> getFingerprintVersions()
         {
         assert isFingerprint();
-        return vtreeImportAllowVers;
+        return m_vtreeImportAllowVers;
         }
 
     /**
@@ -225,8 +225,8 @@ public class ModuleStructure
     public void setFingerprintVersions(VersionTree<Boolean> vtreeAllow)
         {
         assert isFingerprint();
-        vtreeImportAllowVers.clear();
-        vtreeImportAllowVers.putAll(vtreeAllow);
+        m_vtreeImportAllowVers.clear();
+        m_vtreeImportAllowVers.putAll(vtreeAllow);
         markModified();
         }
 
@@ -239,7 +239,7 @@ public class ModuleStructure
         {
         assert isFingerprint();
 
-        List<Version> list = listImportPreferVers;
+        List<Version> list = m_listImportPreferVers;
         assert (list = Collections.unmodifiableList(list)) != null;
         return list;
         }
@@ -252,8 +252,8 @@ public class ModuleStructure
     public void setFingerprintVersionPrefs(List<Version> listPrefer)
         {
         assert isFingerprint();
-        listImportPreferVers.clear();
-        listImportPreferVers.addAll(listPrefer);
+        m_listImportPreferVers.clear();
+        m_listImportPreferVers.addAll(listPrefer);
         markModified();
         }
 
@@ -271,9 +271,9 @@ public class ModuleStructure
     public void fingerprintDesired()
         {
         assert isFingerprint();
-        if (moduletype == ModuleType.Optional)
+        if (m_moduletype == ModuleType.Optional)
             {
-            moduletype = ModuleType.Desired;
+            m_moduletype = ModuleType.Desired;
             markModified();
             }
         }
@@ -284,9 +284,9 @@ public class ModuleStructure
     public void fingerprintRequired()
         {
         assert isFingerprint();
-        if (moduletype == ModuleType.Optional || moduletype == ModuleType.Desired)
+        if (m_moduletype == ModuleType.Optional || m_moduletype == ModuleType.Desired)
             {
-            moduletype = ModuleType.Required;
+            m_moduletype = ModuleType.Required;
             markModified();
             }
         }
@@ -297,8 +297,8 @@ public class ModuleStructure
      */
     public boolean isEmbeddedModule()
         {
-        assert (moduletype == ModuleType.Embedded) == (!isMainModule() && !isFingerprint());
-        return moduletype == ModuleType.Embedded;
+        assert (m_moduletype == ModuleType.Embedded) == (!isMainModule() && !isFingerprint());
+        return m_moduletype == ModuleType.Embedded;
         }
 
     /**
@@ -401,16 +401,16 @@ public class ModuleStructure
         {
         ModuleStructure that = (ModuleStructure) super.cloneBody();
 
-        if (this.vtreeImportAllowVers != null)
+        if (this.m_vtreeImportAllowVers != null)
             {
-            that.vtreeImportAllowVers = new VersionTree<>();
-            that.vtreeImportAllowVers.putAll(this.vtreeImportAllowVers);
+            that.m_vtreeImportAllowVers = new VersionTree<>();
+            that.m_vtreeImportAllowVers.putAll(this.m_vtreeImportAllowVers);
             }
 
-        if (this.listImportPreferVers != null)
+        if (this.m_listImportPreferVers != null)
             {
-            that.listImportPreferVers = new ArrayList<>();
-            that.listImportPreferVers.addAll(this.listImportPreferVers);
+            that.m_listImportPreferVers = new ArrayList<>();
+            that.m_listImportPreferVers.addAll(this.m_listImportPreferVers);
             }
 
         return that;
@@ -445,7 +445,7 @@ public class ModuleStructure
         {
         super.disassemble(in);
 
-        moduletype = ModuleType.valueOf(in.readUnsignedByte());
+        m_moduletype = ModuleType.valueOf(in.readUnsignedByte());
 
         ConstantPool pool = getConstantPool();
         if (isFingerprint())
@@ -468,14 +468,14 @@ public class ModuleStructure
                     }
                 }
 
-            vtreeImportAllowVers = vtreeAllow;
-            listImportPreferVers = listPrefer;
+            m_vtreeImportAllowVers = vtreeAllow;
+            m_listImportPreferVers = listPrefer;
             }
         else
             {
             if (in.readBoolean())
                 {
-                version = (VersionConstant) pool.getConstant(readMagnitude(in));
+                m_constVersion = (VersionConstant) pool.getConstant(readMagnitude(in));
                 }
             }
 
@@ -490,19 +490,19 @@ public class ModuleStructure
 
         if (isFingerprint())
             {
-            for (Version ver : vtreeImportAllowVers)
+            for (Version ver : m_vtreeImportAllowVers)
                 {
                 pool.ensureVersionConstant(ver);
                 }
 
-            for (Version ver : listImportPreferVers)
+            for (Version ver : m_listImportPreferVers)
                 {
                 pool.ensureVersionConstant(ver);
                 }
             }
-        else if (version != null)
+        else if (m_constVersion != null)
             {
-            version = (VersionConstant) pool.register(version);
+            m_constVersion = (VersionConstant) pool.register(m_constVersion);
             }
 
         m_constDir       = (LiteralConstant) pool.register(m_constDir);
@@ -515,13 +515,13 @@ public class ModuleStructure
         {
         super.assemble(out);
 
-        out.writeByte(moduletype.ordinal());
+        out.writeByte(m_moduletype.ordinal());
 
         ConstantPool pool = getConstantPool();
 
         if (isFingerprint())
             {
-            VersionTree<Boolean> vtreeAllow = vtreeImportAllowVers;
+            VersionTree<Boolean> vtreeAllow = m_vtreeImportAllowVers;
             writePackedLong(out, vtreeAllow.size());
             for (Version ver : vtreeAllow)
                 {
@@ -529,7 +529,7 @@ public class ModuleStructure
                 out.writeBoolean(vtreeAllow.get(ver));
                 }
 
-            List<Version> listPrefer = listImportPreferVers;
+            List<Version> listPrefer = m_listImportPreferVers;
             writePackedLong(out, listPrefer.size());
             for (Version ver : listPrefer)
                 {
@@ -538,14 +538,14 @@ public class ModuleStructure
             }
         else
             {
-            if (version == null)
+            if (m_constVersion == null)
                 {
                 out.writeBoolean(false);
                 }
             else
                 {
                 out.writeBoolean(true);
-                writePackedLong(out, version.getPosition());
+                writePackedLong(out, m_constVersion.getPosition());
                 }
             }
 
@@ -560,14 +560,14 @@ public class ModuleStructure
         sb.append(super.getDescription());
 
         sb.append(", module type=")
-                .append(moduletype);
+          .append(m_moduletype);
 
         if (isFingerprint())
             {
             sb.append(", fingerprint=true");
 
-            VersionTree<Boolean> vtreeAllow = vtreeImportAllowVers;
-            List<Version>        listPrefer = listImportPreferVers;
+            VersionTree<Boolean> vtreeAllow = m_vtreeImportAllowVers;
+            List<Version>        listPrefer = m_listImportPreferVers;
             if (!vtreeAllow.isEmpty() || !listPrefer.isEmpty())
                 {
                 sb.append(", version={");
@@ -602,10 +602,10 @@ public class ModuleStructure
             }
         else
             {
-            if (version != null)
+            if (m_constVersion != null)
                 {
                 sb.append(", version={")
-                  .append(version.getVersion())
+                  .append(m_constVersion.getVersion())
                   .append('}');
                 }
             }
@@ -635,9 +635,10 @@ public class ModuleStructure
             }
 
         // compare versions
-        return this.moduletype == that.moduletype
-                && Handy.equals(this.vtreeImportAllowVers, that.vtreeImportAllowVers)
-                && Handy.equals(this.listImportPreferVers, that.listImportPreferVers)
+        return this.m_moduletype == that.m_moduletype
+                && Handy.equals(this.m_vtreeImportAllowVers, that.m_vtreeImportAllowVers)
+                && Handy.equals(this.m_listImportPreferVers, that.m_listImportPreferVers)
+                && Handy.equals(this.m_constVersion,         that.m_constVersion)
                 && Handy.equals(this.m_constDir, that.m_constDir);
         }
 
@@ -704,24 +705,24 @@ public class ModuleStructure
     /**
      * Module type.
      */
-    private ModuleType moduletype = ModuleType.Primary;
+    private ModuleType m_moduletype = ModuleType.Primary;
 
     /**
      * Module version; always null for fingerprints.
      */
-    private VersionConstant version;
+    private VersionConstant m_constVersion;
 
     /**
      * If this is a fingerprint, then this will be a non-null version tree (but potentially empty)
      * specifying which versions are allowed (via a TRUE value) and avoided (via a FALSE value).
      */
-    private VersionTree<Boolean> vtreeImportAllowVers;
+    private VersionTree<Boolean> m_vtreeImportAllowVers;
 
     /**
      * If this is a fingerprint, then this will be a non-null (but potentially empty) list of
      * versions that are specified as preferred, in their order of preference.
      */
-    private List<Version> listImportPreferVers;
+    private List<Version> m_listImportPreferVers;
 
     /**
      * If this is a fingerprint, during compilation this will hold the actual module from which the

--- a/javatools/src/main/java/org/xvm/asm/ModuleStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ModuleStructure.java
@@ -50,15 +50,16 @@ public class ModuleStructure
      * @param constId    the constant that specifies the identity of the Module
      * @param condition  the optional condition for this ModuleStructure
      */
-    protected ModuleStructure(XvmStructure xsParent, int nFlags, ModuleConstant constId, ConditionalConstant condition)
+    protected ModuleStructure(XvmStructure xsParent, int nFlags, ModuleConstant constId,
+                              ConditionalConstant condition)
         {
         super(xsParent, nFlags, constId, condition);
 
         // when the main module is created in the FileStructure, the name has not yet been
         // configured, so if this is being created and the file already has a main module name, then
         // this module is being created to act as a fingerprint
-        String sPrimary = xsParent.getFileStructure().getModuleName();
-        if (sPrimary != null && !sPrimary.equals(constId.getName()))
+        ModuleConstant idPrimary = xsParent.getFileStructure().getModuleId();
+        if (idPrimary != null && !idPrimary.equals(constId))
             {
             moduletype           = ModuleType.Optional;
             vtreeImportAllowVers = new VersionTree<>();
@@ -94,7 +95,7 @@ public class ModuleStructure
     public boolean isMainModule()
         {
         return moduletype == ModuleType.Primary &&
-                getName().equals(getFileStructure().getModuleName());
+                getIdentityConstant().equals(getFileStructure().getModuleId());
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/Version.java
+++ b/javatools/src/main/java/org/xvm/asm/Version.java
@@ -192,12 +192,11 @@ public class Version
                 {
                 // parse the build string, which must be the remainder of the version
                 sBuild = sLiteral.substring(ix + 1);
-                ix = cLen;
 
                 // semver states that only A..Z, a..z, 0..9, and '-' may occur in the build
                 // metadata, but the examples given also include '.', so Ecstasy considers the
                 // '.' to be legal
-                if (!sBuild.matches("[A-Za-z0-9\\-\\.]*"))
+                if (!sBuild.matches("[A-Za-z0-9\\-.]*"))
                     {
                     sErr = "illegal build string \"" + sBuild + "\"; only A-Z, a-z, 0-9, '-', and '.' are permitted";
                     }

--- a/javatools/src/main/java/org/xvm/asm/VersionTree.java
+++ b/javatools/src/main/java/org/xvm/asm/VersionTree.java
@@ -209,6 +209,18 @@ public class VersionTree<V>
         }
 
     /**
+     * Retrieve the lowest version in the tree.
+     *
+     * @return the lowest version, or null
+     */
+    public Version findLowestVersion()
+        {
+        return isEmpty()
+                ? null
+                : root.kids[0].firstContainedPresent().getVersion();
+        }
+
+    /**
      * Find the latest (preferably GA) version in the tree.
      *
      * @return the latest version, or null

--- a/javatools/src/main/java/org/xvm/asm/constants/ClassConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ClassConstant.java
@@ -303,7 +303,6 @@ public class ClassConstant
         return getConstantPool().ensureChildClassConstant(constPath, constChild.getName());
         }
 
-
     /**
      * @return if this ClassConstant represents an implicitly imported class return it's
      *         implicit name; null otherwise
@@ -313,6 +312,15 @@ public class ClassConstant
         return getModuleConstant().isEcstasyModule()
                 ? ConstantPool.getImplicitImportName("ecstasy." + getPathString())
                 : null;
+        }
+
+
+    // ----- IdentityConstant methods --------------------------------------------------------------
+
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new ClassConstant(getConstantPool(), idParent, getName());
         }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/DecoratedClassConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DecoratedClassConstant.java
@@ -65,6 +65,12 @@ public class DecoratedClassConstant
 
     // ----- IdentityConstant methods --------------------------------------------------------------
 
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return this;
+        }
+
     /**
      * @return the IdentityConstant that this DecoratedClassConstant represents a class of
      */

--- a/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
@@ -217,6 +217,13 @@ public class DynamicFormalConstant
     // ----- IdentityConstant methods --------------------------------------------------------------
 
     @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new DynamicFormalConstant(getConstantPool(), (MethodConstant) idParent, getName(),
+                getRegister(), getFormalConstant());
+        }
+
+    @Override
     public IdentityConstant appendTrailingSegmentTo(IdentityConstant that)
         {
         throw new IllegalStateException();

--- a/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
@@ -177,6 +177,12 @@ public class FormalTypeChildConstant
     // ----- IdentityConstant methods --------------------------------------------------------------
 
     @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new FormalTypeChildConstant(getConstantPool(), (FormalConstant) idParent, getName());
+        }
+
+    @Override
     public FormalConstant getParentConstant()
         {
         return (FormalConstant) super.getParentConstant();

--- a/javatools/src/main/java/org/xvm/asm/constants/IdentityConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/IdentityConstant.java
@@ -46,6 +46,13 @@ public abstract class IdentityConstant
     public abstract IdentityConstant getParentConstant();
 
     /**
+     * Create a new IdentityConstant that is a child for the specified parent.
+     *
+     * @return the new IdentityConstant that is equivalent to this one, but has the specified parent
+     */
+    public abstract IdentityConstant replaceParentConstant(IdentityConstant idParent);
+
+    /**
      * Determine the constant within which the name of this constant is registered. In most cases,
      * the namespace is the parent, but in the case of the MethodConstant, the namespace is the
      * grandparent, because the parent is the MultiMethodConstant.

--- a/javatools/src/main/java/org/xvm/asm/constants/MethodConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/MethodConstant.java
@@ -309,6 +309,12 @@ public class MethodConstant
     // ----- IdentityConstant methods --------------------------------------------------------------
 
     @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new MethodConstant(getConstantPool(), (MultiMethodConstant) idParent, getSignature());
+        }
+
+    @Override
     public MultiMethodConstant getParentConstant()
         {
         return m_constParent;

--- a/javatools/src/main/java/org/xvm/asm/constants/ModuleConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ModuleConstant.java
@@ -158,6 +158,12 @@ public class ModuleConstant
         return null;
         }
 
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return this;
+        }
+
     /**
      * Get the qualified name of the Module.
      * <p/>

--- a/javatools/src/main/java/org/xvm/asm/constants/ModuleConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ModuleConstant.java
@@ -158,8 +158,7 @@ public class ModuleConstant
     @Override
     public Component getComponent()
         {
-        String          sName  = getName();
-        ModuleStructure struct = getFileStructure().getModule(sName);
+        ModuleStructure struct = getFileStructure().getModule(this);
         if (struct == null)
             {
             return null;
@@ -231,11 +230,11 @@ public class ModuleConstant
     @Override
     protected int compareDetails(Constant that)
         {
-        if (!(that instanceof ModuleConstant))
+        if (!(that instanceof ModuleConstant idThat))
             {
             return -1;
             }
-        return this.m_constName.compareTo(((ModuleConstant) that).m_constName);
+        return this.m_constName.compareTo(idThat.m_constName);
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/MultiMethodConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/MultiMethodConstant.java
@@ -64,6 +64,15 @@ public class MultiMethodConstant
         }
 
 
+    // ----- IdentityConstant methods --------------------------------------------------------------
+
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new MultiMethodConstant(getConstantPool(), idParent, getName());
+        }
+
+
     // ----- Constant methods ----------------------------------------------------------------------
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/NativeRebaseConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/NativeRebaseConstant.java
@@ -44,8 +44,17 @@ public class NativeRebaseConstant
         }
 
 
-    // ----- Constant methods ----------------------------------------------------------------------
+    // ----- IdentityConstant methods --------------------------------------------------------------
 
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new NativeRebaseConstant((ClassConstant)
+                getClassConstant().replaceParentConstant(idParent));
+        }
+
+
+    // ----- Constant methods ----------------------------------------------------------------------
 
     @Override
     public boolean containsUnresolved()

--- a/javatools/src/main/java/org/xvm/asm/constants/PackageConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PackageConstant.java
@@ -51,6 +51,15 @@ public class PackageConstant
         }
 
 
+    // ----- IdentityConstant methods --------------------------------------------------------------
+
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new PackageConstant(getConstantPool(), idParent, getName());
+        }
+
+
     // ----- Constant methods ----------------------------------------------------------------------
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
@@ -286,6 +286,12 @@ public class PropertyConstant
     // ----- IdentityConstant methods --------------------------------------------------------------
 
     @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new PropertyConstant(getConstantPool(), idParent, getName());
+        }
+
+    @Override
     public TypeConstant getValueType(ConstantPool pool, TypeConstant typeTarget)
         {
         if (typeTarget == null)

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeParameterConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeParameterConstant.java
@@ -193,6 +193,13 @@ public class TypeParameterConstant
     // ----- IdentityConstant methods --------------------------------------------------------------
 
     @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new TypeParameterConstant(getConstantPool(), (MethodConstant) idParent, getName(),
+                getRegister());
+        }
+
+    @Override
     public IdentityConstant appendTrailingSegmentTo(IdentityConstant that)
         {
         return that.getConstantPool().ensureRegisterConstant(

--- a/javatools/src/main/java/org/xvm/asm/constants/TypedefConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypedefConstant.java
@@ -106,6 +106,15 @@ public class TypedefConstant
         }
 
 
+    // ----- IdentityConstant methods --------------------------------------------------------------
+
+    @Override
+    public IdentityConstant replaceParentConstant(IdentityConstant idParent)
+        {
+        return new TypedefConstant(getConstantPool(), idParent, getName());
+        }
+
+
     // ----- Constant methods ----------------------------------------------------------------------
 
     @Override

--- a/javatools/src/main/java/org/xvm/compiler/Compiler.java
+++ b/javatools/src/main/java/org/xvm/compiler/Compiler.java
@@ -7,6 +7,8 @@ import org.xvm.asm.ErrorListener;
 import org.xvm.asm.FileStructure;
 import org.xvm.asm.ModuleRepository;
 
+import org.xvm.asm.constants.ModuleConstant;
+
 import org.xvm.compiler.ast.StageMgr;
 import org.xvm.compiler.ast.TypeCompositionStatement;
 
@@ -154,9 +156,9 @@ public class Compiler
      *
      * @param repo  the module repository to use
      *
-     * @return a name of a first missing module, if any
+     * @return an id of a first missing module, if any
      */
-    public String linkModules(ModuleRepository repo)
+    public ModuleConstant linkModules(ModuleRepository repo)
         {
         validateCompiler();
         ensureReached(Stage.Registered);
@@ -171,14 +173,14 @@ public class Compiler
             {
             // first time through, load any module dependencies
             setStage(Stage.Loading);
-            String sMissing = m_structFile.linkModules(repo, false);
+            ModuleConstant idMissing = m_structFile.linkModules(repo, false);
 
-            if (sMissing == null)
+            if (idMissing == null)
                 {
                 setStage(Stage.Loaded);
                 }
 
-            return sMissing;
+            return idMissing;
             }
         }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameResolver.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameResolver.java
@@ -780,7 +780,7 @@ public class NameResolver
                             m_stage = Stage.ERROR;
                             return ResolutionResult.ERROR;
                             }
-                        id = component.getIdentityConstant();
+                        id = module.getIdentityConstant();
                         }
                     break;
 

--- a/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
@@ -127,9 +127,9 @@ public class NativeContainer
         fileRoot.linkModules(f_repository, true);
 
         // obtain the cloned modules that belong to the merged container
-        m_moduleSystem = (ModuleStructure) fileRoot.getChild(ECSTASY_MODULE);
-        m_moduleTurtle = (ModuleStructure) fileRoot.getChild(TURTLE_MODULE);
-        m_moduleNative = (ModuleStructure) fileRoot.getChild(NATIVE_MODULE);
+        m_moduleSystem = fileRoot.getChild(ECSTASY_MODULE);
+        m_moduleTurtle = fileRoot.getChild(TURTLE_MODULE);
+        m_moduleNative = fileRoot.getChild(NATIVE_MODULE);
 
         ConstantPool pool = fileRoot.getConstantPool();
         ConstantPool.setCurrentPool(pool);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
@@ -83,7 +83,7 @@ public class xRTCompiler
     public void initNative()
         {
         ClassStructure structRepo = f_container.getClassStructure("mgmt.ModuleRepository");
-        GET_MODULE_ID = structRepo.findMethod("getModule", 1).getIdentityConstant();
+        GET_MODULE_ID = structRepo.findMethod("getModule", 2).getIdentityConstant();
 
         markNativeMethod("compileImpl", null, null);
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
@@ -20,6 +20,7 @@ import org.xvm.asm.Op;
 import org.xvm.asm.Version;
 
 import org.xvm.asm.constants.MethodConstant;
+import org.xvm.asm.constants.ModuleConstant;
 import org.xvm.asm.constants.TypeConstant;
 
 import org.xvm.compiler.BuildRepository;
@@ -485,14 +486,14 @@ public class xRTCompiler
             // inline linkModules() implementation
             for (var compiler : compilers)
                 {
-                String sMissing = compiler.linkModules(repoLib);
-                if (sMissing != null)
+                ModuleConstant idMissing = compiler.linkModules(repoLib);
+                if (idMissing != null)
                     {
                     // save off the necessary state
                     m_compilers  = compilers;
                     m_repoOutput = repoOutput;
                     m_allNodes   = allNodes;
-                    return sMissing;
+                    return idMissing.getName();
                     }
                 }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
@@ -55,7 +55,7 @@ public class xCoreRepository
         m_clzRepo = ensureClass(f_container, typeInception, typeMask);
 
         markNativeProperty("moduleNames");
-        markNativeMethod("getModule", STRING, null);
+        markNativeMethod("getModule", null, null);
 
         typeInception.invalidateTypeInfo();
         }
@@ -89,7 +89,7 @@ public class xCoreRepository
         {
         switch (method.getName())
             {
-            case "getModule": // conditional ModuleTemplate getModule(String name)
+            case "getModule": // conditional ModuleTemplate getModule(String name, Version? version = Null)
                 {
                 String           sName  = ((StringHandle) ahArg[0]).getStringValue();
                 ModuleRepository repo   = f_container.getModuleRepository();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
@@ -17,6 +17,7 @@ import org.xvm.asm.FileStructure;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.ModuleStructure;
 import org.xvm.asm.Op;
+import org.xvm.asm.Version;
 
 import org.xvm.asm.constants.ModuleConstant;
 import org.xvm.asm.constants.TypeConstant;
@@ -74,7 +75,7 @@ public class xRTFileTemplate
         markNativeProperty("contents");
         markNativeProperty("createdMillis");
 
-        markNativeMethod("getModule", STRING, null);
+        markNativeMethod("extractVersionImpl", STRING, null);
         markNativeMethod("resolve", null, null);
         markNativeMethod("replace", null, null);
 
@@ -145,10 +146,27 @@ public class xRTFileTemplate
         FileStructure           file  = (FileStructure) hFile.getComponent();
         switch (method.getName())
             {
-            case "getModule": // conditional ModuleTemplate getModule(String name)
+            case "extractVersionImpl": // conditional ModuleTemplate extractVersionImpl(String version)
                 {
-                StringHandle    hName  = (StringHandle) ahArg[0];
-                ModuleStructure module = file.getChild(hName.getStringValue());
+                String sVersion = ((StringHandle) ahArg[0]).getStringValue();
+
+                ModuleStructure module;
+                if (sVersion.isEmpty())
+                    {
+                    module = file.getModule();
+                    }
+                else
+                    {
+                    Version version = new Version(sVersion);
+                    if (file.containsVersion(version))
+                        {
+                        module = file.extractVersion(version);
+                        }
+                    else
+                        {
+                        module = null;
+                        }
+                    }
                 return module == null
                     ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
                     : frame.assignValues(aiReturn,
@@ -264,16 +282,20 @@ public class xRTFileTemplate
         GenericArrayDelegate haGeneric = (GenericArrayDelegate) hArray.m_hDelegate;
         for (long i = 0, c = haGeneric.m_cSize; i < c; i++)
             {
-            ComponentTemplateHandle hModule           = (ComponentTemplateHandle) haGeneric.get(i);
-            ModuleStructure         moduleUnlinked    = (ModuleStructure) hModule.getComponent();
-            ModuleStructure         moduleFingerprint = file.getChild(moduleUnlinked.getName());
-            if (moduleFingerprint == null || !moduleFingerprint.isFingerprint())
+            ComponentTemplateHandle hModule        = (ComponentTemplateHandle) haGeneric.get(i);
+            ModuleStructure         moduleUnlinked = (ModuleStructure) hModule.getComponent();
+            ModuleStructure         moduleReplace  = file.getModule(moduleUnlinked.getIdentityConstant());
+
+            if (moduleReplace == null)
                 {
-                return frame.raiseException(
-                        (moduleFingerprint == null ? "Missing" : "Not a fingerprint") +
-                        " module \"" + moduleUnlinked.getName() + "\" at " + file.getModuleId());
+                return frame.raiseException("Missing module \"" + moduleUnlinked.getName() +
+                                            "\" at " + file.getModuleId());
                 }
-            listUnlinked.add(moduleUnlinked);
+
+            if (moduleReplace.isFingerprint())
+                {
+                listUnlinked.add(moduleUnlinked);
+                }
             }
         file.replace(listUnlinked);
         return Op.R_NEXT;
@@ -299,7 +321,7 @@ public class xRTFileTemplate
             {
             if (!idDep.equals(module.getIdentityConstant()))
                 {
-                ahModule[index++] = makeComponentHandle(container, file.getChild(idDep.getName()));
+                ahModule[index++] = makeComponentHandle(container, file.getModule(idDep));
                 }
             }
         assert index == cModules;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
@@ -148,7 +148,7 @@ public class xRTFileTemplate
             case "getModule": // conditional ModuleTemplate getModule(String name)
                 {
                 StringHandle    hName  = (StringHandle) ahArg[0];
-                ModuleStructure module = file.getModule(hName.getStringValue());
+                ModuleStructure module = file.getChild(hName.getStringValue());
                 return module == null
                     ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
                     : frame.assignValues(aiReturn,
@@ -222,12 +222,10 @@ public class xRTFileTemplate
 
         if (hRepo.getTemplate() instanceof xCoreRepository)
             {
-            String sMissing = file.linkModules(f_container.getModuleRepository(), true);
-            if (sMissing != null)
-                {
-                return frame.raiseException("Missing dependent module: " + sMissing);
-                }
-            return frame.assignValue(iReturn, makeHandle(container, file));
+            ModuleConstant idMissing = file.linkModules(f_container.getModuleRepository(), true);
+            return idMissing == null
+                    ? frame.assignValue(iReturn, makeHandle(container, file))
+                    : frame.raiseException("Missing dependent module: " + idMissing.getName());
             }
 
         ObjectHandle[] ahArg = new ObjectHandle[LINK_MODULES_METHOD.getMaxVars()];
@@ -268,12 +266,12 @@ public class xRTFileTemplate
             {
             ComponentTemplateHandle hModule           = (ComponentTemplateHandle) haGeneric.get(i);
             ModuleStructure         moduleUnlinked    = (ModuleStructure) hModule.getComponent();
-            ModuleStructure         moduleFingerprint = file.getModule(moduleUnlinked.getName());
+            ModuleStructure         moduleFingerprint = file.getChild(moduleUnlinked.getName());
             if (moduleFingerprint == null || !moduleFingerprint.isFingerprint())
                 {
                 return frame.raiseException(
                         (moduleFingerprint == null ? "Missing" : "Not a fingerprint") +
-                        " module \"" + moduleUnlinked.getName() + "\" at " + file.getModuleName());
+                        " module \"" + moduleUnlinked.getName() + "\" at " + file.getModuleId());
                 }
             listUnlinked.add(moduleUnlinked);
             }
@@ -301,7 +299,7 @@ public class xRTFileTemplate
             {
             if (!idDep.equals(module.getIdentityConstant()))
                 {
-                ahModule[index++] = makeComponentHandle(container, file.getModule(idDep.getName()));
+                ahModule[index++] = makeComponentHandle(container, file.getChild(idDep.getName()));
                 }
             }
         assert index == cModules;
@@ -316,7 +314,7 @@ public class xRTFileTemplate
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn)
         {
         FileStructure module = (FileStructure) ((ComponentTemplateHandle) hTarget).getComponent();
-        return frame.assignValue(iReturn, xString.makeHandle(module.getModuleName()));
+        return frame.assignValue(iReturn, xString.makeHandle(module.getModuleId().getName()));
         }
 
 

--- a/javatools/src/main/java/org/xvm/tool/Compiler.java
+++ b/javatools/src/main/java/org/xvm/tool/Compiler.java
@@ -18,6 +18,7 @@ import org.xvm.asm.ModuleRepository;
 import org.xvm.asm.ModuleStructure;
 import org.xvm.asm.Version;
 
+import org.xvm.asm.constants.ModuleConstant;
 import org.xvm.asm.constants.TypeConstant;
 
 import org.xvm.compiler.Token;
@@ -396,7 +397,7 @@ public class Compiler
                 return null;
                 }
 
-            String name = struct.getModuleName();
+            String name = struct.getModuleId().getName();
             if (mapCompilers.containsKey(name))
                 {
                 log(Severity.ERROR, "Duplicate module name: \"" + name + "\"");
@@ -446,11 +447,11 @@ public class Compiler
         {
         for (var compiler : compilers)
             {
-            String sMissing = compiler.linkModules(repo);
-            if (sMissing != null)
+            ModuleConstant idMissing = compiler.linkModules(repo);
+            if (idMissing != null)
                 {
                 compiler.getErrorListener().log(Severity.FATAL,
-                        org.xvm.compiler.Compiler.MODULE_MISSING, new String[]{sMissing}, null);
+                        org.xvm.compiler.Compiler.MODULE_MISSING, new String[]{idMissing.getName()}, null);
                 return;
                 }
             }

--- a/javatools/src/main/java/org/xvm/tool/Launcher.java
+++ b/javatools/src/main/java/org/xvm/tool/Launcher.java
@@ -28,6 +28,8 @@ import org.xvm.asm.LinkedRepository;
 import org.xvm.asm.ModuleRepository;
 import org.xvm.asm.ModuleStructure;
 
+import org.xvm.asm.constants.ModuleConstant;
+
 import org.xvm.compiler.BuildRepository;
 
 import org.xvm.tool.ModuleInfo.Node;
@@ -35,7 +37,6 @@ import org.xvm.tool.ModuleInfo.Node;
 import org.xvm.util.Handy;
 import org.xvm.util.ListMap;
 import org.xvm.util.Severity;
-
 
 import static org.xvm.tool.ModuleInfo.isExplicitCompiledFile;
 
@@ -1166,9 +1167,9 @@ public abstract class Launcher
                         {
                         sb.append(sIndent)
                           .append("   ")
-                          .append(entry.getKey())
+                          .append(e.getKey())
                           .append("=")
-                          .append(quotedString(String.valueOf(entry.getValue())))
+                          .append(quotedString(String.valueOf(e.getValue())))
                           .append('\n');
                         }
                     }
@@ -1397,11 +1398,11 @@ public abstract class Launcher
         FileStructure structEcstasy = moduleEcstasy.getFileStructure();
         if (structEcstasy != null)
             {
-            String sMissing = structEcstasy.linkModules(reposLib, false);
-            if (sMissing != null)
+            ModuleConstant idMissing = structEcstasy.linkModules(reposLib, false);
+            if (idMissing != null)
                 {
                 log(Severity.FATAL, "Unable to link module " + Constants.ECSTASY_MODULE
-                    + " due to missing module:" + sMissing);
+                    + " due to missing module:" + idMissing.getName());
                 }
             }
 
@@ -1414,11 +1415,11 @@ public abstract class Launcher
         FileStructure structTurtle = moduleTurtle .getFileStructure();
         if (structTurtle != null)
             {
-            String sMissing = structTurtle.linkModules(reposLib, false);
-            if (sMissing != null)
+            ModuleConstant idMissing = structTurtle.linkModules(reposLib, false);
+            if (idMissing != null)
                 {
                 log(Severity.FATAL, "Unable to link module " + Constants.TURTLE_MODULE
-                    + " due to missing module:" + sMissing);
+                    + " due to missing module:" + idMissing.getName());
                 }
             }
         }

--- a/javatools/src/main/java/org/xvm/tool/Launcher.java
+++ b/javatools/src/main/java/org/xvm/tool/Launcher.java
@@ -1412,7 +1412,7 @@ public abstract class Launcher
             log(Severity.FATAL, "Unable to load module: " + Constants.TURTLE_MODULE);
             }
 
-        FileStructure structTurtle = moduleTurtle .getFileStructure();
+        FileStructure structTurtle = moduleTurtle.getFileStructure();
         if (structTurtle != null)
             {
             ModuleConstant idMissing = structTurtle.linkModules(reposLib, false);

--- a/javatools/src/main/java/org/xvm/tool/ModuleInfo.java
+++ b/javatools/src/main/java/org/xvm/tool/ModuleInfo.java
@@ -670,13 +670,10 @@ public class ModuleInfo
                 try
                     {
                     FileStructure struct = new FileStructure(file);
-                    moduleName = struct.getModuleName();
-                    if (moduleName != null)
-                        {
-                        binaryVersion = struct.getModule().getVersion();
-                        binaryContent = Content.Module;
-                        return true;
-                        }
+                    moduleName    = struct.getModuleId().getName();
+                    binaryVersion = struct.getModule().getVersion();
+                    binaryContent = Content.Module;
+                    return true;
                     }
                 catch (Exception ignore) {}
                 }
@@ -1750,7 +1747,7 @@ public class ModuleInfo
                 {
                 try
                     {
-                    return new FileStructure(file).getModuleName();
+                    return new FileStructure(file).getModuleId().getName();
                     }
                 catch (IOException ignore) {}
                 }
@@ -2002,7 +1999,7 @@ public class ModuleInfo
         }
 
     /**
-     * Walk up the directory tree to find a project directory (or make a best guess).
+     * Walk up the directory tree to find a project directory (or make the best guess).
      *
      * @param dir  the directory to start from
      *
@@ -2012,8 +2009,8 @@ public class ModuleInfo
         {
         assert dir != null;
 
-        File   prjDir = null;
-        String name   = dir.getName();
+        String name = dir.getName();
+        File   prjDir;
         if (   "build" .equalsIgnoreCase(name)
             || "target".equalsIgnoreCase(name))
             {

--- a/javatools/src/test/java/org/xvm/asm/FileStructureTest.java
+++ b/javatools/src/test/java/org/xvm/asm/FileStructureTest.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import org.xvm.asm.ErrorListener.ErrorInfo;
 
-import org.xvm.asm.constants.ClassConstant;
-
 import org.xvm.compiler.Compiler;
 import org.xvm.compiler.CompilerException;
 import org.xvm.compiler.Parser;
@@ -36,12 +34,12 @@ import static org.xvm.util.Handy.byteArrayToHexDump;
  */
 public class FileStructureTest
     {
-    @Test @Disabled("TODO: Reenable test")
+    @Test @Disabled("TODO: Re-enable test")
     public void testEmptyModule()
             throws IOException
         {
         FileStructure structfile = new FileStructure("Test");
-        assertEquals("Test", structfile.getModuleName());
+        assertEquals("Test", structfile.getModuleId().getName());
         assertEquals("Test", structfile.getModule().getName());
         assertTrue(structfile.getModule().isPackageContainer());
         assertTrue(structfile.getModule().isClassContainer());
@@ -51,7 +49,7 @@ public class FileStructureTest
         testFileStructure(structfile);
         }
 
-    @Test @Disabled("TODO: Reenable test")
+    @Test @Disabled("TODO: Re-enable test")
     public void testMinimumModule()
             throws IOException
         {
@@ -61,7 +59,7 @@ public class FileStructureTest
         testFileStructure(structfile);
         }
 
-    @Test @Disabled("TODO: Reenable test")
+    @Test @Disabled("TODO: Re-enable test")
     public void testBaseClass()
             throws IOException
         {
@@ -81,11 +79,11 @@ public class FileStructureTest
                 "collections", null);
         ClassStructure structclz = structpkg.createClass(Constants.Access.PUBLIC,
                 Component.Format.INTERFACE, "List", null);
-        structclz.addTypeParam("Element", ((ClassConstant) structobj.getIdentityConstant()).getType());
+        structclz.addTypeParam("Element", structobj.getIdentityConstant().getType());
         testFileStructure(structfile);
         }
 
-    @Test @Disabled("TODO: Reenable test")
+    @Test @Disabled("TODO: Re-enable test")
     public void testMapClass()
             throws IOException
         {
@@ -95,11 +93,11 @@ public class FileStructureTest
         PackageStructure pkgColl = module.createPackage(Constants.Access.PUBLIC, "collections", null);
         ClassStructure   clzHash = pkgColl.createClass(Constants.Access.PUBLIC, Component.Format.INTERFACE, "Hashable", null);
         ClassStructure   clzMap  = pkgColl.createClass(Constants.Access.PUBLIC, Component.Format.INTERFACE, "Map", null);
-        clzMap.addTypeParam("Key", ((ClassConstant) clzObj.getIdentityConstant()).getType());
-        clzMap.addTypeParam("Value", ((ClassConstant) clzObj.getIdentityConstant()).getType());
+        clzMap.addTypeParam("Key", clzObj.getIdentityConstant().getType());
+        clzMap.addTypeParam("Value", clzObj.getIdentityConstant().getType());
         ClassStructure clzHashMap = pkgColl.createClass(Constants.Access.PUBLIC, Component.Format.CLASS, "HashMap", null);
-        clzHashMap.addTypeParam("Key", ((ClassConstant) clzHash.getIdentityConstant()).getType());
-        clzHashMap.addTypeParam("Value", ((ClassConstant) clzObj.getIdentityConstant()).getType());
+        clzHashMap.addTypeParam("Key", clzHash.getIdentityConstant().getType());
+        clzHashMap.addTypeParam("Value", clzObj.getIdentityConstant().getType());
         clzHashMap.addContribution(ClassStructure.Composition.Implements, clzMap.getIdentityConstant().getType());
 
         testFileStructure(file);
@@ -179,7 +177,7 @@ public class FileStructureTest
             }
 
         FileStructure structfile2 = new FileStructure(new ByteArrayInputStream(ab));
-        assertEquals(structfile.getModuleName(), structfile2.getModuleName());
+        assertEquals(structfile.getModuleId(), structfile2.getModuleId());
 
         if (DEBUG)
             {
@@ -205,19 +203,19 @@ public class FileStructureTest
                 FileStructure structfile3 = new FileStructure(new ByteArrayInputStream(ab2));
                 System.out.println("structfile3:");
                 structfile3.dump(new PrintWriter(System.out, true));
-                assertEquals(structfile.getModuleName(), structfile3.getModuleName());
+                assertEquals(structfile.getModuleId(), structfile3.getModuleId());
                 }
             }
 
         assertArrayEquals(ab, ab2);
         }
 
-    @Test @Disabled("TODO: Reenable test")
+    @Test @Disabled("TODO: Re-enable test")
     public void testFoo()
             throws IOException
         {
         FileStructure structfile = new FileStructure("test");
-        assertEquals("test", structfile.getModuleName());
+        assertEquals("test", structfile.getModuleId().getName());
 
         ModuleStructure  structmodule  = structfile.getModule();
         PackageStructure structpackage = structmodule.createPackage(Constants.Access.PUBLIC, "classes", null);

--- a/javatools_bridge/src/main/x/_native/mgmt/CoreRepository.x
+++ b/javatools_bridge/src/main/x/_native/mgmt/CoreRepository.x
@@ -4,18 +4,14 @@ import ecstasy.reflect.ModuleTemplate;
 
 const CoreRepository
         implements ModuleRepository {
-    @Override immutable Set<String> moduleNames.get() {TODO("Native");}
+    @Override immutable Set<String> moduleNames.get() = TODO("Native");
 
     @Override
-    conditional ModuleTemplate getModule(String name) {TODO("Native");}
+    conditional ModuleTemplate getModule(String name, Version? version = Null) = TODO("Native");
 
     @Override
-    void storeModule(ModuleTemplate template) {
-        throw new ReadOnly();
-    }
+    void storeModule(ModuleTemplate template) = throw new ReadOnly();
 
     @Override
-    String toString() {
-        return "CoreRepository";
-    }
+    String toString() = "CoreRepository";
 }

--- a/javatools_bridge/src/main/x/_native/reflect/RTFileTemplate.x
+++ b/javatools_bridge/src/main/x/_native/reflect/RTFileTemplate.x
@@ -10,16 +10,17 @@ class RTFileTemplate
         implements FileTemplate {
 
     @Override
-    ModuleTemplate mainModule.get()                     {TODO("native");}
+    ModuleTemplate mainModule.get() = TODO("native");
 
     @Override
-    RTFileTemplate resolve(ModuleRepository repository) {TODO("native");}
+    RTFileTemplate resolve(ModuleRepository repository) = TODO("native");
 
     @Override
-    conditional ModuleTemplate getModule(String name)   {TODO("native");}
+    conditional ModuleTemplate extractVersion(Version? version = Null) =
+            extractVersionImpl(version?.toString() : "");
 
     @Override
-    immutable Byte[] contents.get()                     {TODO("native");}
+    immutable Byte[] contents.get() = TODO("native");
 
     @Override
     Time? created.get() {
@@ -37,42 +38,46 @@ class RTFileTemplate
      * Called by native "resolve(ModuleRepository)". See FileStructure.java for the "original" code.
      */
     private RTFileTemplate linkModules(ModuleRepository repository) {
-        String      moduleName      = mainModule.name;
-        String[]    moduleNamesTodo = moduleNames.reify(Mutable);
-        Set<String> moduleNamesDone = new HashSet();
+        const ModuleId(String name, Version? version) {
+            construct(ModuleTemplate template) {
+                name    = template.qualifiedName;
+                version = template.version;
+            }
+        }
+
+        ModuleId      moduleId    = new ModuleId(mainModule);
+        Set<ModuleId> modulesDone = new HashSet();
 
         // the primary module is implicitly linked already
-        moduleNamesDone.add(moduleName);
+        modulesDone.add(moduleId);
 
+        ModuleTemplate[] modulesTodo       = modules.reify(Mutable);
         ModuleTemplate[] unresolvedModules = new ModuleTemplate[];
-        // iteratively link all downstream modules (moduleNamesTodo array may grow)
-        for (Int i = 0; i < moduleNamesTodo.size; ++i) {
-            String nextName = moduleNamesTodo[i];
+
+        // iteratively link all downstream modules (modulesTodo array may grow)
+        for (Int i = 0; i < modulesTodo.size; ++i) {
+            ModuleId nextId = new ModuleId(modulesTodo[i]);
 
             // only need to link it once (each node in the graph gets visited once)
-            if (moduleNamesDone.contains(nextName)) {
+            if (modulesDone.contains(nextId)) {
                 continue;
             }
-            moduleNamesDone.add(nextName);
-
-            ModuleTemplate nextModule;
-            if (nextModule := getModule(nextName), nextModule.resolved) {
-                continue;
-            }
+            modulesDone.add(nextId);
 
             // load the module against which the compilation will occur
-            assert ModuleTemplate unresolved := repository.getModule(nextName)
-                as $"Missing dependent module {nextName.quoted()}";
+            assert ModuleTemplate unresolved := repository.getModule(nextId.name, nextId.version)
+                as $"Missing dependent module {nextId}";
 
             unresolvedModules += unresolved;
-            moduleNamesTodo.addAll(unresolved.parent.as(FileTemplate).moduleNames);
+            modulesTodo.addAll(unresolved.parent.as(FileTemplate).modules);
         }
 
         replace(unresolvedModules);
         return this;
     }
 
-    private void replace(ModuleTemplate[] unresolvedModules) { TODO("native"); }
+    private conditional ModuleTemplate extractVersionImpl(String version) = TODO("native");
+    private void replace(ModuleTemplate[] unresolvedModules) = TODO("native");
 
-    private Int createdMillis.get() { TODO("native"); }
+    private Int createdMillis.get() = TODO("native");
 }

--- a/javatools_bridge/src/main/x/_native/reflect/RTModuleTemplate.x
+++ b/javatools_bridge/src/main/x/_native/reflect/RTModuleTemplate.x
@@ -1,6 +1,5 @@
 import ecstasy.reflect.ModuleTemplate;
 
-
 /**
  * The native reflected ModuleTemplate implementation.
  */
@@ -8,11 +7,16 @@ class RTModuleTemplate
         extends RTClassTemplate
         implements ModuleTemplate {
     @Override
-    String qualifiedName.get()                            {TODO("native");}
+    String qualifiedName.get() = TODO("native");
 
     @Override
-    immutable Map<String, String> moduleNamesByPath.get() {TODO("native");}
+    @Lazy Version? version.calc() = new Version(versionString?) : Null;
+
+    private String? versionString.get() = TODO("native");
 
     @Override
-    @RO Boolean resolved.get()                            {TODO("native");}
+    immutable Map<String, ModuleTemplate> modulesByPath.get() = TODO("native");
+
+    @Override
+    @RO Boolean resolved.get() = TODO("native");
 }

--- a/lib_ecstasy/src/main/x/ecstasy/mgmt/InstantRepository.x
+++ b/lib_ecstasy/src/main/x/ecstasy/mgmt/InstantRepository.x
@@ -27,10 +27,10 @@ const InstantRepository
     public/private immutable Set<String> moduleNames;
 
     @Override
-    conditional ModuleTemplate getModule(String name) {
+    conditional ModuleTemplate getModule(String name, Version? version = Null) {
         return name == moduleName
                 ? (True, template)
-                : (repository?.getModule(name) : False);
+                : (repository?.getModule(name, version) : False);
     }
 
     @Override

--- a/lib_ecstasy/src/main/x/ecstasy/mgmt/LinkedRepository.x
+++ b/lib_ecstasy/src/main/x/ecstasy/mgmt/LinkedRepository.x
@@ -27,9 +27,9 @@ service LinkedRepository(List<ModuleRepository> repos)
     }
 
     @Override
-    conditional ModuleTemplate getModule(String name) {
+    conditional ModuleTemplate getModule(String name, Version? version = Null) {
         for (ModuleRepository repo : repos) {
-            if (ModuleTemplate template := repo.getModule(name)) {
+            if (ModuleTemplate template := repo.getModule(name, version)) {
                 return True, template;
             }
         }
@@ -37,12 +37,8 @@ service LinkedRepository(List<ModuleRepository> repos)
     }
 
     @Override
-    void storeModule(ModuleTemplate template) {
-        repos[0].storeModule(template);
-    }
+    void storeModule(ModuleTemplate template) = repos[0].storeModule(template);
 
     @Override
-    String toString() {
-        return $"LinkRepository({repos})";
-    }
+    String toString() = $"LinkRepository({repos})";
 }

--- a/lib_ecstasy/src/main/x/ecstasy/mgmt/ModuleRepository.x
+++ b/lib_ecstasy/src/main/x/ecstasy/mgmt/ModuleRepository.x
@@ -11,27 +11,31 @@ interface ModuleRepository {
 
     /**
      * Obtain a module template for the specified module. Note, that the returned template may not
-     * be [resolved](`ModuleTemplate.resolved`)
+     * be [resolved](`ModuleTemplate.resolved`). If the version is specified, choose the module
+     * that [matches](Version.satisfies) that version.
      *
-     * @param name  the module name (qualified)
+     * @param name     the module name (qualified)
+     * @param version  (optional) the module version
      *
      * @return True iff the module exists
      * @return (conditional) the ModuleTemplate
      */
-    conditional ModuleTemplate getModule(String name);
+    conditional ModuleTemplate getModule(String name, Version? version = Null);
 
     /**
      * Obtain a resolved module template for the specified name.
      *
-     * @param name  the module name (qualified)
+     * @param name     the module name (qualified)
+     * @param version  (optional) the module version
      *
      * @return the resolved ModuleTemplate
      *
      * @throws IllegalArgument if the module does not exist
      * @throws Exception       if the module cannot be resolved
      */
-    ModuleTemplate getResolvedModule(String name) {
-        assert ModuleTemplate template := getModule(name) as $"Missing or corrupt module {name.quoted()}";
+    ModuleTemplate getResolvedModule(String name, Version? version = Null) {
+        assert ModuleTemplate template := getModule(name, version) as
+                $"Missing or corrupt module {name.quoted()} {version == Null ? "" : "v:" + version}";
         return template.parent.resolve(this).mainModule;
     }
 

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/ClassTemplate.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/ClassTemplate.x
@@ -629,8 +629,8 @@ interface ClassTemplate
                 return True, relPath;
             }
 
-            for ((String name, String qualifiedName) : mainModule.moduleNamesByPath) {
-                if (qualifiedName == moduleName) {
+            for ((String name, ModuleTemplate moduleDepends) : mainModule.modulesByPath) {
+                if (moduleDepends.qualifiedName == moduleName) {
                     return True, name + '.' + relPath;
                 }
             }

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/FileTemplate.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/FileTemplate.x
@@ -1,7 +1,7 @@
 import mgmt.ModuleRepository;
 
 /**
- * A FileTemplate is a representation of an Ecstasy portable binary (".xtc") file.
+ * `FileTemplate` is a representation of an Ecstasy portable binary (".xtc") file.
  */
 interface FileTemplate
         extends ComponentTemplate {
@@ -27,15 +27,20 @@ interface FileTemplate
     FileTemplate resolve(ModuleRepository repository);
 
     /**
-     * Obtain the specified module from the `FileTemplate`. Note that the returned template may not
-     * be [resolved](`ModuleTemplate.resolved`).
+     * Obtain the specified version of the main module from the `FileTemplate`.
      *
-     * @param name  the qualified module name
+     * If the version is specified, choose whichever of the present module versions
+     * [satisfies](Version.satisfies) it, otherwise take any available (latest) version.
      *
-     * @return True iff the module exists
-     * @return (conditional) the ModuleTemplate
+     * Note: the returned `ModuleTemplate` may not be [resolved](ModuleTemplate.resolved).
+     * Note2: the returned `ModuleTemplate` may have a different parent `FileTemplate`.
+     *
+     * @param version  (optional) the module version
+     *
+     * @return True iff there is a module that satisfies the specified version
+     * @return (conditional) the `ModuleTemplate`
      */
-    conditional ModuleTemplate getModule(String name);
+    conditional ModuleTemplate extractVersion(Version? version = Null);
 
     /**
      * The date/time at which the FileTemplate was created. The value is not `Null` for
@@ -49,12 +54,13 @@ interface FileTemplate
     @RO immutable Byte[] contents;
 
     /**
-     * An array of qualified module names contained within this `FileTemplate`.
+     * An array of modules contained within this `FileTemplate`.
+     *
+     * Note: the modules are most probably unresolved (fingerprints).
      */
-    @RO String[] moduleNames.get() {
+    @RO ModuleTemplate[] modules.get() {
         ComponentTemplate[] children = children();
-        return new String[](children.size, i -> children[i].as(ModuleTemplate).qualifiedName)
-                .freeze(True);
+        return new ModuleTemplate[](children.size, i -> children[i].as(ModuleTemplate)).freeze(True);
     }
 
     @Override

--- a/lib_ecstasy/src/main/x/ecstasy/reflect/ModuleTemplate.x
+++ b/lib_ecstasy/src/main/x/ecstasy/reflect/ModuleTemplate.x
@@ -9,10 +9,16 @@ interface ModuleTemplate
     @RO String qualifiedName;
 
     /**
-     * The modules that this module depends on by linkage, both directly and indirectly.
-     * The map's key is a module path; the value is the module qualified name.
+     * (Optional) The module version. For unresolved modules (fingerprints) it would indicate a
+     *            desired version.
      */
-    @RO immutable Map<String, String> moduleNamesByPath;
+    @RO Version? version;
+
+    /**
+     * The modules that this module depends on by linkage, both directly and indirectly.
+     * The map's key is a module path.
+     */
+    @RO immutable Map<String, ModuleTemplate> modulesByPath;
 
     /**
      * Module's parent is always a FileTemplate.
@@ -21,14 +27,10 @@ interface ModuleTemplate
     @RO FileTemplate parent;
 
     @Override
-    @RO ModuleTemplate containingModule.get() {
-        return this;
-    }
+    @RO ModuleTemplate containingModule.get() = this;
 
     @Override
-    @RO String path.get() {
-        return qualifiedName + ':';
-    }
+    @RO String path.get() = qualifiedName + ':';
 
     @Override
     @RO String displayName.get() {
@@ -44,13 +46,10 @@ interface ModuleTemplate
      */
     @RO Boolean resolved;
 
-
     // ----- Stringable methods --------------------------------------------------------------------
 
     @Override
-    Int estimateStringLength() {
-        return qualifiedName.size;
-    }
+    Int estimateStringLength() = qualifiedName.size;
 
     @Override
     Appender<Char> appendTo(Appender<Char> buf) = qualifiedName.appendTo(buf);

--- a/lib_jsondb/src/main/x/jsondb.x
+++ b/lib_jsondb/src/main/x/jsondb.x
@@ -282,12 +282,13 @@ module jsondb.xtclang.org {
      * [close](oodb.Connection.close()) it before terminating, at which point the database will be
      * shut down cleanly.
      *
-     * @param dbModuleName  the name of the database module
-     * @param dataDir       the directory to use for the database data
-     * @param buildDir      the directory to use for the auto-generated classes and modules
+     * @param moduleSpec  the name of the database module or the ModuleTemplate
+     * @param dataDir     the directory to use for the database data
+     * @param buildDir    the directory to use for the auto-generated classes and modules
+     * TODO
      */
     static oodb.Connection createConnection(String dbModuleName, Directory dataDir, Directory buildDir,
-                                            oodb.DBUser? user = Null) {
+                                            oodb.DBUser? user = Null, Version? version = Null) {
         import ecstasy.lang.src.Compiler;
 
         import ecstasy.mgmt.BasicResourceProvider;
@@ -306,7 +307,7 @@ module jsondb.xtclang.org {
 
         @Inject("repository") ModuleRepository coreRepo;
 
-        ModuleGenerator  gen  = new ModuleGenerator(dbModuleName);
+        ModuleGenerator  gen  = new ModuleGenerator(dbModuleName, version);
         ModuleRepository repo = new LinkedRepository([new DirRepository(buildDir), coreRepo].freeze(True));
         Log              log  = new SimpleLog();
 
@@ -316,9 +317,10 @@ module jsondb.xtclang.org {
             throw new Exception(log.toString());
         }
 
-        Container       container = new Container(dbTemplate, Lightweight, repo, new Injector(dataDir));
-        CatalogMetadata meta      = container.innerTypeSystem.primaryModule.as(CatalogMetadata);
-        Catalog         catalog   = meta.createCatalog(dataDir);
+        Container container = new Container(dbTemplate, Lightweight, repo, new Injector(dataDir));
+
+        CatalogMetadata meta    = container.innerTypeSystem.primaryModule.as(CatalogMetadata);
+        Catalog         catalog = meta.createCatalog(dataDir);
 
         catalog.ensureOpenDB(dbModuleName);
 

--- a/lib_jsondb/src/main/x/jsondb/tools/ModuleGenerator.x
+++ b/lib_jsondb/src/main/x/jsondb/tools/ModuleGenerator.x
@@ -16,20 +16,17 @@ import ecstasy.text.Log;
 
 import oodb.DBObject.DBCategory;
 
-
 /**
  * The jsondb-based ModuleGenerator.
+ *
+ * @param moduleName  the underlying (hosted) fully qualified module name
+ * @param version     (optional) the version of the underlying (hosted) module
  */
-class ModuleGenerator(String moduleName) {
+class ModuleGenerator(String moduleName, Version? version = Null) {
     /**
      * The implementation name.
      */
     protected String implName = "jsondb";
-
-    /**
-     * The underlying (hosted) fully qualified module name.
-     */
-    protected String moduleName;
 
     /**
      * Generic templates.
@@ -57,7 +54,8 @@ class ModuleGenerator(String moduleName) {
      */
     conditional ModuleTemplate ensureDBModule(
             ModuleRepository repository, Directory buildDir, Log errors) {
-        ModuleTemplate dbModule = repository.getResolvedModule(moduleName);
+
+        ModuleTemplate dbModule = repository.getResolvedModule(moduleName, version);
 
         String appName   = moduleName;
         String qualifier = "";
@@ -116,11 +114,13 @@ class ModuleGenerator(String moduleName) {
             ) :=
             createSchema(appName, moduleTemplate, appSchemaTemplate,
                          rootSchemaSourceTemplate, "", "", 0, errors)) {
-            String appSchema    = appSchemaTemplate.name;
-            String moduleSource = moduleSourceTemplate
+            String appSchema     = appSchemaTemplate.name;
+            String versionString = version == Null ? "" : $" v:{version}";
+            String moduleSource  = moduleSourceTemplate
                                     .replace("%appName%"             , appName)
                                     .replace("%appSchema%"           , appSchema)
                                     .replace("%qualifier%"           , qualifier)
+                                    .replace("%version%"             , versionString)
                                     .replace("%ChildrenIds%"         , childrenIds)
                                     .replace("%ChildrenNames%"       , childrenNames)
                                     .replace("%PropertyInfos%"       , propertyInfos)
@@ -518,7 +518,6 @@ class ModuleGenerator(String moduleName) {
         return customMethods;
     }
 
-
     // ----- common helper methods -----------------------------------------------------------------
 
     /**
@@ -709,7 +708,6 @@ class ModuleGenerator(String moduleName) {
         }
         return success;
     }
-
 
     // ----- constants -----------------------------------------------------------------------------
 

--- a/lib_jsondb/src/main/x/jsondb/tools/templates/_module.txt
+++ b/lib_jsondb/src/main/x/jsondb/tools/templates/_module.txt
@@ -10,7 +10,7 @@ module %appName%_jsondb%qualifier%
     import jsondb_.Client        as Client_;
     import jsondb_.model.DboInfo as DboInfo_;
 
-    package %appName%_ import %appName%%qualifier%;
+    package %appName%_ import %appName%%qualifier%%version%;
 
     import %appName%_.%appSchema% as RootSchema_;
 


### PR DESCRIPTION
As one of possible approaches for DB evolution, it would be quite useful to allow the evolution process to work with both "old" and "new" schemas within the same container. The driver code would have use the following pattern:
   
    package v1 import DB v:1.0;
    package v2 import DB v:2.0;

Then if would read "old" objects from the "old" DB (e.g. `v1.Person`), instantiate the corresponding "new" objects (e.g. `new v2.Person(...)`) and store into the "new" DB.

In order to allow that to work, we need to change the way `FileStructure` keeps the contained `ModuleStructure` objects based on their identity constant rather than the name, add the compiler awareness and fix the linking phase. Also we need to make corresponding changes in the natural ModuleRepository and FileStructure APIs