### PR TITLE
Add timestamp to RTServer trace messages

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
@@ -43,6 +43,8 @@ import org.xvm.runtime.template.text.xString.StringHandle;
 
 import org.xvm.runtime.template._native.crypto.xRTKeyStore.KeyStoreHandle;
 
+import org.xvm.util.Handy;
+
 
 /**
  * Native implementation of the xRTCertificateManager.x service.
@@ -469,10 +471,10 @@ public class xRTCertificateManager
     }
 
     private Key loadKey(ObjectHandle hPathOrStore, StringHandle hPwd, StringHandle hName) {
-        try {
-            char[] achPwd = hPwd.getValue();
-            String sKey   = hName.getStringValue();
+        char[] achPwd = hPwd.getValue();
+        String sKey   = hName.getStringValue();
 
+        try {
             KeyStore keyStore;
             if (hPathOrStore instanceof StringHandle hPath) {
                 File fileStore = new File(hPath.getStringValue());
@@ -485,6 +487,8 @@ public class xRTCertificateManager
 
             return keyStore.getKey(sKey, achPwd);
         } catch (Exception e) {
+            System.err.println(Handy.logTime() + " [Debug]: Failed to load key: " + sKey +
+                " (" + e.getMessage() + ")");
             return null;
         }
     }
@@ -525,7 +529,7 @@ public class xRTCertificateManager
         ProcessBuilder builder = new ProcessBuilder(cmd);
         try {
             // TODO: remove
-            System.out.println("*** running command: " + toString(cmd));
+            System.out.println(Handy.logTime() + " Trace: running command: " + toString(cmd));
 
             Process process = builder.start();
             if (sInput != null) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
@@ -83,6 +83,8 @@ import org.xvm.runtime.template._native.crypto.xRTKeyStore.KeyStoreHandle;
 import org.xvm.runtime.template._native.reflect.xRTFunction;
 import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
 
+import org.xvm.util.Handy;
+
 
 /**
  * Native implementation of the RTServer.x service that uses native Java {@link HttpServer}.
@@ -736,14 +738,15 @@ public class xRTServer
                         : f_hServer.getRouter().mapRoutes.get(sHost);
                 if (route == null) {
                     // TODO: REMOVE
-                    System.err.println("*** Handshake with unknown host: " + sHost);
+                    System.err.println(Handy.logTime() + " Trace: Handshake with unknown host: " + sHost);
                 } else {
                     f_tloKeyStore.set(route.hKeyStore);
                     return route.sTlsKey;
                 }
             } else {
                 // TODO: REMOVE
-                System.err.println("*** Handshake from unknown session");
+                System.err.println(Handy.logTime() + " Trace: Handshake from unknown session" +
+                    session.getClass().getName());
             }
             return null;
         }
@@ -813,8 +816,9 @@ public class xRTServer
             boolean   fTls  = exchange instanceof HttpsExchange;
             RouteInfo route = mapRoutes.get(sName);
             if (route == null || nPort != (fTls ? route.nHttpsPort : route.nHttpPort)) {
-                System.err.println("*** Request for unregistered route: "
-                    + (fTls ? "https://" : "http://") + sHost + exchange.getRequestURI());
+                System.err.println(Handy.logTime() + " Trace: Request for unregistered route: "
+                    + (fTls ? "https://" : "http://") + sHost + exchange.getRequestURI() + " from "
+                    + exchange.getRemoteAddress().getAddress());
                 exchange.sendResponseHeaders(421, -1); // HttpStatus.MisdirectedRequest
             } else {
                 route.handler.handle(exchange);

--- a/javatools_utils/src/main/java/org/xvm/util/Handy.java
+++ b/javatools_utils/src/main/java/org/xvm/util/Handy.java
@@ -892,25 +892,45 @@ public final class Handy {
     /**
      * @param cMillis  date/time in millis
      *
-     * @return date/time string in format "YYYY-MM-DD HH:MM:SS" format
+     * @return date/time string in "yyyy-MM-dd HH:mm:ss" format
      */
     public static String dateString(final long cMillis) {
-        return Instant.ofEpochMilli(cMillis)
-                .atZone(ZoneId.systemDefault())
-                .format(DATE_TIME_FORMATTER);
+        return logTime(cMillis, DATE_TIME_FORMATTER);
     }
 
     /**
      * @param cMillis       date/time in millis
      * @param defaultValue  the value to return if cMillis is 0
      *
-     * @return date/time string in format "YYYY-MM-DD HH:MM:SS" format, or the default value if
-     *         cMillis is 0
+     * @return date/time string in "yyyy-MM-dd HH:mm:ss" format, or the default value if cMillis is 0
      */
     public static String dateString(final long cMillis, final String defaultValue) {
         return cMillis == 0L ? defaultValue : dateString(cMillis);
     }
 
+    /**
+     * @param cMillis  date/time in millis
+     *
+     * @return date/time string in "yyyy-MM-dd HH:mm:ss.SSS" format
+     */
+    public static String logTime() {
+        return logTime(System.currentTimeMillis(), DATE_TIME_MILLS_FORMATTER);
+    }
+
+    /**
+     * @param cMillis  date/time in millis
+     *
+     * @return date/time string in "yyyy-MM-dd HH:mm:ss.SSS" format
+     */
+    public static String logTime(final long cMillis) {
+        return logTime(cMillis, DATE_TIME_MILLS_FORMATTER);
+    }
+
+    public static String logTime(final long cMillis, final DateTimeFormatter formatter) {
+        return Instant.ofEpochMilli(cMillis)
+            .atZone(ZoneId.systemDefault())
+            .format(formatter);
+    }
 
     // ----- packed integers -----------------------------------------------------------------------
 
@@ -1993,7 +2013,14 @@ public final class Handy {
     /**
      * DateTimeFormatter for "yyyy-MM-dd HH:mm:ss" format.
      */
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * DateTimeFormatter for "yyyy-MM-dd HH:mm:ss.SSS" format.
+     */
+    private static final DateTimeFormatter DATE_TIME_MILLS_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
     /**
      * A constant empty array of <tt>byte</tt>.

--- a/lib_jsondb/src/main/x/jsondb/tools/ModuleGenerator.x
+++ b/lib_jsondb/src/main/x/jsondb/tools/ModuleGenerator.x
@@ -73,7 +73,7 @@ class ModuleGenerator(String moduleName, Version? version = Null) {
                 Time? dbStamp    = dbModule.parent.created;
                 Time? hostStamp  = hostModule.parent.created;
                 if (dbStamp != Null && hostStamp != Null && hostStamp > dbStamp) {
-                    errors.add($"Info: Host module '{hostName}' for '{moduleName}' is up to date");
+                    errors.add($"Info : Host module '{hostName}' for '{moduleName}' is up to date");
                     return True, hostModule;
                 }
             } catch (Exception ignore) {}
@@ -89,7 +89,7 @@ class ModuleGenerator(String moduleName, Version? version = Null) {
 
         if (createModule(sourceFile, appName, qualifier, dbModule, appSchemaTemplate, errors) &&
             compileModule(repository, sourceFile, buildDir, errors)) {
-            errors.add($"Info: Created a host module '{hostName}' for '{moduleName}'");
+            errors.add($"Info : Created a host module '{hostName}' for '{moduleName}'");
             return repository.getModule(hostName);
         }
         return False;

--- a/lib_xml/src/main/x/xml/Document.x
+++ b/lib_xml/src/main/x/xml/Document.x
@@ -85,13 +85,13 @@ interface Document
     Boolean? standalone;
 
     @Override
-    Int estimateStringLength(Boolean pretty = False, Int indent=0) {
+    Int estimateStringLength(Boolean pretty = False, Int indent = 0) {
         return parts.reduce(0, (sum, part) -> sum + part.estimateStringLength(pretty))
                 + (pretty ? parts.size - 1 : 0);
     }
 
     @Override
-    Writer appendTo(Writer buf, Boolean pretty = False, String indent="") {
+    Writer appendTo(Writer buf, Boolean pretty = False, String indent = "") {
         Loop: for (Part part : parts) {
             if (pretty && !Loop.first) {
                 buf.add('\n');

--- a/lib_xunit_engine/src/main/x/xunit_engine/tools/ModuleGenerator.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/tools/ModuleGenerator.x
@@ -50,7 +50,7 @@ class ModuleGenerator(String moduleName, Version? version = Null) {
                 Time? dbStamp    = testModule.parent.created;
                 Time? hostStamp  = hostModule.parent.created;
                 if (dbStamp != Null && hostStamp != Null && hostStamp > dbStamp) {
-                    errors.add($"Info: Host module '{hostName}' for '{moduleName}' is up to date");
+                    errors.add($"Info : Host module '{hostName}' for '{moduleName}' is up to date");
                     return True, hostModule;
                 }
             } catch (Exception ignore) {}
@@ -60,7 +60,7 @@ class ModuleGenerator(String moduleName, Version? version = Null) {
         createModule(sourceFile, appName, qualifier, testModule);
 
         if (compileModule(repository, sourceFile, buildDir, errors)) {
-            errors.add($"Info: Created a host module '{hostName}' for '{moduleName}'");
+            errors.add($"Info : Created a host module '{hostName}' for '{moduleName}'");
             // clean up the temporary test module source file
             sourceFile.delete();
             return repository.getModule(hostName);


### PR DESCRIPTION
While we're running "host,xqiz.it" on the internal network we need to have better logging for the requests coming onto the host and the internal messages. This fix adds the uniform timestamp to most of the common log messages coming from the native layer. The second part of that change will be done in the "platform" repo.