### PR TITLE
Trigger Homebrew formula update after snapshot publish

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -169,6 +169,17 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   release-type: snapshot
 
+            - name: Trigger Homebrew formula update
+              if: success() && steps.commit.outputs.has-artifact == 'true'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  echo "🍺 Triggering Homebrew formula update..."
+                  gh workflow run homebrew-update.yml \
+                      --field ci-run-id="${{ steps.commit.outputs.run-id }}" \
+                      --field xdk-version="${{ steps.versions.outputs.xdk-version }}"
+                  echo "✅ Homebrew update workflow triggered"
+
             - name: Summary
               if: success()
               shell: bash
@@ -183,8 +194,10 @@ jobs:
                   echo "- ✅ Maven Central Snapshots" >> $GITHUB_STEP_SUMMARY
                   if [ "${{ steps.commit.outputs.has-artifact }}" = "true" ]; then
                       echo "- ✅ GitHub Releases (xdk-snapshots)" >> $GITHUB_STEP_SUMMARY
+                      echo "- ✅ Homebrew formula update (triggered)" >> $GITHUB_STEP_SUMMARY
                   else
                       echo "- ⏭️ GitHub Releases (skipped - manual trigger)" >> $GITHUB_STEP_SUMMARY
+                      echo "- ⏭️ Homebrew formula update (skipped - manual trigger)" >> $GITHUB_STEP_SUMMARY
                   fi
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Maven artifacts:**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
As suggested by Claude :)

The `homebrew` checksum mismatch occurred because the XDK distribution zip file was updated to include the new xtc launcher script, which changed its SHA-256 checksum. The updated artifact was published to GitHub Releases, but the homebrew formula in the xtclang/homebrew-xvm tap still contained the old checksum because the homebrew-update.yml workflow wasn't automatically triggered after snapshot publishing—it only ran on manual invocation. This created a situation where the GitHub Release had the new zip file, but the homebrew formula still validated against the old checksum. When users ran `brew install xdk-latest`, Homebrew downloaded the new zip but compared it against the outdated checksum in their cached formula, causing the installation to fail with "Formula reports different checksum". 
 
This fix adds an automatic trigger to publish-snapshot.yml that invokes homebrew-update.yml immediately after publishing to GitHub Releases,  ensuring the formula checksum is atomically updated whenever the artifact changes, allowing users to seamlessly upgrade with standard `brew upgrade` command.