### PR TITLE
Fix isA() implementation for immutable types

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/Component.java
+++ b/javatools/src/main/java/org/xvm/asm/Component.java
@@ -3276,11 +3276,12 @@ public abstract class Component
 
                         if (typeContrib.isAccessSpecified())
                             {
-                            typeContribNew = pool.ensureAccessTypeConstant(typeContribNew, typeContrib.getAccess());
+                            typeContribNew = pool.ensureAccessTypeConstant(typeContribNew,
+                                    typeContrib.getAccess());
                             }
                         if (typeContrib.isImmutabilitySpecified())
                             {
-                            typeContribNew = pool.ensureImmutableTypeConstant(typeContribNew);
+                            typeContribNew = typeContribNew.freeze();
                             }
                         typeContrib = typeContribNew;
                         fNormalize  = false;

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -73,7 +73,7 @@ public class DifferenceTypeConstant
             return typeDiff.andNotInternal(type2);
             }
 
-        if (type1.isImmutabilitySpecified() && type2.isImmutableOnly())
+        if (type1.isImmutabilitySpecified() && type2.isOnlyImmutable())
             {
             // ((immutable X) - immutable) -> X
             return type1.removeImmutable();

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -109,6 +109,12 @@ public class DifferenceTypeConstant
         }
 
     @Override
+    public TypeConstant removeImmutable()
+        {
+        return cloneRelational(getConstantPool(), m_constType1.removeImmutable(), m_constType2);
+        }
+
+    @Override
     public TypeConstant freeze()
         {
         // the immutability of the second type is irrelevant
@@ -450,18 +456,21 @@ public class DifferenceTypeConstant
             TypeConstant typeCR   = ((FormalConstant) m_constType1.getDefiningConstant()).getConstraintType();
             TypeConstant typeSubR = typeCR.andNot(getConstantPool(), m_constType2);
 
-            if (typeLeft.isFormalType())
+            if (typeSubR != null)
                 {
-                // typeLeft is a formal type FL with a constraint of CL;
-                // the logic below implies that if (CR - X) is assignable to CL then (FR - X) is
-                // assignable to FL
-                TypeConstant typeCL = ((FormalConstant) typeLeft.getDefiningConstant()).getConstraintType();
-                return typeSubR.calculateRelation(typeCL);
-                }
-            else
-                {
-                // if (CR - X) is assignable to L then (FR - X) is assignable to L
-                return typeSubR.calculateRelation(typeLeft);
+                if (typeLeft.isFormalType())
+                    {
+                    // typeLeft is a formal type FL with a constraint of CL;
+                    // the logic below implies that if (CR - X) is assignable to CL then (FR - X) is
+                    // assignable to FL
+                    TypeConstant typeCL = ((FormalConstant) typeLeft.getDefiningConstant()).getConstraintType();
+                    return typeSubR.calculateRelation(typeCL);
+                    }
+                else
+                    {
+                    // if (CR - X) is assignable to L then (FR - X) is assignable to L
+                    return typeSubR.calculateRelation(typeLeft);
+                    }
                 }
             }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/ImmutableTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ImmutableTypeConstant.java
@@ -100,6 +100,12 @@ public class ImmutableTypeConstant
         }
 
     @Override
+    public boolean isOnlyImmutable()
+        {
+        return getUnderlyingType().equals(getConstantPool().typeObject());
+        }
+
+    @Override
     public TypeConstant freeze()
         {
         return this;
@@ -162,6 +168,7 @@ public class ImmutableTypeConstant
     @Override
     protected Relation calculateRelationToRight(TypeConstant typeRight)
         {
+        // the immutability aspect has already been checked at TypeConstant.calculateRelation()
         return getUnderlyingType().calculateRelationToRight(typeRight);
         }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/ImmutableTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ImmutableTypeConstant.java
@@ -41,6 +41,10 @@ public class ImmutableTypeConstant
             {
             throw new IllegalArgumentException("type required");
             }
+        if (!constType.isSingleDefiningConstant())
+            {
+            throw new IllegalArgumentException("immutability cannot be specified for a relational type");
+            }
 
         m_constType = constType;
         }
@@ -139,6 +143,26 @@ public class ImmutableTypeConstant
         return constResolved == constOriginal
                 ? this
                 : constResolved.freeze();
+        }
+
+    @Override
+    public TypeConstant resolveAutoNarrowing(ConstantPool pool, boolean fRetainParams,
+                                             TypeConstant typeTarget, IdentityConstant idCtx)
+        {
+        return getUnderlyingType()
+                .resolveAutoNarrowing(pool, fRetainParams, typeTarget, idCtx).freeze();
+        }
+
+    @Override
+    protected Relation calculateRelationToLeft(TypeConstant typeLeft)
+        {
+        return getUnderlyingType().calculateRelationToLeft(typeLeft.removeImmutable());
+        }
+
+    @Override
+    protected Relation calculateRelationToRight(TypeConstant typeRight)
+        {
+        return getUnderlyingType().calculateRelationToRight(typeRight);
         }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
@@ -713,6 +713,18 @@ public class IntersectionTypeConstant
         TypeConstant thisRight1 = getUnderlyingType();
         TypeConstant thisRight2 = getUnderlyingType2();
 
+        // if any of the right types is immutable, the entire intersection is immutable;
+        // don't discard that fact; for example:
+        // (immutable A) + B should be assignable to (immutable B)
+        if (thisRight1.isImmutable())
+            {
+            thisRight2 = thisRight2.freeze();
+            }
+        if (thisRight2.isImmutable())
+            {
+            thisRight1 = thisRight1.freeze();
+            }
+
         Relation rel1 = thisRight1.calculateRelation(typeLeft);
         Relation rel2 = thisRight2.calculateRelation(typeLeft);
         return rel1.bestOf(rel2);

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -6076,24 +6076,15 @@ public abstract class TypeConstant
             return Relation.INCOMPATIBLE;
             }
 
-        // check immutability modifiers
-        if (typeLeft.isImmutabilitySpecified())
+        // check immutability, but exclude formal type parameters and dynamic types that are handled
+        // quite specially in other assignability related methods. See for example:
+        // TypeConstant.calculateRelationToContribution(), ClassStructure.calculateAssignability(),
+        // TerminalTypeConstant.calculateRelationToLeft()
+        if (typeLeft.isImmutable() && !typeRight.isImmutable() &&
+                !typeLeft.isTypeParameter() && !typeLeft.isDynamicType())
             {
-            relation = typeRight.isImmutable()
-                    ? typeRight.removeImmutable().calculateRelation(typeLeft.removeImmutable())
-                    : Relation.INCOMPATIBLE;
-            mapRelations.put(typeLeft, relation);
-            return relation;
-            }
-
-        if (typeRight.isImmutabilitySpecified())
-            {
-            // even though we know that typeLeft doesn't specify immutability directly, relational
-            // types may contain components that do
-            relation = typeRight.removeImmutable().calculateRelation(typeLeft.removeImmutable());
-
-            mapRelations.put(typeLeft, relation);
-            return relation;
+            mapRelations.put(typeLeft, Relation.INCOMPATIBLE);
+            return Relation.INCOMPATIBLE;
             }
 
         // if either side is relational, defer the access test; it will come back for the underlying

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -235,7 +235,8 @@ public abstract class TypeConstant
      */
     public boolean isImmutableOnly()
         {
-        return isImmutable() && getUnderlyingType().equals(getConstantPool().typeObject());
+        return isImmutabilitySpecified() &&
+                getUnderlyingType().equals(getConstantPool().typeObject());
         }
 
     /**
@@ -951,13 +952,11 @@ public abstract class TypeConstant
         // if T1 == (immutable T0) and T2.isA(T0) then (T1 + T2) => immutable T2
         if (this instanceof ImmutableTypeConstant && that.isA(this.getUnderlyingType()))
             {
-            assert !that.isImmutable();
-            return pool.ensureImmutableTypeConstant(that);
+            return that.freeze();
             }
         if (that instanceof ImmutableTypeConstant && this.isA(that.getUnderlyingType()))
             {
-            assert !this.isImmutable();
-            return pool.ensureImmutableTypeConstant(this);
+            return this.freeze();
             }
 
         // if T1 == T0<E> and T2.isA(T0) then (T1 + T2) => T2<E + EC2>
@@ -1094,7 +1093,7 @@ public abstract class TypeConstant
                 TypeConstant typeUnion = typeThis.union(pool, typeThat);
                 if (typeUnion.isSingleUnderlyingClass(true))
                     {
-                    return pool.ensureImmutableTypeConstant(typeUnion);
+                    return typeUnion.freeze();
                     }
                 // atm, we don't allow (immutable (T1 | T2))
                 }
@@ -1454,8 +1453,8 @@ public abstract class TypeConstant
             }
 
         TypeConstant constOriginal = getUnderlyingType();
-        TypeConstant constResolved = constOriginal.resolveAutoNarrowing(
-                                                    pool, fRetainParams, typeTarget, idCtx);
+        TypeConstant constResolved = constOriginal.
+                resolveAutoNarrowing(pool, fRetainParams, typeTarget, idCtx);
         return constResolved == constOriginal
                 ? this
                 : cloneSingle(pool, constResolved);

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -231,12 +231,11 @@ public abstract class TypeConstant
         }
 
     /**
-     * @return true iff this TypeConstant refers to an immutable Object type
+     * @return true iff this TypeConstant refers to an "immutable Object" type
      */
-    public boolean isImmutableOnly()
+    public boolean isOnlyImmutable()
         {
-        return isImmutabilitySpecified() &&
-                getUnderlyingType().equals(getConstantPool().typeObject());
+        return false;
         }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeSequenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeSequenceTypeConstant.java
@@ -115,7 +115,7 @@ public class TypeSequenceTypeConstant
     @Override
     public boolean isImmutable()
         {
-        return true;
+        return false;
         }
 
     @Override

--- a/javatools/src/main/java/org/xvm/compiler/ast/DecoratedTypeExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/DecoratedTypeExpression.java
@@ -62,7 +62,7 @@ public class DecoratedTypeExpression
         return switch (keyword.getId())
             {
             case IMMUTABLE ->
-                pool().ensureImmutableTypeConstant(type.ensureTypeConstant(ctx, errs));
+                type.ensureTypeConstant(ctx, errs).freeze();
 
             case CONDITIONAL ->
                 // TODO

--- a/javatools/src/main/java/org/xvm/compiler/ast/ListExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ListExpression.java
@@ -261,7 +261,7 @@ public class ListExpression
         typeActual = pool.ensureParameterizedTypeConstant(typeActual, typeElement);
         if (typeElement.isImmutable() || typeElement.isService())
             {
-            typeActual = pool.ensureImmutableTypeConstant(typeActual);
+            typeActual = typeActual.freeze();
             }
 
         if (cExprs > 0)

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -900,7 +900,7 @@ public class NameExpression
                 }
             else
                 {
-                String sLabel = ((NameExpression) left).getName();
+                String sLabel = exprName.getName();
                 log(errs, Severity.ERROR, Compiler.LABEL_VARIABLE_ILLEGAL, sVar, sLabel);
                 return finishValidation(ctx, typeRequired, null, TypeFit.NoFit, null, errs);
                 }

--- a/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
@@ -458,7 +458,7 @@ public class NamedTypeExpression
 
         if (immutable != null)
             {
-            type = pool.ensureImmutableTypeConstant(type);
+            type = type.freeze();
             }
 
         return type;
@@ -807,7 +807,7 @@ public class NamedTypeExpression
 
         if (immutable != null)
             {
-            type = pool.ensureImmutableTypeConstant(type);
+            type = type.freeze();
             }
 
         TypeConstant typeType = type.getType();

--- a/javatools/src/main/java/org/xvm/compiler/ast/TupleExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TupleExpression.java
@@ -444,7 +444,7 @@ public class TupleExpression
             ArrayConstant constVal = null;
             if (aFieldVals != null)
                 {
-                typeResult = pool.ensureImmutableTypeConstant(typeResult);
+                typeResult = typeResult.freeze();
                 constVal   = pool.ensureTupleConstant(typeResult, aFieldVals);
                 }
 

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -2307,8 +2307,7 @@ public abstract class ClassTemplate
 
         if (sName.startsWith("immutable "))
             {
-            return pool.ensureImmutableTypeConstant(
-                    getClassType(sName.substring("immutable ".length()), template));
+            return getClassType(sName.substring("immutable ".length()), template).freeze();
             }
 
         if (sName.startsWith("@"))

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -374,11 +374,11 @@ public class xRTType
         // hArg may be a Type, a Method, or a Property
         if (hArg instanceof TypeHandle hTypeThat)
             {
-            if (hTypeThis.getUnsafeDataType().isImmutableOnly())
+            if (hTypeThis.getUnsafeDataType().isOnlyImmutable())
                 {
                 return ensureImmutable(frame, hTypeThat, iReturn);
                 }
-            if (hTypeThat.getUnsafeDataType().isImmutableOnly())
+            if (hTypeThat.getUnsafeDataType().isOnlyImmutable())
                 {
                 return ensureImmutable(frame, hTypeThis, iReturn);
                 }

--- a/javatools/src/main/java/org/xvm/runtime/template/xConst.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xConst.java
@@ -311,12 +311,10 @@ public class xConst
                                 }
                             else
                                 {
-                                TypeConstant typeExpected = frameCaller.poolContext().
-                                    ensureImmutableTypeConstant(typeOld);
                                 return frameCaller.raiseException(
                                     "The freeze() result type for the \"" + field.getName() +
                                     "\" field was illegally changed; \"" +
-                                    typeExpected.getValueString() + "\" expected, \"" +
+                                    typeOld.freeze().getValueString() + "\" expected, \"" +
                                     typeNew.getValueString() + "\" returned");
                                 }
                             }

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -1,21 +1,16 @@
-
 module TestSimple {
     @Inject Console console;
 
     void run() {
-        new Test().report();
+        Int[] ints = new Int[];
+        ints += 17;
+
+        assert ints.mutability == Mutable;
+        assert !ints.is(Const); // this used to throw
     }
 
-    class Base {
-        Object baseValue.get() = this;
-    }
+    interface DBMap<Key extends immutable Const, Value extends immutable Const> {}
 
-    class Test extends Base {
-        // this line below used to be allowed to compile and then would NPE at run-time
-        Base derivedValue = baseValue.as(Base);
-
-        void report() {
-            console.print(derivedValue);
-        }
-    }
+    // this used to be allowed to compile without "immutable" modifier
+    mixin FileChunkIds into DBMap<String, immutable Int[]> {}
 }


### PR DESCRIPTION
A number of DBObject derived types require `immutable Const` parameters, for example:

    `interface DBMap<Key extends immutable Const, Value extends immutable Const>`
    
However, the compiler would allow the following declaration:

    `mixin MyTable into DBMap<String, Int[]>`

instead of the correct one:

    `mixin MyTable into DBMap<String, immutable Int[]>`

This would result in a run-time exception.

This change fixes that compiler deficiency. An additional benefit is a compiler check for the actual value types for DBMap method calls, such as `put(key, value)`, forcing the value to be known an `immutable Const` at compile time