### PR TITLE
Improve code generation for IsExpression

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/Register.java
+++ b/javatools/src/main/java/org/xvm/asm/Register.java
@@ -354,16 +354,17 @@ public class Register
      * Force the register to be treated as effectively final from this point forward.
      */
     public void markEffectivelyFinal() {
+        assert m_fEffectivelyFinal || !m_fRO;
         m_fRO               = true;
         m_fEffectivelyFinal = true;
     }
 
     /**
-     * @return true iff this is a normal (not D_VAR), readable and writable, local variable (and
-     *         not the stack)
+     * @return true iff this is a normal (not D_VAR), readable and writable (but exempt the
+     *         effectively final registers that started as writable), local variable
      */
     public boolean isNormal() {
-        return !isPredefined() && isReadable() && isWritable() && !isVar();
+        return !isPredefined() && isReadable() && (isWritable() | isEffectivelyFinal()) && !isVar();
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/ast/ElvisExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/ElvisExpression.java
@@ -292,17 +292,15 @@ public class ElvisExpression
 
     @Override
     public void generateAssignment(Context ctx, Code code, Assignable LVal, ErrorListener errs) {
-        if (isConstant() || !LVal.isNormalVariable() || !m_fCond && !pool().typeNull().isA(LVal.getType())) {
+        if (isConstant() || !(LVal.isNormalVariable() || LVal.isProperty()) ||
+                !m_fCond && !pool().typeNull().isA(LVal.getType())) {
             super.generateAssignment(ctx, code, LVal, errs);
             return;
         }
 
         Label labelEnd = getEndLabel();
         if (m_fCond) {
-            Assignable   varCond = createTempVar(code, pool().typeBoolean());
-            Assignable[] LVals   = new Assignable[] {varCond, LVal};
-            expr1.generateAssignments(ctx, code, LVals, errs);
-            code.add(new JumpTrue(varCond.getRegister(), labelEnd));
+            expr1.generateConditionalAssignment(ctx, code, LVal, labelEnd, errs);
         } else {
             expr1.generateAssignment(ctx, code, LVal, errs);
             code.add(new JumpNotNull(LVal.getLocalArgument(), labelEnd));

--- a/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
@@ -1556,6 +1556,25 @@ public abstract class Expression
     }
 
     /**
+     * Generate the necessary code that computes a conditional assignment and jumps to the specified
+     * label if this expression evaluates to `true`.
+     *
+     * @param ctx       the compilation context for the statement
+     * @param code      the code block
+     * @param label     the label to conditionally jump to
+     * @param errs      the error list to log any errors to
+     */
+    public void generateConditionalAssignment(Context ctx, Code code,
+                                              Assignable LVal, Label labelEnd, ErrorListener errs) {
+        Assignable   varCond = createTempVar(code, pool().typeBoolean());
+        Assignable[] LVals   = new Assignable[] {varCond, LVal};
+
+        generateAssignments(ctx, code, LVals, errs);
+
+        code.add(new JumpTrue(varCond.getRegister(), labelEnd));
+    }
+
+    /**
      * Generate the necessary code that jumps to the specified label if this expression evaluates
      * to the boolean value indicated in <tt>fWhenTrue</tt>.
      *

--- a/javatools/src/main/java/org/xvm/compiler/ast/IsExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/IsExpression.java
@@ -248,11 +248,7 @@ public class IsExpression
         Expression exprTest  = expr2;
         Argument   argType;
 
-        // there is an asymmetry between processing of the static and dynamic exprTest type:
-        // - if the test type is static (e.g. "x.is(String)"), the type of exprTest is a
-        //     TypeConstant that "isTypeOfType" and we need to extract that underlying type;
-        // - in the test type is dynamic (e.g. "Null.is(Serializable))", the argument produced
-        //   by the exprTest would be a TypeHandle and the runtime should take care of the rest
+        // see the comment in "generateAssignments" regarding  static and dynamic types
         if (exprTest.isConstant()) {
             argType = exprTest.getType().getParamType(0).resolveAutoNarrowingBase();
         } else {

--- a/javatools/src/main/java/org/xvm/compiler/ast/IsExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/IsExpression.java
@@ -237,6 +237,44 @@ public class IsExpression
     }
 
     @Override
+    public void generateConditionalAssignment(Context ctx, Code code, Assignable LVal,
+                                              Label lblEnd, ErrorListener errs) {
+        if (!LVal.isLocalArgument()) {
+            super.generateConditionalAssignment(ctx, code, LVal, lblEnd, errs);
+            return;
+        }
+
+        Argument   argTarget = expr1.generateArgument(ctx, code, true, errs);
+        Expression exprTest  = expr2;
+        Argument   argType;
+
+        // there is an asymmetry between processing of the static and dynamic exprTest type:
+        // - if the test type is static (e.g. "x.is(String)"), the type of exprTest is a
+        //     TypeConstant that "isTypeOfType" and we need to extract that underlying type;
+        // - in the test type is dynamic (e.g. "Null.is(Serializable))", the argument produced
+        //   by the exprTest would be a TypeHandle and the runtime should take care of the rest
+        if (exprTest.isConstant()) {
+            argType = exprTest.getType().getParamType(0).resolveAutoNarrowingBase();
+        } else {
+            argType = exprTest.generateArgument(ctx, code, false, errs);
+            if (argType instanceof TypeConstant type) {
+                argType = type.getParamType(0);
+            }
+        }
+
+        Label lblCond  = getConditionFalseLabel();
+        Label lblIsNot = lblCond == null ? new Label("skip_assign") : lblCond;
+
+        code.add(new JumpNType(argTarget, argType, lblIsNot));
+        LVal.assign(argTarget, code, errs);
+        code.add(new Jump(lblEnd));
+
+        if (lblCond == null) {
+            code.add(lblIsNot);
+        }
+    }
+
+    @Override
     public void generateConditionalJump(
             Context ctx, Code code, Label label, boolean fWhenTrue, ErrorListener errs) {
         Argument argTarget = expr1.generateArgument(ctx, code, true, errs);


### PR DESCRIPTION
This fix streamlines the op flow control for ops generated by the IsExpression used for a conditional assignment