### PR TITLE
Add MAC signing support

### DIFF
--- a/javatools_bridge/src/main/x/_native/crypto/RTMacAlgorithm.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTMacAlgorithm.x
@@ -1,0 +1,59 @@
+import libcrypto.Algorithm;
+import libcrypto.Algorithm.Category;
+import libcrypto.CryptoKey;
+import libcrypto.PrivateKey;
+import libcrypto.Signer;
+import libcrypto.Verifier;
+
+/**
+ * The native [Signing] [Algorithm] implementation that requires a symmetric key.
+ */
+service RTMacAlgorithm(String name, Int|Int[] keySize)
+        implements Algorithm {
+
+    construct(String name, Int|Int[] keySize, Object mac) {
+        this.name    = name;
+        this.keySize = keySize;
+        this.mac     = mac;
+    }
+
+    /**
+     * The native signature.
+     */
+    private Object mac;
+
+    // ----- Algorithm API -------------------------------------------------------------------------
+
+    @Override
+    Category category.get() {
+        return Signing;
+    }
+
+    @Override
+    conditional Int|Int[] keyRequired() {
+        return True, keySize;
+    }
+
+    @Override
+    Verifier|Signer allocate(CryptoKey? key) {
+        if (key == Null) {
+            throw new IllegalArgument("Key is required");
+        }
+
+        switch (key.form) {
+        case Secret:
+            assert key.is(PrivateKey) as "key must be a PrivateKey";
+
+            Signer signer = new RTSigner(this, key, key, 0, mac);
+            return &signer.maskAs(Signer);
+
+        default:
+            throw new IllegalArgument("a Secret key is required");
+        }
+    }
+
+    @Override
+    String toString() {
+        return $"{name.quoted()} MAC algorithm with {keySize} bytes keys";
+    }
+}

--- a/javatools_bridge/src/main/x/_native/crypto/RTSigner.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTSigner.x
@@ -11,7 +11,8 @@ service RTSigner
         extends RTVerifier
         implements Signer {
 
-    construct(Algorithm algorithm, CryptoKey publicKey, CryptoKey privateKey, Int signatureSize, Object signer) {
+    construct(Algorithm algorithm, CryptoKey publicKey, CryptoKey privateKey,
+              Int signatureSize, Object signer) {
         construct RTVerifier(algorithm, publicKey, signatureSize, signer);
 
         assert privateKey.form == Secret;

--- a/javatools_bridge/src/main/x/_native/crypto/RTSigningAlgorithm.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTSigningAlgorithm.x
@@ -2,13 +2,12 @@ import libcrypto.Algorithms;
 import libcrypto.Algorithm;
 import libcrypto.Algorithm.Category;
 import libcrypto.CryptoKey;
-import libcrypto.KeyForm;
 import libcrypto.KeyPair;
 import libcrypto.Signer;
 import libcrypto.Verifier;
 
 /**
- * The native [Signing] [Algorithm] implementation that requires a key.
+ * The native [Signing] [Algorithm] implementation that requires a public/private key.
  */
 service RTSigningAlgorithm(String name, Int blockSize, Int signatureSize)
         implements Algorithm {
@@ -71,8 +70,8 @@ service RTSigningAlgorithm(String name, Int blockSize, Int signatureSize)
 
     @Override
     String toString() {
-        return $|{name.quoted()} signing algorithm with {keySize} bytes key and \
-                |{signatureSize} bytes signature
+        return $|"{name}" signing algorithm with {keySize} bytes keys and {signatureSize} bytes \
+                |signature
                 ;
     }
 }

--- a/javatools_bridge/src/main/x/_native/crypto/RTVerifier.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTVerifier.x
@@ -11,7 +11,7 @@ service RTVerifier
         implements Verifier {
 
     construct(Algorithm algorithm, CryptoKey publicKey, Int signatureSize, Object signer) {
-        assert publicKey.form == Public;
+        assert publicKey.form == Public || publicKey.form == Secret;
 
         this.algorithm     = algorithm;
         this.publicKey     = publicKey;

--- a/lib_crypto/src/main/x/crypto/Algorithms.x
+++ b/lib_crypto/src/main/x/crypto/Algorithms.x
@@ -72,7 +72,10 @@ const Algorithms {
      */
     conditional Signer signerFor(Specifier specifier, CryptoKey key) {
         if (key.is(KeyPair),
-            Algorithm algorithm := findAlgorithm(specifier, Signing, key.privateKey, True)) {
+                Algorithm algorithm := findAlgorithm(specifier, Signing, key.privateKey, True)) {
+            return True, algorithm.allocate(key).as(Signer);
+        } else if (key.is(PrivateKey),
+                Algorithm algorithm := findAlgorithm(specifier, Signing, key, True)) {
             return True, algorithm.allocate(key).as(Signer);
         }
 


### PR DESCRIPTION
As Michael@Compator pointed out, our current crypto algorithms support both symmetric and asymmetric encryption, but only asymmetric signing. This change fills that gap, introducing the support for Message Authentication Code (MAC) algorithms as specified in RFC 2104.  More specifically, it adds three symmetric signing algorithms:
- HmacSHA1
- HmacSHA256
- HmacSHA512

Since the MAC algorithms in general are advised to be using larger keys, also added the corresponding key generator algorithms (even though AES keys should be sufficient).