### PR TITLE
Added installWithLauncherScripts that uses the gradle application plugin to create working xec/xcc executable scripts for all platforms.

### DIFF
--- a/xdk/build.gradle.kts
+++ b/xdk/build.gradle.kts
@@ -300,9 +300,7 @@ private fun Distribution.contentSpec(distName: String, distVersion: String, dist
             into("javatools")
         }
         from(tasks.xtcVersionFile)
-        // Exclude ALL application plugin scripts by default
-        exclude("**/xdk")
-        exclude("**/xdk.bat") 
+        // Exclude launcher scripts by default - only include them based on LauncherType
         exclude("**/xcc")
         exclude("**/xec")
         exclude("**/xcc.bat")
@@ -322,17 +320,13 @@ private fun Distribution.contentSpec(distName: String, distVersion: String, dist
             }
             LauncherType.Scripts -> {
                 // Copy generated script launchers and rename them
-                from(layout.buildDirectory.dir("launcher-scripts")) {
-                    include("launch-xcc-script", "launch-xcc-script.bat")
-                    rename("launch-xcc-script", "xcc")
-                    rename("launch-xcc-script.bat", "xcc.bat")
-                    into("bin")
-                }
-                from(layout.buildDirectory.dir("launcher-scripts")) {
-                    include("launch-xec-script", "launch-xec-script.bat") 
-                    rename("launch-xec-script", "xec")
-                    rename("launch-xec-script.bat", "xec.bat")
-                    into("bin")
+                launcherScripts.keys.forEach { scriptName ->
+                    from(layout.buildDirectory.dir("launcher-scripts")) {
+                        include("launch-$scriptName-script", "launch-$scriptName-script.bat")
+                        rename("launch-$scriptName-script", scriptName)
+                        rename("launch-$scriptName-script.bat", "$scriptName.bat")
+                        into("bin")
+                    }
                 }
             }
             LauncherType.None -> {


### PR DESCRIPTION
# PR #289: Add installWithLauncherScripts Distribution Option

## Overview

This PR adds a new Gradle task called `installWithLauncherScripts` (and its corresponding distribution task `installWithLauncherScriptsDist`) that provides an **alternative** distribution option, rather than replacing the existing launcher mechanism.

## What This PR Actually Changes

### Adds a Third Distribution Option

The PR creates a new distribution variant alongside the existing ones:

1. **`installDist`** (existing): Creates a distribution with **no launchers** at all
1. **`installWithLaunchersDist`** (existing, default): Creates a distribution with **binary launchers** (`xec` and `xcc`) copied from checked-in precompiled binaries, as it always has
1. **`installWithLauncherScriptsDist`** (NEW): Creates a distribution where `xec` and `xcc` in the `bin/` directory are **script-based launchers** instead of binary executables

### Technical Implementation Details

- **Uses Gradle Application Plugin**: The new task leverages Gradle’s application plugin to generate platform-specific wrapper scripts
- **Same Functionality, Different Implementation**: The script-based `xec` and `xcc` provide the same functionality as the binary versions, but are implemented as shell scripts (Unix) and batch files (Windows)
- **Not Default**: This new option is **not enabled by default** and doesn’t change any existing build behavior
- **Optional Alternative**: Provides an alternative for users who prefer script-based launchers over binary ones

### Why This Addition Matters

1. **Eliminates Native Build Dependencies**: For users who choose this option, they don’t need the overhead of maintaining/building native binaries
1. **Easier Debugging**: Script launchers are human-readable and easier to modify or debug
1. **Reduced Platform Complexity**: No need to maintain separate native binaries for different platforms when using this option
1. **Testing Alternative**: Allows testing whether script-based launchers work as well as binary ones in practice

### Relationship to Existing System

- **Preserves Current Workflow**: The default `installWithLaunchersDist` continues to work exactly as before with binary launchers
- **Additive Change**: This is purely an addition that gives users more choice
- **Future Evaluation**: As noted in the PR description, this allows evaluation of whether script launchers are “as usable as the existing binary launchers”

### Future Considerations

The PR mentions that “Should they need to be native, we can graalVm the scripts to EXEs” - indicating that if the script approach proves viable, there’s still a path back to native executables using GraalVM’s native image compilation if performance requirements dictate it.

## Summary

This PR doesn’t replace anything - it adds a new optional distribution method that uses Gradle-generated script launchers instead of the traditional precompiled binary launchers, giving developers and users more flexibility in how they deploy and run the XTC toolchain.
