### PR TITLE
Fix TestRunner.java to correctly handle relative paths

### DIFF
--- a/javatools/src/main/java/org/xvm/tool/TestRunner.java
+++ b/javatools/src/main/java/org/xvm/tool/TestRunner.java
@@ -112,12 +112,11 @@ public class TestRunner extends Runner {
         Path wd = new File("").getAbsoluteFile().toPath();
         options.getOutputFile().ifPresent(out ->
                 injections.put(XUNIT_TEST_BUILD_DIR,
-                        List.of(wd.relativize(out.toPath()).toString())));
+                        List.of(wd.relativize(out.getAbsoluteFile().toPath()).toString())));
 
         options.optionValue(LauncherOptions.OPTION_XUNIT_OUT).map(File::new).ifPresent(dir -> {
                     injections.put(XUNIT_TEST_OUTPUT_DIR,
-                            List.of(wd.relativize(dir.toPath()).toString()));
-
+                            List.of(wd.relativize(dir.getAbsoluteFile().toPath()).toString()));
                 });
         connector.start(injections);
         return connector;

--- a/manualTests/src/main/x/xunit-demo.x
+++ b/manualTests/src/main/x/xunit-demo.x
@@ -5,6 +5,12 @@
  *
  *  xtc test -L build/xtc/main/lib -o  build/xtc/main/lib src/main/x/xunit-demo.x
  *
+ * Any XUnit test output will be in the manualTests/xunit directory. This can be changed using the
+ * --xunit-out command line option, for example to put output into the manualTests/build/xunit
+ * directory
+ *
+ *  xtc test -L build/xtc/main/lib -o build/xtc/main/lib --xunit-out build/xunit src/main/x/xunit-demo.x
+ *
  */
 module xunit_demo {
 
@@ -35,10 +41,6 @@ module xunit_demo {
         console.print(">>>> In Module BeforeAll");
         @Inject ExecutionContext context;
         console.print($">>>> In Module BeforeAll {context.testClass} {context.testMethod}");
-        @Inject("buildDir") Directory buildDir;
-        @Inject("testOutputRoot") Directory testOutputRoot;
-        @Inject("testOutput") Directory testOutput;
-        console.print($">>>> In Module BeforeAll buildDir={buildDir}/{buildDir.exists} testOutputRoot={testOutputRoot}/{testOutputRoot.exists} testOutput={testOutput}/{testOutput.exists}");
     }
 
     /**
@@ -60,10 +62,6 @@ module xunit_demo {
         console.print($"  >>>> In Module BeforeEach static");
         @Inject ExecutionContext context;
         console.print($"  >>>> In Module BeforeEach static {context.testClass} {context.testMethod}");
-        @Inject("buildDir") Directory buildDir;
-        @Inject("testOutputRoot") Directory testOutputRoot;
-        @Inject("testOutput") Directory testOutput;
-        console.print($">>>> In Module BeforeEach static buildDir={buildDir}/{buildDir.exists} testOutputRoot={testOutputRoot}/{testOutputRoot.exists} testOutput={testOutput}/{testOutput.exists}");
     }
 
     /**
@@ -227,13 +225,12 @@ module xunit_demo {
 
    package tests {
 
-    class Bar {
-        @Test
-        void testBar() {
-            @Inject ExecutionContext context;
-            console.print($"       >>>> In Bar testBar {context.testClass} {context.testMethod}");
+        class Bar {
+            @Test
+            void testBar() {
+                @Inject ExecutionContext context;
+                console.print($"       >>>> In Bar testBar {context.testClass} {context.testMethod}");
+            }
         }
-    }
-
    }
 }


### PR DESCRIPTION
TestRunner passes command line arguments for the build and XUnit output directories as injectables. This PR fixes a bug that caused an exception when the command line args used relative paths.