### PR TITLE
Add missing native conversion method

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseBinaryFP.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseBinaryFP.java
@@ -34,6 +34,20 @@ public abstract class BaseBinaryFP
     }
 
     @Override
+    public void initNative() {
+        super.initNative();
+
+        markNativeMethod("toInt64",   null, null);
+        markNativeMethod("toDec64",   null, null);
+        markNativeMethod("toFloat32", null, null);
+        markNativeMethod("toFloat64", null, null);
+        markNativeMethod("toIntN",    null, null);
+        markNativeMethod("toUIntN",   null, null);
+        markNativeMethod("toFloatN",  null, null);
+        markNativeMethod("toDecN",    null, null);
+    }
+
+    @Override
     public int invokeNativeGet(Frame frame, String sPropName, ObjectHandle hTarget, int iReturn) {
         double d = ((FloatHandle) hTarget).getValue();
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseDecFP.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseDecFP.java
@@ -41,6 +41,19 @@ public abstract class BaseDecFP
     }
 
     @Override
+    public void initNative() {
+        super.initNative();
+
+        markNativeMethod("toInt64",   null, null);
+        markNativeMethod("toFloat32", null, null);
+        markNativeMethod("toFloat64", null, null);
+        markNativeMethod("toIntN",    null, null);
+        markNativeMethod("toUIntN",   null, null);
+        markNativeMethod("toFloatN",  null, null);
+        markNativeMethod("toDecN",    null, null);
+    }
+
+    @Override
     public int createConstHandle(Frame frame, Constant constant) {
         if (constant instanceof DecimalConstant constDec) {
             return frame.pushStack(makeHandle(constDec.getValue()));

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntNumber.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntNumber.java
@@ -17,6 +17,22 @@ public abstract class xIntNumber
 
     @Override
     public void initNative() {
+        String[] NAMES = {
+                "Int8",  "Int16",  "Int32",  "Int64",  "Int128",  "IntN",
+                "UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UIntN",
+
+                "Float16", "Float32", "Float64", "FloatN",
+
+                "Dec32", "Dec64", "Dec128", "DecN"
+            };
+
+        for (String sName : NAMES) {
+            String sNameQ = "numbers." + sName;
+            if (!sNameQ.equals(f_sName)) {
+                markNativeMethod("to" + sName, null, new String[]{sNameQ});
+            }
+        }
+
         markNativeMethod("toChar", null, new String[]{"text.Char"});
 
         markNativeProperty("bitCount");

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xNumber.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xNumber.java
@@ -34,22 +34,6 @@ public abstract class xNumber
 
     @Override
     public void initNative() {
-        String[] NAMES = {
-                "Int8",  "Int16",  "Int32",  "Int64",  "Int128",  "IntN",
-                "UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UIntN",
-
-                "Float16", "Float32", "Float64", "FloatN",
-
-                "Dec32", "Dec64", "Dec128", "DecN"
-            };
-
-        for (String sName : NAMES) {
-            String sNameQ = "numbers." + sName;
-            if (!sNameQ.equals(f_sName)) {
-                markNativeMethod("to" + sName, null, new String[]{sNameQ});
-            }
-        }
-
         markNativeProperty("bits");
 
         ClassStructure structure = getStructure();

--- a/lib_ecstasy/src/main/x/ecstasy/numbers/Dec64.x
+++ b/lib_ecstasy/src/main/x/ecstasy/numbers/Dec64.x
@@ -267,7 +267,7 @@ const Dec64
     Float128 toFloat128();
 
     @Override
-    Dec64 toDec64() =this;
+    Dec64 toDec64() = this;
 
     @Auto
     @Override

--- a/manualTests/src/main/x/TestSimple.x
+++ b/manualTests/src/main/x/TestSimple.x
@@ -2,13 +2,16 @@ module TestSimple {
     @Inject Console console;
 
     void run() {
-        Int i = 0;
-        Int j = 1;
+        Double i = 0.1;
+        Int    j = 10;
+        Int    k64 = (j / i).toInt64();
 
-        assert i > j as assert as assert as message();
-        assert i > j as assert False; // this used to blow up in the compiler
+        // used to throw at run-time
+        Int32  k32 = (j / i).toInt32();
+        Int16  k16 = (j / i).toInt16();
+        Int8   k8  = (j / i).toInt8();
+
+        console.print($"{k64=} {k32=} {k16=} {k8=}");
     }
-
-    String message() = "wrong";
 }
 


### PR DESCRIPTION
Dima pointed out to some missing native conversions. The reason for the failure was the fact that while floating point numbers have a number of conversion methods implemented naturally, those methods were still declared as native.

This fix moves the native declaration from `xNumber.java` to corresponding sub-classes