### PR TITLE
Fix Runner not forwarding deduce/verbose flags to Compiler during recompilation

### DIFF
--- a/javatools/src/main/java/org/xvm/tool/Runner.java
+++ b/javatools/src/main/java/org/xvm/tool/Runner.java
@@ -158,9 +158,15 @@ public class Runner extends Launcher<RunnerOptions> {
 
             if (fCompile) {
                 // Build CompilerOptions programmatically using fluent API
+                // TODO: NOTE that we can only forward compiler options from the runner command line, i.e.
+                //   options shared by both. This means that we put deduce and verbose in there, but if the
+                //   old compile was done with e.g. strict, we have no way to pass that, even though that would
+                //   be consistent. This feels a bit brittle.
                 final var builder = CompilerOptions.builder()
                         .addInputFile(fileSpec)
-                        .addModulePath(opts.getModulePath());
+                        .addModulePath(opts.getModulePath())
+                        .enableDeduction(opts.mayDeduceLocations())
+                        .enableVerbose(opts.isVerbose());
                 outFile.ifPresent(builder::setOutputLocation);
                 final var exitCode = new Compiler(builder.build(), m_console, m_errors).run();
                 if (exitCode != 0) {


### PR DESCRIPTION
## Summary

PR #352 refactored Runner to use the programmatic `CompilerOptions` builder API, but inadvertently dropped the forwarding of `-d` (deduce) and `-v` (verbose) flags when Runner needs to recompile an out-of-date module.

This caused commands like:
```bash
xec -d -L build/xtc/main/lib -o build/xtc/main/lib TestSimple.x
```
to fail with `Error: Failed to locate the module source code for: TestSimple.x` because the deduce flag wasn't being passed to the Compiler.

## Changes

- Forward `deduce` and `verbose` flags from `RunnerOptions` to `CompilerOptions` in `Runner.java`
- Add integration tests in `XdkIntegrationTest.java` that verify flag forwarding during recompilation

## Semantic Limitation

There is an inherent brittleness in this design: **we can only forward compiler options that exist on both the Runner and Compiler command lines**.

For example, if a module was originally compiled with `--strict`, there is no way for the Runner to know this or to forward it during recompilation. This means an automatic recompilation triggered by Runner may produce different results than the original compilation.

Options that **can** be forwarded (shared by both):
- `-d` / `--deduce`
- `-v` / `--verbose`
- `-L` (module path)
- `-o` (output location)

Options that **cannot** be forwarded (compiler-only):
- `--strict`
- `--nowarn`
- `--rebuild`
- `--set-version`

This is documented with a TODO comment in the code. A more robust solution might involve storing compilation metadata with the `.xtc` file, but that's a larger architectural change.

## Test plan

- [x] Added `testRunnerForwardsDeduceAndVerboseFlagsToCompiler` - verifies flags are forwarded when Runner compiles a source file
- [x] Added `testRunnerRecompilesOutOfDateModule` - verifies flags are forwarded when Runner recompiles a stale module
- [x] Both tests pass: `./gradlew xdk:test --tests "XdkIntegrationTest.testRunner*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)