### PR TITLE
Add new GitHub Actions workflow structure (triggers disabled for testing)

### DIFF
--- a/.github/actions/publish-github-release/action.yml
+++ b/.github/actions/publish-github-release/action.yml
@@ -1,0 +1,232 @@
+#
+# Publishes XDK distribution to GitHub Release
+#
+# This action takes a build artifact and publishes it to a GitHub Release with
+# version-based naming. Supports both snapshot (overwrites) and release (tagged) modes.
+#
+name: 'Publish GitHub Release'
+description: 'Publishes XDK build artifact to GitHub Release with version-based naming'
+
+inputs:
+    artifact-path:
+        description: 'Path to the XDK distribution zip file (build artifact)'
+        required: true
+    xdk-version:
+        description: 'XDK version (e.g., 0.4.4-SNAPSHOT or 0.4.4)'
+        required: true
+    commit:
+        description: 'Commit SHA for release metadata'
+        required: true
+    repo:
+        description: 'Repository in format owner/repo'
+        required: true
+    github-token:
+        description: 'GitHub token with contents:write permission'
+        required: true
+    release-type:
+        description: 'Type of release: "snapshot" (overwrites) or "release" (tagged draft)'
+        required: true
+    release-tag:
+        description: 'Release tag (defaults: "xdk-snapshots" for snapshot, "v${VERSION}" for release)'
+        required: false
+
+outputs:
+    release-url:
+        description: 'URL of the published release'
+        value: ${{ steps.output-snapshot.outputs.release-url || steps.output-release.outputs.release-url }}
+    asset-name:
+        description: 'Name of the published asset'
+        value: ${{ steps.prepare.outputs.asset-name }}
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Prepare release asset
+          id: prepare
+          shell: bash
+          run: |
+              ARTIFACT_PATH="${{ inputs.artifact-path }}"
+              VERSION="${{ inputs.xdk-version }}"
+              COMMIT="${{ inputs.commit }}"
+              RELEASE_TYPE="${{ inputs.release-type }}"
+
+              echo "📦 Preparing GitHub Release"
+              echo "  Type:    $RELEASE_TYPE"
+              echo "  Version: $VERSION"
+              echo "  Commit:  $COMMIT"
+
+              # Verify artifact exists
+              if [ ! -f "$ARTIFACT_PATH" ]; then
+                  echo "❌ Artifact not found: $ARTIFACT_PATH"
+                  exit 1
+              fi
+
+              # Create version-named file
+              ASSET_NAME="xdk-${VERSION}.zip"
+              cp "$ARTIFACT_PATH" "$ASSET_NAME"
+              echo "📝 Created: $ASSET_NAME (from $(basename "$ARTIFACT_PATH"))"
+              ls -lh "$ASSET_NAME"
+
+              echo "asset-name=$ASSET_NAME" >> $GITHUB_OUTPUT
+
+        - name: Publish snapshot release
+          if: inputs.release-type == 'snapshot'
+          id: publish-snapshot
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+          run: |
+              ASSET_NAME="${{ steps.prepare.outputs.asset-name }}"
+              VERSION="${{ inputs.xdk-version }}"
+              COMMIT="${{ inputs.commit }}"
+              REPO="${{ inputs.repo }}"
+              RELEASE_TAG="${{ inputs.release-tag }}"
+
+              # Default to xdk-snapshots if not specified
+              if [ -z "$RELEASE_TAG" ]; then
+                  RELEASE_TAG="xdk-snapshots"
+              fi
+
+              echo "📥 Publishing snapshot to: $RELEASE_TAG"
+
+              # Create or update snapshot release
+              if gh release view "$RELEASE_TAG" --repo "$REPO" >/dev/null 2>&1; then
+                  echo "Uploading to existing snapshot release..."
+                  gh release upload "$RELEASE_TAG" "$ASSET_NAME" \
+                      --repo "$REPO" \
+                      --clobber
+              else
+                  echo "Creating new snapshot release..."
+                  gh release create "$RELEASE_TAG" \
+                      "$ASSET_NAME" \
+                      --repo "$REPO" \
+                      --title "XDK Snapshot Builds" \
+                      --notes "**Automated snapshot builds from master branch**
+
+              Latest snapshot version: **${VERSION}**
+              Build commit: \`${COMMIT}\`
+
+              Download the \`xdk-${VERSION}.zip\` asset below for the most recent snapshot build." \
+                      --prerelease \
+                      --latest=false
+              fi
+
+              echo "✅ Snapshot published: $ASSET_NAME"
+
+        - name: Get snapshot release URL
+          if: inputs.release-type == 'snapshot'
+          id: output-snapshot
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+          run: |
+              RELEASE_TAG="${{ inputs.release-tag }}"
+              if [ -z "$RELEASE_TAG" ]; then
+                  RELEASE_TAG="xdk-snapshots"
+              fi
+              RELEASE_URL=$(gh release view "$RELEASE_TAG" --repo "${{ inputs.repo }}" --json url --jq '.url')
+              echo "🔗 Release: $RELEASE_URL"
+              echo "release-url=$RELEASE_URL" >> $GITHUB_OUTPUT
+
+        - name: Publish draft release
+          if: inputs.release-type == 'release'
+          id: publish-release
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+          run: |
+              ASSET_NAME="${{ steps.prepare.outputs.asset-name }}"
+              VERSION="${{ inputs.xdk-version }}"
+              COMMIT="${{ inputs.commit }}"
+              REPO="${{ inputs.repo }}"
+              RELEASE_TAG="${{ inputs.release-tag }}"
+
+              # Default to v${VERSION} if not specified
+              if [ -z "$RELEASE_TAG" ]; then
+                  RELEASE_TAG="v${VERSION}"
+              fi
+
+              echo "🎉 Creating draft release: $RELEASE_TAG"
+
+              # Check if release already exists and delete it
+              if gh release view "$RELEASE_TAG" --repo "$REPO" >/dev/null 2>&1; then
+                  echo "⚠️  Release $RELEASE_TAG already exists, deleting..."
+                  gh release delete "$RELEASE_TAG" --yes --repo "$REPO"
+              fi
+
+              # Create draft release with Git tag
+              gh release create "$RELEASE_TAG" \
+                  "$ASSET_NAME" \
+                  --repo "$REPO" \
+                  --title "XDK ${VERSION}" \
+                  --notes "# XDK Release ${VERSION}
+
+              **This is a DRAFT release - review and manually publish when ready.**
+
+              ## What's Changed
+
+              <!-- TODO: Fill in release notes before publishing -->
+              - TODO: Add release notes
+              - TODO: Highlight major changes
+              - TODO: Document breaking changes (if any)
+
+              ## Installation
+
+              ### Homebrew
+              \`\`\`sh
+              brew tap xtclang/xvm
+              brew install xdk
+              \`\`\`
+
+              ### Maven
+              \`\`\`xml
+              <dependency>
+                  <groupId>org.xtclang</groupId>
+                  <artifactId>xdk</artifactId>
+                  <version>${VERSION}</version>
+              </dependency>
+              \`\`\`
+
+              ### Gradle Plugin
+              \`\`\`kotlin
+              plugins {
+                  id(\"org.xtclang.xtc-plugin\") version \"${VERSION}\"
+              }
+              \`\`\`
+
+              ### Direct Download
+              Download the \`xdk-${VERSION}.zip\` asset below.
+
+              ---
+
+              **Commit:** ${COMMIT}
+              **Built:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+              🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+                  --draft \
+                  --target "$COMMIT"
+
+              echo "✅ Draft release created: $RELEASE_TAG"
+
+        - name: Get release URL
+          if: inputs.release-type == 'release'
+          id: output-release
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github-token }}
+          run: |
+              RELEASE_TAG="${{ inputs.release-tag }}"
+              VERSION="${{ inputs.xdk-version }}"
+              if [ -z "$RELEASE_TAG" ]; then
+                  RELEASE_TAG="v${VERSION}"
+              fi
+              RELEASE_URL=$(gh release view "$RELEASE_TAG" --repo "${{ inputs.repo }}" --json url --jq '.url')
+              echo "🔗 Release: $RELEASE_URL"
+              echo "⚠️  IMPORTANT: This is a DRAFT release"
+              echo "   1. Review the release notes and edit as needed"
+              echo "   2. After Maven Central is released, manually publish this GitHub release"
+              echo "release-url=$RELEASE_URL" >> $GITHUB_OUTPUT
+
+branding:
+    icon: 'upload-cloud'
+    color: 'blue'

--- a/.github/actions/setup-xvm-project/action.yml
+++ b/.github/actions/setup-xvm-project/action.yml
@@ -1,0 +1,205 @@
+name: 'Setup XVM Project'
+description: 'Complete XVM project setup: extract versions from properties and optionally setup build environment (requires sources already checked out)'
+
+inputs:
+    setup-build:
+        description: 'Setup Java and Gradle build environment (set false for metadata-only jobs)'
+        required: false
+        default: 'true'
+    cache-read-only:
+        description: 'Set Gradle cache to read-only mode (only used if setup-build is true)'
+        required: false
+        default: 'false'
+    enable-debug:
+        description: 'Enable debug logging for Gradle and setup actions'
+        required: false
+        default: 'false'
+
+outputs:
+    java-version:
+        description: 'Java version from version.properties'
+        value: ${{ steps.get-versions.outputs.java-version }}
+    xdk-version:
+        description: 'XDK version from version.properties (e.g., 0.4.4-SNAPSHOT)'
+        value: ${{ steps.get-versions.outputs.xdk-version }}
+    xdk-version-release:
+        description: 'XDK release version with -SNAPSHOT stripped (e.g., 0.4.4)'
+        value: ${{ steps.get-versions.outputs.xdk-version-release }}
+    xdk-version-next-snapshot:
+        description: 'Next XDK snapshot version with patch bumped (e.g., 0.4.5-SNAPSHOT)'
+        value: ${{ steps.get-versions.outputs.xdk-version-next-snapshot }}
+    gradle-version:
+        description: 'Gradle version from gradle-wrapper.properties'
+        value: ${{ steps.get-versions.outputs.gradle-version }}
+    java-distribution:
+        description: 'Java distribution to use (temurin)'
+        value: ${{ steps.get-versions.outputs.java-distribution }}
+    gradle-options:
+        description: 'Standard Gradle command line options'
+        value: ${{ steps.get-versions.outputs.gradle-options }}
+    gradle-jvm-opts:
+        description: 'Standard Gradle JVM options (GRADLE_OPTS)'
+        value: ${{ steps.get-versions.outputs.gradle-jvm-opts }}
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Get versions from properties files
+          id: get-versions
+          shell: bash
+          run: |
+              if [ ! -f "version.properties" ]; then
+                  echo "❌ version.properties not found"
+                  exit 1
+              fi
+              if [ ! -f "gradle/wrapper/gradle-wrapper.properties" ]; then
+                  echo "❌ gradle/wrapper/gradle-wrapper.properties not found"
+                  exit 1
+              fi
+
+              JAVA_VERSION=$(grep "^org.xtclang.java.jdk=" version.properties | cut -d'=' -f2 | tr -d '\n\r ')
+              XDK_VERSION=$(grep "^xdk.version=" version.properties | cut -d'=' -f2 | tr -d '\n\r ')
+              GRADLE_VERSION=$(grep "^distributionUrl=" gradle/wrapper/gradle-wrapper.properties | sed 's/.*gradle-\(.*\)-bin.zip/\1/')
+
+              if [ -z "$JAVA_VERSION" ]; then
+                  echo "❌ org.xtclang.java.jdk not found in version.properties"
+                  exit 1
+              fi
+              if [ -z "$XDK_VERSION" ]; then
+                  echo "❌ xdk.version not found in version.properties"
+                  exit 1
+              fi
+              if [ -z "$GRADLE_VERSION" ]; then
+                  echo "❌ Could not extract Gradle version from gradle-wrapper.properties"
+                  exit 1
+              fi
+
+              # Compute release and next snapshot versions
+              if [[ "$XDK_VERSION" == *-SNAPSHOT ]]; then
+                  XDK_VERSION_RELEASE="${XDK_VERSION%-SNAPSHOT}"
+              else
+                  XDK_VERSION_RELEASE="$XDK_VERSION"
+              fi
+
+              # Validate semantic versioning format
+              if ! [[ "$XDK_VERSION_RELEASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "⚠️  WARNING: Version does not follow semantic versioning: $XDK_VERSION_RELEASE"
+                  echo "⚠️  Next snapshot calculation may be incorrect"
+                  XDK_VERSION_NEXT_SNAPSHOT="$XDK_VERSION_RELEASE-SNAPSHOT"
+              else
+                  # Parse semantic version and bump patch
+                  IFS='.' read -r MAJOR MINOR PATCH <<< "$XDK_VERSION_RELEASE"
+                  NEXT_PATCH=$((PATCH + 1))
+                  XDK_VERSION_NEXT_SNAPSHOT="$MAJOR.$MINOR.$NEXT_PATCH-SNAPSHOT"
+              fi
+
+              # Standard build configuration
+              JAVA_DISTRIBUTION="temurin"
+              GRADLE_OPTIONS="-Dorg.gradle.vfs.verbose=false --stacktrace --console=plain"
+              GRADLE_JVM_OPTS="-Xmx4g -XX:+UseStringDeduplication"
+
+              # Compute Kotlin toolchain Java version (main version - 1)
+              KOTLIN_JAVA_VERSION=$((JAVA_VERSION - 1))
+
+              echo "📋 Java Version             : $JAVA_VERSION"
+              echo "📋 Java Version (Kotlin)    : $KOTLIN_JAVA_VERSION"
+              echo "📋 XDK Version              : $XDK_VERSION"
+              echo "📋 XDK Version (Release)    : $XDK_VERSION_RELEASE"
+              echo "📋 XDK Version (Next)       : $XDK_VERSION_NEXT_SNAPSHOT"
+              echo "📋 Gradle Version           : $GRADLE_VERSION"
+              echo "📋 Java Distribution        : $JAVA_DISTRIBUTION"
+              echo "📋 Gradle Options           : $GRADLE_OPTIONS"
+              echo "📋 Gradle JVM Options       : $GRADLE_JVM_OPTS"
+
+              echo "java-version=$JAVA_VERSION" >> $GITHUB_OUTPUT
+              echo "xdk-version=$XDK_VERSION" >> $GITHUB_OUTPUT
+              echo "xdk-version-release=$XDK_VERSION_RELEASE" >> $GITHUB_OUTPUT
+              echo "xdk-version-next-snapshot=$XDK_VERSION_NEXT_SNAPSHOT" >> $GITHUB_OUTPUT
+              echo "gradle-version=$GRADLE_VERSION" >> $GITHUB_OUTPUT
+              echo "java-distribution=$JAVA_DISTRIBUTION" >> $GITHUB_OUTPUT
+              echo "gradle-options=$GRADLE_OPTIONS" >> $GITHUB_OUTPUT
+              echo "gradle-jvm-opts=$GRADLE_JVM_OPTS" >> $GITHUB_OUTPUT
+              echo "kotlin-java-version=$KOTLIN_JAVA_VERSION" >> $GITHUB_OUTPUT
+
+        - name: Display workflow context
+          shell: bash
+          run: |
+              echo ""
+              echo "=================================================="
+
+              # Determine branch name and context
+              BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+              IS_MASTER="false"
+              [ "$BRANCH_NAME" = "master" ] && IS_MASTER="true"
+              IS_MANUAL="false"
+              [ "${{ github.event_name }}" = "workflow_dispatch" ] && IS_MANUAL="true"
+
+              # Master + Manual dispatch
+              if [ "$IS_MASTER" = "true" ] && [ "$IS_MANUAL" = "true" ]; then
+                  echo "🔵 MASTER - MANUAL DISPATCH"
+                  echo "   CI Build: ✅  Publishing: ✅"
+                  echo "=================================================="
+                  echo ""
+                  exit 0
+              fi
+
+              # Master + Automatic
+              if [ "$IS_MASTER" = "true" ]; then
+                  echo "🟢 MASTER - PUSH/PR"
+                  echo "   CI Build: ✅  Publishing: ✅"
+                  echo "=================================================="
+                  echo ""
+                  exit 0
+              fi
+
+              # Non-master + Manual dispatch (testing)
+              if [ "$IS_MANUAL" = "true" ]; then
+                  echo "🟠 BRANCH - MANUAL DISPATCH (TESTING MODE)"
+                  echo "   CI Build: ✅  Publishing: ✅ ⚠️"
+                  echo "   Branch: $BRANCH_NAME"
+                  echo "   Testing full publishing pipeline without merging to master"
+                  echo "=================================================="
+                  echo ""
+                  exit 0
+              fi
+
+              # Non-master + Automatic (default case)
+              echo "⚪ BRANCH - PUSH/PR"
+              echo "   CI Build: ✅  Publishing: ❌"
+              echo "   Branch: $BRANCH_NAME"
+              echo "=================================================="
+              echo ""
+
+        - name: Setup Java for Kotlin toolchain
+          if: ${{ inputs.setup-build == 'true' }}
+          uses: actions/setup-java@v4
+          with:
+              distribution: ${{ steps.get-versions.outputs.java-distribution }}
+              java-version: ${{ steps.get-versions.outputs.kotlin-java-version }}
+
+        - name: Setup Java (main)
+          if: ${{ inputs.setup-build == 'true' }}
+          id: setup-java
+          uses: actions/setup-java@v4
+          with:
+              distribution: ${{ steps.get-versions.outputs.java-distribution }}
+              java-version: ${{ steps.get-versions.outputs.java-version }}
+
+        - name: Setup Gradle
+          if: ${{ inputs.setup-build == 'true' }}
+          uses: gradle/actions/setup-gradle@v4
+          with:
+              cache-disabled: false
+              cache-read-only: ${{ inputs.cache-read-only }}
+              gradle-version: ${{ steps.get-versions.outputs.gradle-version }}
+          env:
+              GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: ${{ inputs.enable-debug }}
+              ACTIONS_STEP_DEBUG: ${{ inputs.enable-debug }}
+
+        - name: Validate Gradle Wrapper
+          if: ${{ inputs.setup-build == 'true' }}
+          uses: gradle/actions/wrapper-validation@v4
+
+branding:
+    icon: 'package'
+    color: 'purple'

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,190 @@
+#
+# GitHub runner workflow for building, verifying and testing the XVM repo.
+#
+# This is the main CI workflow that runs on every push. It builds the XDK,
+# runs tests, and uploads build artifacts. Other workflows (snapshot-release,
+# maven-publish-snapshot, docker-build, homebrew-update) depend on this workflow
+# and are triggered automatically on master branch or manually from any branch.
+#
+# PLATFORM NOTES:
+# - Ubuntu: ubuntu-latest (currently Ubuntu 22.04)
+# - Windows: windows-latest
+#
+name: VerifyCommit
+
+permissions:
+    contents: write
+    actions: read
+
+on:
+    # AUTOMATIC TRIGGERS DISABLED FOR TESTING
+    # Uncomment the following lines to enable automatic CI on push/PR:
+    # push:
+    # pull_request:
+
+    # Manual trigger - optionally triggers publishing workflows after successful completion
+    # This allows testing the full publishing pipeline (snapshot, docker, homebrew) from any branch
+    # without pushing to master. Set test-publishing=true to trigger publishing workflows.
+    workflow_dispatch:
+        inputs:
+            test-publishing:
+                description: 'Trigger publishing workflows after build (snapshot, docker, homebrew)'
+                type: boolean
+                required: false
+                default: false
+            platforms:
+                description: 'Run only single platform (ubuntu-latest, windows-latest, or all platforms)'
+                type: choice
+                required: false
+                default: 'all'
+                options:
+                    - 'all'
+                    - 'ubuntu-latest'
+                    - 'windows-latest'
+            extra-gradle-options:
+                description: 'Extra Gradle options to pass to the build'
+                required: false
+            test:
+                description: 'Run manual tests'
+                type: boolean
+                required: false
+                default: true
+            parallel-test:
+                description: 'Run manual tests in parallel mode'
+                type: boolean
+                required: false
+                default: false
+
+env:
+    # Add manual tests as an included build to the composite build configuration
+    ORG_GRADLE_PROJECT_includeBuildManualTests: true
+    ORG_GRADLE_PROJECT_includeBuildAttachManualTests: true
+    ORG_GRADLE_PROJECT_xtcPluginOverrideVerboseLogging: true
+
+    # Optional flags to control manual tests
+    run_manual_tests: ${{ github.event.inputs.test != 'false' }}
+    run_manual_tests_parallel: ${{ github.event.inputs.parallel-test == 'true' }}
+
+    # Gradle cache inspection function
+    GRADLE_CACHE_INSPECT: |
+        inspect_gradle_cache() {
+            local label="${1:-}"
+            local gradle_home="${GRADLE_USER_HOME:-$HOME/.gradle}"
+            echo "🔍 Gradle Cache Inspection${label:+ ($label)}:"
+            echo "  Cache location: $gradle_home"
+            if [ ! -d "$gradle_home" ]; then
+                echo "  Cache exists: ❌"
+                return 0
+            fi
+            echo "  Cache exists: ✅"
+            local total_size=$(du -sh "$gradle_home" 2>/dev/null | cut -f1 || echo "unknown")
+            echo "  Cache size: $total_size"
+            for dir in caches wrapper build-cache; do
+                if [ -d "$gradle_home/$dir" ]; then
+                    local dir_size=$(du -sh "$gradle_home/$dir" 2>/dev/null | cut -f1 || echo "unknown")
+                    echo "    $dir: $dir_size"
+                fi
+            done
+        }
+
+# Concurrency settings: group by workflow and ref, cancel intermediate builds except on master
+concurrency:
+    group: "${{ github.workflow }}-${{ github.ref }}"
+    cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+    build-and-test:
+        strategy:
+            matrix:
+                os: ${{ github.event.inputs.platforms == 'ubuntu-latest' && fromJSON('["ubuntu-latest"]') || github.event.inputs.platforms == 'windows-latest' && fromJSON('["windows-latest"]') || fromJSON('["ubuntu-latest", "windows-latest"]') }}
+
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: true
+                  cache-read-only: false
+                  enable-debug: true
+
+            - name: Debug Environment (Windows)
+              if: runner.os == 'Windows'
+              shell: bash
+              run: |
+                  echo "=== Windows Debug Information ==="
+                  echo "OS: $RUNNER_OS"
+                  echo "Operating System: $(uname -a 2>/dev/null || echo 'N/A')"
+                  echo "Java version:"
+                  java -version 2>&1 || echo "Java not available"
+                  echo "=== End Debug Information ==="
+
+            - name: Dump environment info
+              shell: bash
+              run: |
+                  echo "*** Branch (github.ref)    : ${{ github.ref }}"
+                  echo "*** Commit (github.sha)    : ${{ github.sha }}"
+                  echo "*** Runner OS              : ${{ runner.os }}"
+                  echo "*** XDK Version            : ${{ steps.versions.outputs.xdk-version }}"
+                  echo "*** Java Version           : ${{ steps.versions.outputs.java-version }}"
+
+            - name: Build the XDK and create a distribution
+              shell: bash
+              env:
+                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
+              run: |
+                  ${{ env.GRADLE_CACHE_INSPECT }}
+
+                    # Combine standard options with optional extra options
+                    GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }} ${{ github.event.inputs.extra-gradle-options }}"
+
+                    cwd_path=$(pwd)
+                  echo "Executing Gradle 'clean', 'check', and 'distZip' tasks from: '$cwd_path'"
+                    ls -la build/ 2>/dev/null && echo "Build directory exists - will be cleaned" || echo "✅ No previous build outputs"
+
+                    inspect_gradle_cache "before build"
+                    ./gradlew $GRADLE_OPTIONS clean --info
+                    ./gradlew $GRADLE_OPTIONS check -Porg.xtclang.java.lint=true -Porg.xtclang.java.warningsAsErrors=false -Porg.xtclang.java.test.stdout=true
+                  ./gradlew $GRADLE_OPTIONS :xdk:distZip
+
+                    # Run manual tests inline if enabled (avoids cache rebuild)
+                    if [ "${{ env.run_manual_tests }}" != "true" ]; then
+                        echo "⏭️ Manual tests skipped (disabled)"
+                        exit 0
+                    fi
+                    echo "🧪 Running manual tests inline (cache still hot)..."
+                    inspect_gradle_cache "before manual tests"
+                  ./gradlew $GRADLE_OPTIONS manualTests:runXtc
+                  ./gradlew $GRADLE_OPTIONS manualTests:runOne -PtestName=TestMisc
+                  ./gradlew $GRADLE_OPTIONS manualTests:runTwoTestsInSequence
+                    MANUAL_TASK=$( [ "${{ env.run_manual_tests_parallel }}" = "true" ] && echo "runParallel" || echo "runAllTestTasks" )
+                  echo "Running manual tests: $MANUAL_TASK"
+                  ./gradlew $GRADLE_OPTIONS manualTests:$MANUAL_TASK
+                    inspect_gradle_cache "after manual tests"
+                    echo "✅ Manual tests completed"
+
+            - name: Upload XDK distribution artifact
+              if: success() && matrix.os == 'ubuntu-latest'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: xdk-dist-${{ github.sha }}
+                  path: xdk/build/distributions/xdk-*.zip
+                  retention-days: 10
+
+            - name: Summary
+              if: success()
+              shell: bash
+              run: |
+                  echo "### ✅ Build and Test Completed" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Version:** ${{ steps.versions.outputs.xdk-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Java Version:** ${{ steps.versions.outputs.java-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,0 +1,172 @@
+#
+# GitHub workflow for updating Homebrew tap
+#
+# This workflow updates the Homebrew formula with the latest XDK snapshot release.
+# It triggers automatically on master after CI completes, or can be manually triggered.
+#
+name: Update Homebrew
+
+permissions:
+    contents: read
+    actions: read
+
+on:
+    # AUTOMATIC TRIGGERS DISABLED FOR TESTING
+    # Uncomment the following lines to enable automatic publishing after CI:
+    # workflow_run:
+    #     workflows: ["VerifyCommit"]
+    #     types: [completed]
+
+    # Manual trigger from any branch
+    workflow_dispatch:
+        inputs:
+            ci-run-id:
+                description: 'CI run ID to download artifact from (required for manual trigger)'
+                required: true
+            xdk-version:
+                description: 'XDK version to publish (leave empty to use latest from version.properties)'
+                required: false
+
+jobs:
+    update-homebrew:
+        name: Update Homebrew tap
+        runs-on: ubuntu-latest
+        # Only run if:
+        # - Manual trigger, OR
+        # - CI succeeded AND (master branch OR manually dispatched CI with test-publishing=true)
+        if: |
+            github.event_name == 'workflow_dispatch' ||
+            (github.event.workflow_run.conclusion == 'success' &&
+             (github.event.workflow_run.head_branch == 'master' ||
+              (github.event.workflow_run.event == 'workflow_dispatch' &&
+               github.event.workflow_run.inputs.test-publishing == 'true')))
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: false  # Only need version info, no Java/Gradle needed
+
+            - name: Determine XDK version
+              id: version
+              shell: bash
+              run: |
+                  if [ -n "${{ github.event.inputs.xdk-version }}" ]; then
+                      VERSION="${{ github.event.inputs.xdk-version }}"
+                      echo "Using manual version: $VERSION"
+                  else
+                      VERSION="${{ steps.versions.outputs.xdk-version }}"
+                      echo "Using version from version.properties: $VERSION"
+                  fi
+                  echo "xdk-version=$VERSION" >> $GITHUB_OUTPUT
+
+            - name: Determine commit and run ID
+              id: commit
+              shell: bash
+              run: |
+                  # Use workflow_run commit if triggered automatically
+                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
+                      GH_COMMIT="${{ github.event.workflow_run.head_sha }}"
+                      RUN_ID="${{ github.event.workflow_run.id }}"
+                      echo "📌 Using commit from workflow_run: $GH_COMMIT (run: $RUN_ID)"
+                  # Use manual input (required for manual trigger)
+                  else
+                      RUN_ID="${{ github.event.inputs.ci-run-id }}"
+                      # Get commit from the specified run
+                      GH_COMMIT=$(gh api /repos/${{ github.repository }}/actions/runs/$RUN_ID --jq '.head_sha')
+                      echo "📌 Using CI run from input: $RUN_ID (commit: $GH_COMMIT)"
+                  fi
+                  echo "commit=$GH_COMMIT" >> $GITHUB_OUTPUT
+                  echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+
+            - name: Download XDK build artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: xdk-dist-${{ steps.commit.outputs.commit }}
+                  path: ./artifacts
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  repository: ${{ github.repository }}
+                  run-id: ${{ steps.commit.outputs.run-id }}
+
+            - name: Update Homebrew formula
+              env:
+                  HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+              run: |
+                  echo "🍺 Updating Homebrew tap..."
+
+                  if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+                      echo "❌ HOMEBREW_TAP_TOKEN secret not configured"
+                      echo "⚠️ Cannot update Homebrew tap without token"
+                      exit 1
+                  fi
+
+                  # Get SHA256 from build artifact
+                  XDK_ZIP=$(find ./artifacts -name "xdk-*.zip" | head -1)
+                  if [ -z "$XDK_ZIP" ]; then
+                      echo "❌ No XDK artifact found"
+                      exit 1
+                  fi
+                  SHA256=$(sha256sum "$XDK_ZIP" | cut -d' ' -f1)
+
+                  # Build release URL and dynamic version
+                  VERSION="${{ steps.version.outputs.xdk-version }}"
+                  RELEASE_NAME="xdk-${VERSION}.zip"
+                  RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/xdk-snapshots/$RELEASE_NAME"
+
+                  # Use timestamp for dynamic versioning - ensures brew upgrade works correctly
+                  BUILD_TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+                  DYNAMIC_VERSION="$VERSION.$BUILD_TIMESTAMP"
+                  GH_COMMIT="${{ steps.commit.outputs.commit }}"
+
+                  echo "Formula details:"
+                  echo "  Version:  $VERSION"
+                  echo "  Dynamic:  $DYNAMIC_VERSION"
+                  echo "  Commit:   $GH_COMMIT"
+                  echo "  URL:      $RELEASE_URL"
+                  echo "  SHA256:   $SHA256"
+
+                  # Clone homebrew tap
+                  git clone https://oauth2:${HOMEBREW_TAP_TOKEN}@github.com/xtclang/homebrew-xvm.git homebrew-tap
+                  cd homebrew-tap
+
+                  # Update formula using template
+                  cp ../.github/scripts/xdk-latest.rb.template Formula/xdk-latest.rb
+                  sed -i.bak \
+                      -e "s|{{RELEASE_URL}}|$RELEASE_URL|g" \
+                      -e "s|{{DYNAMIC_VERSION}}|$DYNAMIC_VERSION|g" \
+                      -e "s|{{SHA256}}|$SHA256|g" \
+                      -e "s|{{JAVA_VERSION}}|${{ steps.versions.outputs.java-version }}|g" \
+                      Formula/xdk-latest.rb
+                  rm Formula/xdk-latest.rb.bak
+                  echo "Wrote new brew formula:"
+                  cat Formula/xdk-latest.rb
+
+                  # Commit and push
+                  echo "Committing and pushing changes to homebrew tap repo..."
+                  git config user.name "GitHub Actions"
+                  git config user.email "actions@github.com"
+                  git add Formula/xdk-latest.rb
+                  git commit -m "Update XDK to $DYNAMIC_VERSION (commit: $GH_COMMIT)"
+                  git push
+                  echo "✅ Homebrew tap updated to $DYNAMIC_VERSION"
+
+            - name: Summary
+              if: success()
+              run: |
+                  echo "### ✅ Homebrew Tap Updated" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Version:** ${{ steps.version.outputs.xdk-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "Users can now install with:" >> $GITHUB_STEP_SUMMARY
+                  echo '```bash' >> $GITHUB_STEP_SUMMARY
+                  echo "brew tap xtclang/xvm" >> $GITHUB_STEP_SUMMARY
+                  echo "brew install xdk" >> $GITHUB_STEP_SUMMARY
+                  echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,310 @@
+#
+# GitHub workflow for building and publishing Docker images
+#
+# This workflow builds multi-platform Docker images (amd64/arm64) and pushes them to GHCR.
+# It triggers automatically on master after CI completes, or can be manually triggered.
+#
+name: Build Docker Images
+
+permissions:
+    contents: read
+    packages: write
+    actions: read
+
+on:
+    # AUTOMATIC TRIGGERS DISABLED FOR TESTING
+    # Uncomment the following lines to enable automatic publishing after CI:
+    # workflow_run:
+    #     workflows: ["VerifyCommit"]
+    #     types: [completed]
+
+    # Manual trigger from any branch
+    workflow_dispatch:
+        inputs:
+            ci-run-id:
+                description: 'CI run ID to download artifact from (required for manual trigger)'
+                required: true
+            skip-tests:
+                description: 'Skip Docker image tests'
+                type: boolean
+                required: false
+                default: false
+            cleanup:
+                description: 'Run Docker package cleanup after build'
+                type: boolean
+                required: false
+                default: true
+
+env:
+    # Build configuration pulled from get-versions action
+    DOCKER_BASE_IMAGE: ghcr.io/xtclang/xvm
+    GH_COMMIT: ${{ github.sha }}
+    GH_BRANCH: ${{ github.ref_name }}
+
+jobs:
+    compute-tags:
+        name: Compute Docker tags
+        runs-on: ubuntu-latest
+        # Only run if:
+        # - Manual trigger, OR
+        # - CI succeeded AND (master branch OR manually dispatched CI with test-publishing=true)
+        if: |
+            github.event_name == 'workflow_dispatch' ||
+            (github.event.workflow_run.conclusion == 'success' &&
+             (github.event.workflow_run.head_branch == 'master' ||
+              (github.event.workflow_run.event == 'workflow_dispatch' &&
+               github.event.workflow_run.inputs.test-publishing == 'true')))
+        outputs:
+            version: ${{ steps.versions.outputs.xdk-version }}
+            branch-tag: ${{ steps.compute.outputs.branch-tag }}
+            tags-json: ${{ steps.compute.outputs.tags-json }}
+            is-master: ${{ steps.compute.outputs.is-master }}
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: false  # Only need version info for tag computation
+
+            - name: Compute tags
+              id: compute
+              shell: bash
+              run: |
+                  IS_MASTER=${{ github.ref == 'refs/heads/master' }}
+                  VERSION="${{ steps.versions.outputs.xdk-version }}"
+                  BRANCH_TAG=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+
+                  echo "is-master=$IS_MASTER" >> $GITHUB_OUTPUT
+                  echo "branch-tag=$BRANCH_TAG" >> $GITHUB_OUTPUT
+
+                  if [ "$IS_MASTER" = "true" ]; then
+                      TAGS='["latest","'$VERSION'","'${{ github.sha }}'"]'
+                  else
+                      TAGS='["'$BRANCH_TAG'","'${{ github.sha }}'"]'
+                  fi
+
+                  echo "tags-json=$TAGS" >> $GITHUB_OUTPUT
+
+                  echo "🏷️ Computed Docker metadata:"
+                  echo "  Version: $VERSION"
+                  echo "  Branch tag: $BRANCH_TAG"
+                  echo "  Is master: $IS_MASTER"
+                  echo "  Tags: $TAGS"
+
+    docker-build:
+        name: Build Docker image (${{ matrix.arch }})
+        needs: compute-tags
+        runs-on: ${{ matrix.runner }}
+        strategy:
+            matrix:
+                include:
+                    - platform: linux/amd64
+                      arch: amd64
+                      runner: ubuntu-latest
+                    - platform: linux/arm64
+                      arch: arm64
+                      runner: ubuntu-24.04-arm
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: true
+                  cache-read-only: true  # Reuse cache from CI build
+                  enable-debug: false
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Determine commit and run ID
+              id: commit
+              shell: bash
+              run: |
+                  # Use workflow_run commit if triggered automatically
+                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
+                      GH_COMMIT="${{ github.event.workflow_run.head_sha }}"
+                      RUN_ID="${{ github.event.workflow_run.id }}"
+                      echo "📌 Using commit from workflow_run: $GH_COMMIT (run: $RUN_ID)"
+                  # Use manual input (required for manual trigger)
+                  else
+                      RUN_ID="${{ github.event.inputs.ci-run-id }}"
+                      # Get commit from the specified run
+                      GH_COMMIT=$(gh api /repos/${{ github.repository }}/actions/runs/$RUN_ID --jq '.head_sha')
+                      echo "📌 Using CI run from input: $RUN_ID (commit: $GH_COMMIT)"
+                  fi
+                  echo "commit=$GH_COMMIT" >> $GITHUB_OUTPUT
+                  echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+
+            - name: Download XDK build artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: xdk-dist-${{ steps.commit.outputs.commit }}
+                  path: ./artifacts
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  repository: ${{ github.repository }}
+                  run-id: ${{ steps.commit.outputs.run-id }}
+
+            - name: Build and push Docker image (${{ matrix.arch }})
+              shell: bash
+              working-directory: docker
+              run: |
+                  set -euo pipefail
+
+                  VERSION="${{ needs.compute-tags.outputs.version }}"
+                  BASE_TAGS='${{ needs.compute-tags.outputs.tags-json }}'
+
+                  # Generate architecture-specific tags
+                  TAGS=$(echo "$BASE_TAGS" | jq -r --arg base "${{ env.DOCKER_BASE_IMAGE }}" --arg arch "${{ matrix.arch }}" '.[] | $base + ":" + . + "-" + $arch')
+                  TAG_ARGS=""
+                  for tag in $TAGS; do
+                      TAG_ARGS="$TAG_ARGS --tag $tag"
+                  done
+
+                  echo "🏷️ Architecture-specific tags for ${{ matrix.arch }}:"
+                  echo "$TAGS"
+
+                  # Copy XDK ZIP to Docker context
+                  DIST_ZIP_FILE=$(find ../artifacts -name "xdk-*.zip" | head -1)
+                  cp "$DIST_ZIP_FILE" xdk-dist.zip
+                  echo "📦 Copied: $(basename "$DIST_ZIP_FILE") → xdk-dist.zip"
+
+                  # Build and push
+                  docker buildx build \
+                      --platform ${{ matrix.platform }} \
+                      --progress=plain \
+                      $TAG_ARGS \
+                      --build-arg JAVA_VERSION=${{ steps.versions.outputs.java-version }} \
+                      --build-arg DIST_ZIP_URL="xdk-dist.zip" \
+                      --label org.opencontainers.image.created=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+                      --label org.opencontainers.image.revision=${{ github.sha }} \
+                      --label org.opencontainers.image.version="$VERSION" \
+                      --label org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.ref_name }} \
+                      --cache-from type=gha,scope=${{ matrix.arch }} \
+                      --cache-to type=gha,mode=max,scope=${{ matrix.arch }} \
+                      --provenance=false \
+                      --output type=registry \
+                      .
+
+                  echo "✅ Docker image built and pushed for ${{ matrix.arch }}"
+
+    docker-manifest:
+        name: Create multi-platform manifest
+        needs: [compute-tags, docker-build]
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Create and push manifests
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  BASE_TAGS='${{ needs.compute-tags.outputs.tags-json }}'
+                  echo "Creating multi-platform manifests..."
+                  echo "$BASE_TAGS" | jq -r '.[]' | while read base_tag; do
+                      manifest_tag="${{ env.DOCKER_BASE_IMAGE }}:$base_tag"
+                      echo "Creating: $manifest_tag"
+                      docker manifest create $manifest_tag $manifest_tag-amd64 $manifest_tag-arm64
+                      docker manifest push $manifest_tag
+                      echo "✅ Pushed: $manifest_tag"
+                  done
+                  echo "🎉 All multi-platform manifests created"
+
+    docker-test:
+        name: Test Docker images
+        needs: [compute-tags, docker-manifest]
+        runs-on: ubuntu-latest
+        if: ${{ github.event.inputs.skip-tests != 'true' }}
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Test Docker image
+              shell: bash
+              run: |
+                  IMAGE="${{ env.DOCKER_BASE_IMAGE }}:${{ github.sha }}"
+                  echo "🧪 Testing Docker image: $IMAGE"
+
+                  # Test basic functionality
+                  docker run --rm $IMAGE xec --version
+                  docker run --rm $IMAGE xcc --version
+                  docker run --rm $IMAGE xtc --version
+
+                  echo "✅ Docker image tests passed"
+
+    docker-cleanup:
+        name: Clean up old Docker images
+        needs: docker-test
+        runs-on: ubuntu-latest
+        if: ${{ success() && github.event.inputs.cleanup != 'false' }}
+
+        steps:
+            - name: Clean up old Docker image versions (keep 10 newest, preserve latest/master)
+              uses: actions/delete-package-versions@v5
+              with:
+                  package-name: 'xvm'
+                  package-type: 'container'
+                  min-versions-to-keep: 10
+                  ignore-versions: '^(latest|[0-9]+\.[0-9]+\.[0-9]+.*)(-(amd64|arm64))?$'
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+    summary:
+        name: Workflow summary
+        needs: [compute-tags, docker-cleanup]
+        runs-on: ubuntu-latest
+        if: always()
+
+        steps:
+            - name: Generate summary
+              run: |
+                  echo "### 🐳 Docker Build Workflow" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Version:** ${{ needs.compute-tags.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Images published:**" >> $GITHUB_STEP_SUMMARY
+                  echo '```' >> $GITHUB_STEP_SUMMARY
+                  echo "${{ env.DOCKER_BASE_IMAGE }}:${{ needs.compute-tags.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "${{ env.DOCKER_BASE_IMAGE }}:${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+                  if [ "${{ needs.compute-tags.outputs.is-master }}" = "true" ]; then
+                      echo "${{ env.DOCKER_BASE_IMAGE }}:latest" >> $GITHUB_STEP_SUMMARY
+                  fi
+                  echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,346 @@
+#
+# GitHub workflow for publishing XDK releases
+#
+# This workflow handles release publication to multiple repositories:
+# - GitHub Releases (draft, requires manual publish)
+# - Maven Central (staged, requires manual release via Sonatype)
+# - Gradle Plugin Portal (optional, immediate publication)
+#
+# IMPORTANT: This workflow requires a release version (no -SNAPSHOT suffix)
+# Either update version.properties to a release version, or provide a version override.
+#
+name: Publish Release
+
+permissions:
+    contents: write
+    packages: write
+    actions: read
+
+on:
+    # Manual trigger only - releases are never automatic
+    workflow_dispatch:
+        inputs:
+            version-override:
+                description: 'Release version override (e.g., 0.4.4) - must not contain -SNAPSHOT'
+                required: false
+            skip-tests:
+                description: 'Skip test execution (not recommended for releases)'
+                type: boolean
+                required: false
+                default: false
+            publish-to-gradle-plugin-portal:
+                description: 'Publish to Gradle Plugin Portal (immediate, cannot be staged)'
+                type: boolean
+                required: false
+                default: false
+            close-maven-staging:
+                description: 'Automatically close Maven staging repository'
+                type: boolean
+                required: false
+                default: true
+
+env:
+    # Publishing credentials
+    GITHUB_ACTOR: ${{ github.actor }}
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GRADLE_PUBLISH_KEY: ${{ secrets.ORG_XTCLANG_GRADLE_PLUGIN_PORTAL_PUBLISH_KEY }}
+    GRADLE_PUBLISH_SECRET: ${{ secrets.ORG_XTCLANG_GRADLE_PLUGIN_PORTAL_PUBLISH_SECRET }}
+    ORG_GRADLE_PROJECT_github_actor: ${{ github.actor }}
+    ORG_GRADLE_PROJECT_github_token: ${{ secrets.GITHUB_TOKEN }}
+    SIGNING_KEY: ${{ secrets.ORG_XTCLANG_SIGNING_KEY }}
+    SIGNING_KEYID: ${{ secrets.ORG_XTCLANG_SIGNING_KEY_ID }}
+    SIGNING_PASSWORD: ${{ secrets.ORG_XTCLANG_SIGNING_PASSWORD }}
+    ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_XTCLANG_MAVEN_CENTRAL_USERNAME }}
+    ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_XTCLANG_MAVEN_CENTRAL_PASSWORD }}
+
+jobs:
+    build-and-test:
+        name: Build and test release
+        runs-on: ubuntu-latest
+        outputs:
+            release-version: ${{ steps.version.outputs.release-version }}
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: true
+                  cache-read-only: false
+                  enable-debug: false
+
+            - name: Validate and determine release version
+              id: version
+              shell: bash
+              run: |
+                  # Determine which version to use
+                  if [ -n "${{ github.event.inputs.version-override }}" ]; then
+                      RELEASE_VERSION="${{ github.event.inputs.version-override }}"
+                      echo "📋 Using version override: $RELEASE_VERSION"
+                  else
+                      RELEASE_VERSION="${{ steps.versions.outputs.xdk-version }}"
+                      echo "📋 Using version from version.properties: $RELEASE_VERSION"
+                  fi
+
+                  # Fail if version contains -SNAPSHOT
+                  if [[ "$RELEASE_VERSION" == *-SNAPSHOT ]]; then
+                      echo "❌ ERROR: Cannot publish release with -SNAPSHOT version"
+                      echo ""
+                      echo "Current version: $RELEASE_VERSION"
+                      echo ""
+                      echo "To publish a release, either:"
+                      echo "  1. Update version.properties to a release version (e.g., 0.4.4)"
+                      echo "  2. Provide a version override without -SNAPSHOT"
+                      echo ""
+                      exit 1
+                  fi
+
+                  # Validate semantic versioning format
+                  if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      echo "❌ ERROR: Invalid version format: $RELEASE_VERSION"
+                      echo "Version must follow semantic versioning: MAJOR.MINOR.PATCH"
+                      exit 1
+                  fi
+
+                  echo "release-version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+                  echo ""
+                  echo "✅ Validated release version: $RELEASE_VERSION"
+                  echo ""
+
+            - name: Build XDK distribution
+              env:
+                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
+                  # Override version if provided
+                  VERSION_OVERRIDE: ${{ github.event.inputs.version-override }}
+              run: |
+                  GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }}"
+
+                  # Add version override if provided
+                  if [ -n "$VERSION_OVERRIDE" ]; then
+                      GRADLE_OPTIONS="$GRADLE_OPTIONS -Pversion=$VERSION_OVERRIDE"
+                      echo "🔧 Building with version override: $VERSION_OVERRIDE"
+                  fi
+
+                  echo "🔨 Building XDK release ${{ steps.version.outputs.release-version }}..."
+                  ./gradlew $GRADLE_OPTIONS clean
+                  ./gradlew $GRADLE_OPTIONS :xdk:distZip
+
+            - name: Run tests
+              if: ${{ github.event.inputs.skip-tests != 'true' }}
+              env:
+                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
+                  VERSION_OVERRIDE: ${{ github.event.inputs.version-override }}
+              run: |
+                  GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }}"
+                  if [ -n "$VERSION_OVERRIDE" ]; then
+                      GRADLE_OPTIONS="$GRADLE_OPTIONS -Pversion=$VERSION_OVERRIDE"
+                  fi
+
+                  echo "🧪 Running tests..."
+                  ./gradlew $GRADLE_OPTIONS check
+
+            - name: Upload XDK distribution
+              uses: actions/upload-artifact@v4
+              with:
+                  name: xdk-release-${{ steps.version.outputs.release-version }}
+                  path: xdk/build/distributions/xdk-*.zip
+                  retention-days: 90
+
+            - name: Summary
+              run: |
+                  echo "### ✅ Release Build Completed" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Release Version:** ${{ steps.version.outputs.release-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Tests:** ${{ github.event.inputs.skip-tests != 'true' && 'Passed ✅' || 'Skipped ⚠️' }}" >> $GITHUB_STEP_SUMMARY
+
+    publish-github-draft:
+        name: Create draft GitHub release
+        needs: build-and-test
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: false
+
+            - name: Download XDK distribution
+              uses: actions/download-artifact@v4
+              with:
+                  name: xdk-release-${{ needs.build-and-test.outputs.release-version }}
+                  path: ./artifacts
+
+            - name: Find artifact path
+              id: artifact
+              shell: bash
+              run: |
+                  XDK_ZIP=$(find ./artifacts -name "xdk-*.zip" | head -1)
+                  if [ -z "$XDK_ZIP" ]; then
+                      echo "❌ XDK distribution not found"
+                      exit 1
+                  fi
+                  echo "artifact-path=$XDK_ZIP" >> $GITHUB_OUTPUT
+                  echo "Found artifact: $XDK_ZIP"
+
+            - name: Create draft GitHub release
+              uses: ./.github/actions/publish-github-release
+              with:
+                  artifact-path: ${{ steps.artifact.outputs.artifact-path }}
+                  xdk-version: ${{ needs.build-and-test.outputs.release-version }}
+                  commit: ${{ github.sha }}
+                  repo: ${{ github.repository }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  release-type: release
+                  release-tag: v${{ needs.build-and-test.outputs.release-version }}
+
+    publish-maven-staging:
+        name: Publish to Maven Central staging
+        needs: build-and-test
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: true
+                  cache-read-only: false
+                  enable-debug: false
+
+            - name: Publish to Maven Central staging repository
+              env:
+                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
+                  VERSION_OVERRIDE: ${{ github.event.inputs.version-override }}
+              run: |
+                  GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }}"
+
+                  # Add version override if provided
+                  if [ -n "$VERSION_OVERRIDE" ]; then
+                      GRADLE_OPTIONS="$GRADLE_OPTIONS -Pversion=$VERSION_OVERRIDE"
+                  fi
+
+                  echo "📦 Publishing to Maven Central staging repository..."
+                  echo "   Version: ${{ needs.build-and-test.outputs.release-version }}"
+
+                  ./gradlew $GRADLE_OPTIONS publish --info
+
+                  echo "✅ Published to Maven Central staging repository"
+                  echo ""
+                  echo "📋 Next steps:"
+                  echo "   1. Log in to https://oss.sonatype.org/"
+                  echo "   2. Go to 'Staging Repositories'"
+                  echo "   3. Find repository 'orgxtclang-XXXX'"
+                  echo "   4. Review staged artifacts"
+                  if [ "${{ github.event.inputs.close-maven-staging }}" = "true" ]; then
+                      echo "   5. Repository should be auto-closed (check status)"
+                      echo "   6. Release the repository to Maven Central"
+                  else
+                      echo "   5. Close the repository"
+                      echo "   6. Release the repository to Maven Central"
+                  fi
+                  echo ""
+                  echo "⏱️  Maven Central sync takes ~10-30 minutes after release"
+
+    publish-gradle-plugin-portal:
+        name: Publish to Gradle Plugin Portal
+        needs: build-and-test
+        runs-on: ubuntu-latest
+        if: ${{ github.event.inputs.publish-to-gradle-plugin-portal == 'true' }}
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: true
+                  cache-read-only: false
+                  enable-debug: false
+
+            - name: Publish to Gradle Plugin Portal
+              env:
+                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
+                  VERSION_OVERRIDE: ${{ github.event.inputs.version-override }}
+              run: |
+                  GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }}"
+
+                  # Add version override if provided
+                  if [ -n "$VERSION_OVERRIDE" ]; then
+                      GRADLE_OPTIONS="$GRADLE_OPTIONS -Pversion=$VERSION_OVERRIDE"
+                  fi
+
+                  echo "📦 Publishing to Gradle Plugin Portal..."
+                  echo ""
+                  echo "⚠️  WARNING: Gradle Plugin Portal does not support staging"
+                  echo "   This publication is IMMEDIATE and CANNOT be undone"
+                  echo ""
+
+                  ./gradlew $GRADLE_OPTIONS :plugin:publishPlugins --info
+
+                  echo "✅ Published to Gradle Plugin Portal"
+                  echo "🔗    Plugin page: https://plugins.gradle.org/plugin/org.xtclang.xtc-plugin"
+                  echo "⏱️    Plugin may take a few minutes to appear in search"
+
+    summary:
+        name: Release summary
+        needs: [build-and-test, publish-github-draft, publish-maven-staging]
+        runs-on: ubuntu-latest
+        if: always()
+
+        steps:
+            - name: Generate release summary
+              run: |
+                  echo "### 🚀 Release Publication Summary" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Release Version:** ${{ needs.build-and-test.outputs.release-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "## Publication Status" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ **Build:** Completed" >> $GITHUB_STEP_SUMMARY
+                  echo "- 📝 **GitHub Release:** Created as DRAFT" >> $GITHUB_STEP_SUMMARY
+                  echo "- 🏗️ **Maven Central:** Published to STAGING" >> $GITHUB_STEP_SUMMARY
+                  echo "- ${{ github.event.inputs.publish-to-gradle-plugin-portal == 'true' && '✅' || '⏭️' }} **Gradle Plugin Portal:** ${{ github.event.inputs.publish-to-gradle-plugin-portal == 'true' && 'Published' || 'Skipped' }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "## Required Manual Steps" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### 1. Review and Release Maven Central Staging" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Log in to https://oss.sonatype.org/" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Review staged artifacts in 'Staging Repositories'" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Close and Release the repository" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### 2. Publish GitHub Draft Release" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Go to https://github.com/${{ github.repository }}/releases" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Edit draft release v${{ needs.build-and-test.outputs.release-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Update release notes with actual changes" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Click 'Publish release'" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### 3. Update version.properties for Next Development" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Manually update version.properties to next snapshot version" >> $GITHUB_STEP_SUMMARY
+                  echo "   - For example: ${{ needs.build-and-test.outputs.release-version }} → bump patch and add -SNAPSHOT" >> $GITHUB_STEP_SUMMARY
+                  echo "   - Commit and push to continue development" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,204 @@
+#
+# GitHub workflow for publishing snapshot artifacts
+#
+# This workflow publishes snapshots to:
+# - GitHub Packages (Maven artifacts)
+# - GitHub Releases (XDK snapshot release)
+#
+# It triggers automatically on master after CI completes, or can be manually triggered.
+#
+name: Publish Snapshots
+
+permissions:
+    contents: write
+    packages: write
+    actions: read
+
+on:
+    # AUTOMATIC TRIGGERS DISABLED FOR TESTING
+    # Uncomment the following lines to enable automatic publishing after CI:
+    # workflow_run:
+    #     workflows: ["VerifyCommit"]
+    #     types: [completed]
+
+    # Manual trigger from any branch
+    workflow_dispatch:
+        inputs:
+            ci-run-id:
+                description: 'CI run ID to download artifact from (leave empty to skip artifact download)'
+                required: false
+
+jobs:
+    publish-snapshots:
+        name: Publish snapshot artifacts
+        runs-on: ubuntu-latest
+        # Only run if:
+        # - Manual trigger, OR
+        # - CI succeeded AND (master branch OR manually dispatched CI with test-publishing=true)
+        if: |
+            github.event_name == 'workflow_dispatch' ||
+            (github.event.workflow_run.conclusion == 'success' &&
+             (github.event.workflow_run.head_branch == 'master' ||
+              (github.event.workflow_run.event == 'workflow_dispatch' &&
+               github.event.workflow_run.inputs.test-publishing == 'true')))
+
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+                  show-progress: true
+
+            - name: Setup XVM Project
+              id: versions
+              uses: ./.github/actions/setup-xvm-project
+              with:
+                  setup-build: true
+                  cache-read-only: true  # Read-only since CI build already populated cache
+                  enable-debug: false
+
+            - name: Validate snapshot version
+              shell: bash
+              run: |
+                  VERSION="${{ steps.versions.outputs.xdk-version }}"
+                  if [[ "$VERSION" != *-SNAPSHOT ]]; then
+                      echo "❌ ERROR: Cannot publish snapshots for non-SNAPSHOT version"
+                      echo ""
+                      echo "Current version: $VERSION"
+                      echo ""
+                      echo "This workflow only publishes SNAPSHOT versions."
+                      echo "For release versions, use the publish-release workflow instead."
+                      echo ""
+                      exit 1
+                  fi
+                  echo "✅ Validated snapshot version: $VERSION"
+
+            - name: Determine commit and run ID
+              id: commit
+              shell: bash
+              run: |
+                  # Use workflow_run commit if triggered automatically
+                  if [ "${{ github.event_name }}" = "workflow_run" ]; then
+                      GH_COMMIT="${{ github.event.workflow_run.head_sha }}"
+                      RUN_ID="${{ github.event.workflow_run.id }}"
+                      echo "📌 Using commit from workflow_run: $GH_COMMIT (run: $RUN_ID)"
+                      echo "has-artifact=true" >> $GITHUB_OUTPUT
+                  # Use manual input if provided
+                  elif [ -n "${{ github.event.inputs.ci-run-id }}" ]; then
+                      RUN_ID="${{ github.event.inputs.ci-run-id }}"
+                      # Get commit from the specified run
+                      GH_COMMIT=$(gh api /repos/${{ github.repository }}/actions/runs/$RUN_ID --jq '.head_sha')
+                      echo "📌 Using CI run from input: $RUN_ID (commit: $GH_COMMIT)"
+                      echo "has-artifact=true" >> $GITHUB_OUTPUT
+                  # Manual trigger without run-id
+                  else
+                      GH_COMMIT="${{ github.sha }}"
+                      echo "📌 Manual trigger - commit: $GH_COMMIT"
+                      echo "⚠️  No CI run-id provided"
+                      echo "⚠️  Will publish Maven snapshots but skip GitHub release"
+                      echo "has-artifact=false" >> $GITHUB_OUTPUT
+                  fi
+                  echo "commit=$GH_COMMIT" >> $GITHUB_OUTPUT
+                  echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
+
+            - name: Download XDK artifact from CI
+              if: steps.commit.outputs.has-artifact == 'true'
+              uses: actions/download-artifact@v4
+              with:
+                  name: xdk-dist-${{ steps.commit.outputs.commit }}
+                  path: ./artifacts
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  repository: ${{ github.repository }}
+                  run-id: ${{ steps.commit.outputs.run-id }}
+
+            - name: Publish Maven snapshots
+              env:
+                  GITHUB_ACTOR: ${{ github.actor }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GRADLE_PUBLISH_KEY: ${{ secrets.ORG_XTCLANG_GRADLE_PLUGIN_PORTAL_PUBLISH_KEY }}
+                  GRADLE_PUBLISH_SECRET: ${{ secrets.ORG_XTCLANG_GRADLE_PLUGIN_PORTAL_PUBLISH_SECRET }}
+                  ORG_GRADLE_PROJECT_github_actor: ${{ github.actor }}
+                  ORG_GRADLE_PROJECT_github_token: ${{ secrets.GITHUB_TOKEN }}
+                  SIGNING_KEY: ${{ secrets.ORG_XTCLANG_SIGNING_KEY }}
+                  SIGNING_KEYID: ${{ secrets.ORG_XTCLANG_SIGNING_KEY_ID }}
+                  SIGNING_PASSWORD: ${{ secrets.ORG_XTCLANG_SIGNING_PASSWORD }}
+                  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_XTCLANG_MAVEN_CENTRAL_USERNAME }}
+                  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_XTCLANG_MAVEN_CENTRAL_PASSWORD }}
+                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
+              run: |
+                  echo "📦 Publishing Maven snapshot artifacts to GitHub Packages..."
+                  ./gradlew ${{ steps.versions.outputs.gradle-options }} publish --info
+                  echo "✅ Maven snapshots published"
+
+            - name: Clean up old XDK package versions (keep 50 newest)
+              if: success()
+              uses: actions/delete-package-versions@v5
+              with:
+                  package-name: 'org.xtclang.xdk'
+                  package-type: 'maven'
+                  min-versions-to-keep: 50
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Clean up old Plugin package versions (keep 50 newest)
+              if: success()
+              uses: actions/delete-package-versions@v5
+              with:
+                  package-name: 'org.xtclang.xtc-plugin'
+                  package-type: 'maven'
+                  min-versions-to-keep: 50
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Clean up old Plugin Marker package versions (keep 50 newest)
+              if: success()
+              uses: actions/delete-package-versions@v5
+              with:
+                  package-name: 'org.xtclang.xtc-plugin.org.xtclang.xtc-plugin.gradle.plugin'
+                  package-type: 'maven'
+                  min-versions-to-keep: 50
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Find artifact path
+              if: success() && steps.commit.outputs.has-artifact == 'true'
+              id: artifact
+              shell: bash
+              run: |
+                  XDK_ZIP=$(find ./artifacts -name "xdk-*.zip" | head -1)
+                  if [ -z "$XDK_ZIP" ]; then
+                      echo "❌ No XDK distribution ZIP found in artifacts"
+                      exit 1
+                  fi
+                  echo "artifact-path=$XDK_ZIP" >> $GITHUB_OUTPUT
+                  echo "Found artifact: $XDK_ZIP"
+
+            - name: Publish to GitHub snapshot release
+              if: success() && steps.commit.outputs.has-artifact == 'true'
+              uses: ./.github/actions/publish-github-release
+              with:
+                  artifact-path: ${{ steps.artifact.outputs.artifact-path }}
+                  xdk-version: ${{ steps.versions.outputs.xdk-version }}
+                  commit: ${{ steps.commit.outputs.commit }}
+                  repo: ${{ github.repository }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  release-type: snapshot
+
+            - name: Summary
+              if: success()
+              shell: bash
+              run: |
+                  echo "### ✅ Snapshots Published" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Version:** ${{ steps.versions.outputs.xdk-version }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Commit:** ${{ steps.commit.outputs.commit }}" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Published to:**" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ GitHub Packages (Maven artifacts)" >> $GITHUB_STEP_SUMMARY
+                  if [ "${{ steps.commit.outputs.has-artifact }}" = "true" ]; then
+                      echo "- ✅ GitHub Releases (xdk-snapshots)" >> $GITHUB_STEP_SUMMARY
+                  else
+                      echo "- ⏭️ GitHub Releases (skipped - manual trigger)" >> $GITHUB_STEP_SUMMARY
+                  fi
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "**Maven artifacts:**" >> $GITHUB_STEP_SUMMARY
+                  echo "- XDK distribution" >> $GITHUB_STEP_SUMMARY
+                  echo "- javatools JAR" >> $GITHUB_STEP_SUMMARY
+                  echo "- Gradle plugin" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR introduces the new GitHub Actions workflow structure to enable testing and validation before enabling automatic operation.

## New Workflows

### Main CI
- **commit.yml** (VerifyCommit) - Builds XDK, runs tests, uploads artifacts
  - Replaces the old ci.yml structure
  - Supports Ubuntu and Windows platforms
  - Includes manual test execution

### Publishing Workflows
- **publish-snapshot.yml** - Publishes Maven snapshots to GitHub Packages and snapshot releases to GitHub Releases
- **publish-docker.yml** - Builds multi-platform Docker images (amd64/arm64) and pushes to GHCR
- **homebrew-update.yml** - Updates Homebrew tap with latest XDK version

### Release Workflow
- **publish-release.yml** - Handles release publication (GitHub draft, Maven Central staging, Gradle Plugin Portal)

## New Reusable Actions

- **setup-xvm-project** - Unified action that extracts versions from version.properties and optionally sets up build environment
  - Consolidates version extraction logic
  - Provides outputs for Java version, XDK version, Gradle options, etc.
  
- **publish-github-release** - Reusable action for publishing to GitHub Releases
  - Supports both snapshot and release workflows
  - Handles release creation with proper tagging

## Safety Measures 🛡️

**All automatic triggers are DISABLED in this PR:**

- ✅ `push:` and `pull_request:` triggers are commented out in commit.yml
- ✅ `workflow_run:` triggers are commented out in all publishing workflows
- ✅ Only `workflow_dispatch` (manual trigger) is enabled
- ✅ This prevents any accidental automatic execution on master

**To enable automatic operation later:**
Simply uncomment the trigger sections in each workflow file when ready.

## Testing Approach

With this PR merged, workflows can be tested safely:

1. **Manual triggers only** - Use workflow_dispatch from GitHub UI or gh CLI
2. **No automatic runs** - Pushing to master won't trigger any workflows
3. **Validate before enabling** - Test each workflow manually before enabling automatic triggers
4. **Incremental rollout** - Enable automatic triggers one workflow at a time

## No Name Collisions

The new actions have different names from existing actions on master:
- Existing: `setup-xvm-build`, `get-java-version`, `get-xdk-version`, etc.
- New: `setup-xvm-project`, `publish-github-release`

Old workflows will continue to work until replaced.

## Next Steps

After merging:
1. Test each workflow manually using workflow_dispatch
2. Verify artifact uploads, publishing, etc.
3. Once validated, uncomment automatic triggers
4. Remove old workflows/actions when new ones are confirmed working