### PR TITLE
Add disass --module-name-only flag

### DIFF
--- a/javatools/src/main/java/org/xvm/tool/Disassembler.java
+++ b/javatools/src/main/java/org/xvm/tool/Disassembler.java
@@ -18,6 +18,7 @@ import org.xvm.asm.Constant.Format;
 import org.xvm.asm.ErrorListener;
 import org.xvm.asm.FileStructure;
 import org.xvm.asm.MethodStructure;
+import org.xvm.asm.ModuleStructure;
 
 import org.xvm.asm.constants.FSNodeConstant;
 import org.xvm.asm.constants.StringConstant;
@@ -79,7 +80,9 @@ public class Disassembler extends Launcher<DisassemblerOptions> {
     protected void validateOptions() {
         options().getTarget().ifPresentOrElse(
             file -> {
-                if (!file.exists()) {
+                // .xtc targets are file paths and must exist on disk; bare module names are
+                // resolved later against the module path by process()
+                if (file.getName().endsWith(".xtc") && !file.exists()) {
                     log(ERROR, "Module file does not exist: {}", file);
                 }
             },
@@ -121,7 +124,9 @@ public class Disassembler extends Launcher<DisassemblerOptions> {
 
         if (component != null) {
             var optFindFile = opts.getFindFile();
-            if (opts.isListFiles()) {
+            if (opts.isModuleNameOnly()) {
+                out(qualifiedModuleName(component));
+            } else if (opts.isListFiles()) {
                 dumpFiles(component);
             } else if (optFindFile.isPresent()) {
                 findFile(component, optFindFile.get());
@@ -131,6 +136,19 @@ public class Disassembler extends Launcher<DisassemblerOptions> {
             component.getConstantPool();
         }
         return hasSeriousErrors() ? 1 : 0;
+    }
+
+    /**
+     * Extract the fully qualified module name from a loaded component, which is either a
+     * {@link FileStructure} (when the user passed an .xtc file) or a {@link ModuleStructure}
+     * (when the user passed a module name resolved against the module path).
+     */
+    private static String qualifiedModuleName(Component component) {
+        return switch (component) {
+            case FileStructure fs -> fs.getModuleId().getName();
+            case ModuleStructure ms -> ms.getIdentityConstant().getName();
+            default -> component.getIdentityConstant().getName();
+        };
     }
 
     public void dump(Component component) {

--- a/javatools/src/main/java/org/xvm/tool/LauncherOptions.java
+++ b/javatools/src/main/java/org/xvm/tool/LauncherOptions.java
@@ -108,7 +108,9 @@ public abstract class LauncherOptions {
     private static final Options DISASSEMBLER_OPTIONS = copyOptions(COMMON_OPTIONS)
         .addOption(builder().longOpt("files").desc("List all files embedded in the module").get())
         .addOption(builder().longOpt("findfile").argName("file").hasArg()
-            .desc("File to search for in the module").get());
+            .desc("File to search for in the module").get())
+        .addOption(builder().longOpt("module-name-only")
+            .desc("Print only the fully qualified name of the module, then exit").get());
 
     /**
      * Apache Commons CLI Options schema for the initializer.
@@ -1524,6 +1526,10 @@ public abstract class LauncherOptions {
             return optionValue("findfile").map(File::new);
         }
 
+        public boolean isModuleNameOnly() {
+            return hasOption("module-name-only");
+        }
+
         @Override
         public String[] toCommandLine() {
             final List<String> args = new ArrayList<>();
@@ -1532,6 +1538,9 @@ public abstract class LauncherOptions {
                 args.add("--files");
             }
             getFindFile().ifPresent(findFile -> args.addAll(List.of("--findfile", findFile.getPath())));
+            if (isModuleNameOnly()) {
+                args.add("--module-name-only");
+            }
             getTarget().ifPresent(target -> args.add(target.getPath()));
             return args.toArray(String[]::new);
         }
@@ -1590,6 +1599,26 @@ public abstract class LauncherOptions {
             @SuppressWarnings("unused")
             public Builder findEmbeddedFile(final String file) {
                 return findEmbeddedFile(new File(file));
+            }
+
+            /**
+             * Print only the fully qualified module name, then exit.
+             */
+            @SuppressWarnings("unused")
+            public Builder moduleNameOnly() {
+                return moduleNameOnly(true);
+            }
+
+            /**
+             * Print only the fully qualified module name, then exit.
+             *
+             * @param only true to print only the module name, false otherwise
+             */
+            public Builder moduleNameOnly(final boolean only) {
+                if (only) {
+                    args.add("--module-name-only");
+                }
+                return this;
             }
 
             /**


### PR DESCRIPTION
## Summary

- New `xtc disass --module-name-only` flag prints just the fully qualified module name (e.g. `web.xtclang.org`) of the target, then exits. Works against both an `.xtc` file path and a module name resolved against `-L`.
- Drive-by fix to a pre-existing bug in `Disassembler.validateOptions()`: it unconditionally rejected any target that did not exist as a file on disk, which made `disass <name> -L <path>` unreachable. Validation now only checks file existence for `.xtc` paths; bare module names fall through to the module-path repository as the code in `process()` always intended.

## Motivation

CI pipelines that publish a compiled module to a service which requires its FQN (e.g. registering a `@WebApp` module via `curl`) currently have to hardcode the qualified suffix as an env var, because nothing on the published `.xtc` byte stream is exposed via the CLI. With this flag a CI script can do:

```bash
FQN=$(xtc disass --module-name-only build/.../web.xtc)
curl ... --data-urlencode "module=$FQN" ...
```

## Test plan

- [x] `xtc disass --module-name-only <file>.xtc` prints the FQN for `net.xtc`, `web.xtc`, `aggregate.xtc`, `collections.xtc`
- [x] `xtc disass --module-name-only -L <lib> <module-name>` prints the FQN for `net.xtclang.org`, `web.xtclang.org`, `collections.xtclang.org`, `ecstasy.xtclang.org`
- [x] Nonexistent `.xtc` path → clean error, non-zero exit
- [x] Unknown module name on `-L` → clean error, non-zero exit
- [x] Regular `xtc disass` (no flag) still works for both `.xtc` paths and module names
- [x] `xtc disass --help` lists `--module-name-only` with description
- [x] Full `./gradlew clean` then `./gradlew build` succeeds