### PR TITLE
Fix an incorrect and-mask

### DIFF
--- a/lib_net/src/main/x/net/IPAddress.x
+++ b/lib_net/src/main/x/net/IPAddress.x
@@ -309,8 +309,8 @@ const IPAddress(Byte[] bytes)
                         return False;
                     }
                 } else if (ch == ':') {
-                    bytes[cell*2  ] = (n >> 8 ).toUInt8();
-                    bytes[cell*2+1] = (n & 0xF).toUInt8();
+                    bytes[cell*2  ] = (n >> 8  ).toUInt8();
+                    bytes[cell*2+1] = (n & 0xFF).toUInt8();
                     ++offset;
 
                     // check for "::"


### PR DESCRIPTION
The code masked only a nibble instead of a byte which caused incorrect results.