### PR TITLE
Add file name to exception thrown when creating a file in xOSStorage

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
@@ -139,6 +139,15 @@ public class xOSStorage
                     return frame.assignValue(iReturn, xBoolean.FALSE);
                 }
 
+                Path parent = path.getParent();
+                if (!Files.exists(parent)) {
+                    return frame.raiseException(xException.ioException(frame,
+                            "Cannot create file, parent directory does not exist: " + path));
+                }
+                if (!Files.isDirectory(parent)) {
+                    return frame.raiseException(xException.ioException(frame,
+                            "Cannot create file, parent is not a directory: " + path));
+                }
                 return frame.assignValue(iReturn,
                     xBoolean.makeHandle(path.toFile().createNewFile()));
             } catch (IOException|InvalidPathException e) {


### PR DESCRIPTION
In xOSStorage.java when `createFile` is called, if  the parent directory did not exist or was not a directory a Java IOException is thrown, but this does not contain the file name that caused the exception. This PR throws an Ecstasy IOException that contains the file name.