### PR TITLE
Fix xtc launcher showing spurious -L error when no command given

### DIFF
--- a/javatools/src/main/java/org/xvm/tool/Launcher.java
+++ b/javatools/src/main/java/org/xvm/tool/Launcher.java
@@ -178,11 +178,13 @@ public abstract class Launcher<T extends LauncherOptions>
      * @throws LauncherException if an unrecoverable exception occurs
      */
     public static int launch(String[] asArg) {
+        final var console = new Console() {};
+
         if (asArg.length < 1) {
-            throw new IllegalArgumentException("Command name is missing. Available commands: " + commandNames());
+            showHelp(console);
+            return 0;
         }
 
-        final var console = new Console() {};
         return launch(
                 stripDebugPrefix(asArg[0]),
                 Arrays.copyOfRange(asArg, 1, asArg.length),
@@ -220,6 +222,12 @@ public abstract class Launcher<T extends LauncherOptions>
                     final var handler = COMMANDS.get(cmd);
                     if (handler != null) {
                         yield handler.launch(args, console, errListener);
+                    }
+                    // If the command looks like an option (e.g., "-L"), no command was provided;
+                    // show help without an error message
+                    if (cmd.startsWith("-")) {
+                        showHelp(console);
+                        yield 0;
                     }
                     console.log(ERROR, "Unknown command: {}. Available commands: {}",
                             quoted(cmd), commandNames());


### PR DESCRIPTION
## Summary

- Fixed the `xtc` launcher showing an error when run without a command argument
- Previously: `xtc` would display `Error: Unknown command: "-L"` because the shell script passes `-L` library paths that were incorrectly interpreted as commands
- Now: `xtc` displays the help message cleanly without spurious errors

## Changes

Modified `Launcher.java` to:
1. Show help (instead of throwing exception) when no arguments are provided
2. Treat arguments starting with `-` as "no command given" and show help without an error message
3. Invalid commands that don't start with `-` (e.g., `xtc foo`) still show the appropriate error

## Before
```
$ xtc
Error: Unknown command: "-L". Available commands: test, build, disass, run
Ecstasy command-line tool
...
```

## After
```
$ xtc
Ecstasy command-line tool

Usage:
    xtc <command> [options] [arguments]
...
```

## Test plan
- [x] `xtc` (no args) shows help without error
- [x] `xtc --help` shows help
- [x] `xtc --version` shows version
- [x] `xtc build --help` shows build-specific help
- [x] `xtc foo` (invalid non-option command) properly shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)