### PR TITLE
Add xtc binary to Homebrew formula

### DIFF
--- a/.github/scripts/xdk-latest.rb.template
+++ b/.github/scripts/xdk-latest.rb.template
@@ -10,20 +10,24 @@ class XdkLatest < Formula
   def install
     libexec.install Dir["*"]
     
-    # Install Unix launchers (xec = Ecstasy Execution, xcc = Ecstasy Compiler)
-    %w[xec xcc].each do |cmd|
+    # Install Unix launchers (xec = Ecstasy runner, xcc = Ecstasy compiler, xtc = unified tool)
+    %w[xec xcc xtc].each do |cmd|
       (bin/cmd).write_env_script(libexec/"bin"/cmd, JAVA_HOME: Formula["openjdk@{{JAVA_VERSION}}"].opt_prefix)
     end
   end
   
   test do
-    # Test that xec launcher works and shows help when no arguments provided  
+    # Test that xec launcher works and shows help when no arguments provided
     # TODO: The exit code test is technically correct to check for 1, but xec doesn't follow the accepted standard
     output = shell_output("#{bin}/xec 2>&1")
     assert_match "Ecstasy runner", output
-    
+
     # Test that xcc launcher works and shows version info
     output = shell_output("#{bin}/xcc --version 2>&1")
+    assert_match "Ecstasy", output
+
+    # Test that xtc launcher works
+    output = shell_output("#{bin}/xtc --version 2>&1")
     assert_match "Ecstasy", output
   end
 end


### PR DESCRIPTION
## Summary

- Add `xtc` (unified Ecstasy tool) to the Homebrew `xdk-latest` formula alongside `xec` and `xcc`
- Include test to verify `xtc --version` works correctly after installation

## Context

The `xdk.rb` formula in `homebrew-xvm` already includes `xtc`, but the `xdk-latest.rb.template` (used for snapshot builds) was missing it. This change ensures parity between the two formulas.

When the next CI run triggers the Homebrew update workflow, the updated template will be automatically pushed to the `homebrew-xvm` tap.

## Test plan

- [ ] Verify CI workflow runs successfully
- [ ] After merge, confirm `homebrew-xvm/Formula/xdk-latest.rb` is updated with `xtc`
- [ ] Test installation: `brew reinstall xdk-latest && xtc --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)