### PR TITLE
LSP: stop underlining imports, add URL document links, source-root config

### DIFF
--- a/.github/github-workflows.md
+++ b/.github/github-workflows.md
@@ -7,12 +7,13 @@ This document describes the XVM project's CI/CD pipeline, workflow architecture,
 1. [Pipeline Overview](#pipeline-overview)
 2. [Architecture: Build Artifacts vs Releases](#architecture-build-artifacts-vs-releases)
 3. [Master Push Flow](#master-push-flow)
-4. [Workflows Reference](#workflows-reference)
-5. [Actions Reference](#actions-reference)
-6. [Testing Publishing on Non-Master Branches](#testing-publishing-on-non-master-branches)
-7. [Manual Testing](#manual-testing)
-8. [Version Gating](#version-gating)
-9. [Troubleshooting](#troubleshooting)
+4. [IntelliJ Plugin & Lang Validation Gating](#intellij-plugin--lang-validation-gating)
+5. [Workflows Reference](#workflows-reference)
+6. [Actions Reference](#actions-reference)
+7. [Testing Publishing on Non-Master Branches](#testing-publishing-on-non-master-branches)
+8. [Manual Testing](#manual-testing)
+9. [Version Gating](#version-gating)
+10. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -189,6 +190,56 @@ xdk.version=0.4.4-SNAPSHOT
 ### Manual Execution (any branch)
 
 All workflows support `workflow_dispatch` for manual testing from any branch.
+
+---
+
+## IntelliJ Plugin & Lang Validation Gating
+
+The lang composite build (`lang/`) and the IntelliJ plugin lane are gated separately from the rest of the XDK build, because resolving the IntelliJ plugin dependencies makes Gradle noticeably slower. The gating is driven by the `dorny/paths-filter` step in `commit.yml`, which sets `lang=true` whenever any file under `lang/**` changed.
+
+### Plugin: build, verify, publish
+
+Build, verify, and publish always travel together — they're all gated by the same `effective-publish-intellij` flag computed in `commit.yml`'s `Compute IntelliJ publish flags` step.
+
+| # | Event | Branch | `lang/` changed | Workflow inputs | Plugin built & verified | Plugin published (GitHub release ZIP) |
+|---|-------|--------|-----------------|------------------|--------------------------|----------------------------------------|
+| 1 | `push` | `master` | ✓ | — | ✅ yes | ✅ yes (auto on merge) |
+| 2 | `push` | `master` | ✗ | — | ⏭️ no | ⏭️ no |
+| 3 | `pull_request` | any | ✓ or ✗ | n/a | ⏭️ no | ⏭️ no |
+| 4 | `push` | non-master | ✓ or ✗ | n/a | ⏭️ no | ⏭️ no |
+| 5 | `workflow_dispatch` | any | ✓ | `publish-intellij-plugin=true` | ✅ yes | ✅ yes |
+| 6 | `workflow_dispatch` | any | ✗ | `publish-intellij-plugin=true` | ⏭️ no (reason logged) | ⏭️ no |
+| 7 | `workflow_dispatch` | any | ✓ or ✗ | `force-publish-intellij-plugin=true` | ✅ yes (override) | ✅ yes (override) |
+| 8 | `workflow_dispatch` | any | ✓ or ✗ | neither flag set | ⏭️ no | ⏭️ no |
+
+Plain-English summary:
+
+- **Default policy**: the plugin only ships when there's a real reason — `lang/` was touched and the change merged to master.
+- **Manual trigger**: `publish-intellij-plugin=true` does the same thing on demand from any branch, still gated on lang changes.
+- **Override**: `force-publish-intellij-plugin=true` is the one escape hatch that ignores the lang-changed gate (useful for emergency re-publish without a code change).
+
+### LSP / tree-sitter tests (independent of publishing)
+
+The LSP unit tests and tree-sitter grammar/corpus validation run on every event where lang/ was touched, regardless of publish flags. This is the cheap signal for catching regressions on the way in — every PR that edits `lang/` runs the suite, even though no plugin is built.
+
+| # | Event | `lang/` changed | Runner | LSP & tree-sitter tests |
+|---|-------|------------------|--------|--------------------------|
+| 1 | any | ✓ | `ubuntu-latest` | ✅ run (path filter triggers) |
+| 2 | any | ✗ | `ubuntu-latest` | ⏭️ skip (logged as "no changes under lang/") |
+| 3 | any | any | `windows-latest` | ⏭️ skip (Ubuntu-only step) |
+
+The validation step passes `-PincludeBuildLang=true -PincludeBuildAttachLang=true` directly to its `./gradlew` invocations rather than relying on the job-level env, so the lang composite build is included only for those specific commands. The rest of the job continues to run with lang excluded.
+
+### What's published where
+
+| Artifact | Trigger | Destination |
+|----------|---------|-------------|
+| XDK Maven snapshots | always on `push` to `master` | Maven Central Snapshots, GitHub Packages |
+| XDK GitHub release (snapshot) | always on `push` to `master` | GitHub Releases |
+| **IntelliJ plugin snapshot ZIP** | per the table above (`effective-publish-intellij=true`) | GitHub Releases (attached to the snapshot release) |
+| IntelliJ Marketplace | **not** by this workflow — release-only via `promote-release.yml` | JetBrains Marketplace |
+
+Note on Marketplace: snapshot CI never pushes to JetBrains Marketplace. That's intentional — Marketplace is for tagged releases, handled by the separate `promote-release.yml` flow.
 
 ---
 

--- a/.github/github-workflows.md
+++ b/.github/github-workflows.md
@@ -218,6 +218,17 @@ Plain-English summary:
 - **Manual trigger**: `publish-intellij-plugin=true` does the same thing on demand from any branch, still gated on lang changes.
 - **Override**: `force-publish-intellij-plugin=true` is the one escape hatch that ignores the lang-changed gate (useful for emergency re-publish without a code change).
 
+### Why two `workflow_dispatch` inputs (`publish-intellij-plugin` vs. `force-publish-intellij-plugin`)?
+
+These two booleans look similar but mean different things; they are not redundant.
+
+| Input | Effect | Respects lang-changed gate? | When to use |
+|-------|--------|------------------------------|-------------|
+| `publish-intellij-plugin=true` | "Publish the plugin **if** there's something new to publish." Treats this manual run the same way a master push does — runs only when `lang/` actually changed. | ✅ Yes — no-op if `lang/` is untouched. | Testing the publication pipeline from a branch when you've made lang changes. |
+| `force-publish-intellij-plugin=true` | "Publish the plugin no matter what." Skips the lang-changed check entirely. | ❌ No — always publishes. | Emergency re-publish without a code change (corrupted artifact, broken JetBrains release, manual version bump, etc.). Intended as an escape hatch, not the default knob. |
+
+In short: `publish-intellij-plugin` mirrors the natural master-push policy and is **safe to leave on** — it self-suppresses when there's nothing to publish. `force-publish-intellij-plugin` is the **override** that ignores all gating and should be used sparingly.
+
 ### LSP / tree-sitter tests (independent of publishing)
 
 The LSP unit tests and tree-sitter grammar/corpus validation run on every event where lang/ was touched, regardless of publish flags. This is the cheap signal for catching regressions on the way in — every PR that edits `lang/` runs the suite, even though no plugin is built.

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -147,7 +147,23 @@ jobs:
                   filters: |
                       lang:
                         - 'lang/**'
-                        - 'lib_ecstasy/**/*.x'
+
+            - name: 🌳 Lang validation decision
+              shell: bash
+              run: |
+                  LANG_CHANGED="${{ steps.changes.outputs.lang }}"
+                  echo ""
+                  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                  if [ "$LANG_CHANGED" = "true" ]; then
+                      echo "🌳 lang/ CHANGED -- WILL build lang composite and run LSP/tree-sitter tests"
+                  else
+                      echo "⏭️ no changes under lang/ -- WILL SKIP lang composite build and LSP/tree-sitter tests"
+                      echo "   (the rest of the build runs without -PincludeBuildLang=true to avoid the IntelliJ plugin resolution cost)"
+                  fi
+                  echo "  📋 path-filter result : lang=${LANG_CHANGED:-<unset>}"
+                  echo "  📋 runner             : ${{ matrix.os }} (lang validation only runs on ubuntu-latest)"
+                  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                  echo ""
 
             - name: Compute IntelliJ publish flags
               id: publish-flags
@@ -157,20 +173,31 @@ jobs:
                   REQUESTED="${{ github.event.inputs.publish-intellij-plugin }}"
                   LANG_CHANGED="${{ steps.changes.outputs.lang }}"
                   EVENT_NAME="${{ github.event_name }}"
+                  REF="${{ github.ref }}"
                   EFFECTIVE=false
                   REASON=""
+                  # Gating policy:
+                  #   1. force-publish-intellij-plugin=true (workflow_dispatch only) -> always publish
+                  #   2. push to master with lang changes detected -> auto-publish
+                  #   3. workflow_dispatch with publish-intellij-plugin=true and lang changes detected -> publish
+                  # Anything else -> skip, with a reason.
                   if [ "$FORCE" = "true" ]; then
                       EFFECTIVE=true
-                      REASON="forced via force-publish-intellij-plugin=true (overrides publish-intellij-plugin and lang change gating)"
+                      REASON="forced via force-publish-intellij-plugin=true (overrides all other gating)"
+                  elif [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/master" ] && [ "$LANG_CHANGED" = "true" ]; then
+                      EFFECTIVE=true
+                      REASON="auto-publish on master merge with changes detected under lang/"
+                  elif [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/master" ]; then
+                      REASON="master push but no changes under lang/ -- nothing to publish (use force-publish-intellij-plugin=true via workflow_dispatch to override)"
                   elif [ "$REQUESTED" = "true" ] && [ "$LANG_CHANGED" = "true" ]; then
                       EFFECTIVE=true
-                      REASON="publish-intellij-plugin=true and changes detected under lang/ or lib_ecstasy/**/*.x"
+                      REASON="manual dispatch with publish-intellij-plugin=true and changes detected under lang/"
                   elif [ "$REQUESTED" = "true" ]; then
-                      REASON="publish-intellij-plugin=true but no changes detected under lang/ or lib_ecstasy/**/*.x (set force-publish-intellij-plugin=true to override)"
+                      REASON="manual dispatch with publish-intellij-plugin=true but no changes detected under lang/ (set force-publish-intellij-plugin=true to override)"
                   elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-                      REASON="neither publish-intellij-plugin nor force-publish-intellij-plugin was enabled for this workflow_dispatch run"
+                      REASON="manual dispatch but neither publish-intellij-plugin nor force-publish-intellij-plugin was enabled"
                   else
-                      REASON="event=$EVENT_NAME does not request IntelliJ plugin publishing (no workflow_dispatch inputs available)"
+                      REASON="event=$EVENT_NAME on $REF -- IntelliJ plugin only publishes on master push or manual dispatch"
                   fi
                   echo "effective=$EFFECTIVE" >> $GITHUB_OUTPUT
                   echo "force=$FORCE" >> $GITHUB_OUTPUT
@@ -186,8 +213,8 @@ jobs:
                   echo "  📋 Reason             : $REASON"
                   echo "  📋 force-publish-intellij-plugin : ${FORCE:-<unset>}"
                   echo "  📋 publish-intellij-plugin       : ${REQUESTED:-<unset>}"
-                  echo "  📋 lang/lib_ecstasy changed      : ${LANG_CHANGED:-<unset>}"
-                  echo "  📋 event                         : $EVENT_NAME"
+                  echo "  📋 lang/ changed                 : ${LANG_CHANGED:-<unset>}"
+                  echo "  📋 event                         : $EVENT_NAME on $REF"
                   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
                   echo ""
 
@@ -401,23 +428,25 @@ jobs:
               if: |
                   success() &&
                   matrix.os == 'ubuntu-latest' &&
-                  env.ORG_GRADLE_PROJECT_includeBuildLang == 'true' &&
                   steps.changes.outputs.lang != 'true'
               run: |
-                  echo "⏭️ Skipping Tree-sitter validation - no changes in lang/ or lib_ecstasy/*.x"
+                  echo "⏭️ Skipping Tree-sitter validation - no changes in lang/"
                   echo "Changed paths filter result: lang=${{ steps.changes.outputs.lang }}"
 
             - name: Validate Tree-sitter Grammar and LSP Adapters
               if: |
                   success() &&
                   matrix.os == 'ubuntu-latest' &&
-                  env.ORG_GRADLE_PROJECT_includeBuildLang == 'true' &&
                   steps.changes.outputs.lang == 'true'
               shell: bash
               env:
                   GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
               run: |
                   GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }}"
+                  # Enable the lang composite build only for these lang/LSP-targeted invocations.
+                  # The job-level env keeps lang excluded for the rest of the build to avoid
+                  # paying the IntelliJ-plugin resolution cost on every CI run.
+                  LANG_OPTS="-PincludeBuildLang=true -PincludeBuildAttachLang=true"
 
                   echo ""
                   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -425,17 +454,17 @@ jobs:
                   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
                   echo "📋 Validating grammar compiles (tree-sitter generate)..."
-                  ./gradlew $GRADLE_OPTIONS :lang:tree-sitter:validateTreeSitterGrammar
+                  ./gradlew $GRADLE_OPTIONS $LANG_OPTS :lang:tree-sitter:validateTreeSitterGrammar
                   echo "✅ Grammar: VALID"
 
                   echo ""
                   echo "📋 Testing parser on XDK corpus (with timing)..."
-                  ./gradlew $GRADLE_OPTIONS :lang:tree-sitter:testTreeSitterParse
+                  ./gradlew $GRADLE_OPTIONS $LANG_OPTS :lang:tree-sitter:testTreeSitterParse
                   echo "✅ Corpus parsing: PASSED"
 
                   echo ""
                   echo "📋 Building native libraries for all platforms..."
-                  ./gradlew $GRADLE_OPTIONS :lang:tree-sitter:buildAllNativeLibrariesOnDemand
+                  ./gradlew $GRADLE_OPTIONS $LANG_OPTS :lang:tree-sitter:buildAllNativeLibrariesOnDemand
                   echo "✅ Native libraries: BUILT (cached by content hash)"
 
                   echo ""
@@ -443,14 +472,15 @@ jobs:
                   echo "🔌 LSP ADAPTER TESTS"
                   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-                  echo ""
-                  echo "📋 Running LSP tests with MOCK adapter (-Plsp.adapter=mock)..."
-                  ./gradlew $GRADLE_OPTIONS :lang:lsp-server:test -Plsp.adapter=mock
-                  echo "✅ Mock adapter tests: PASSED"
+                  # Mock adapter is being retired; tree-sitter is the default and only supported adapter.
+                  # echo ""
+                  # echo "📋 Running LSP tests with MOCK adapter (-Plsp.adapter=mock)..."
+                  # ./gradlew $GRADLE_OPTIONS $LANG_OPTS :lang:lsp-server:test -Plsp.adapter=mock
+                  # echo "✅ Mock adapter tests: PASSED"
 
                   echo ""
                   echo "📋 Running LSP tests with TREESITTER adapter (-Plsp.adapter=treesitter)..."
-                  ./gradlew $GRADLE_OPTIONS :lang:lsp-server:test -Plsp.adapter=treesitter
+                  ./gradlew $GRADLE_OPTIONS $LANG_OPTS :lang:lsp-server:test -Plsp.adapter=treesitter
                   echo "✅ Tree-sitter adapter tests: PASSED"
 
                   echo ""
@@ -742,7 +772,7 @@ jobs:
                   MANUAL_TEST_STATUS="✅ Passed"
                   MANUAL_TEST_REASON="executed in the main CI build"
                   LANG_VALIDATION_STATUS="⏭️ Skipped"
-                  LANG_VALIDATION_REASON="lang build not enabled for this run"
+                  LANG_VALIDATION_REASON="not run on this runner"
                   if [ "${{ matrix.os }}" = "ubuntu-latest" ] && {
                        [ "${{ github.ref }}" = "refs/heads/master" ] && [ "${{ github.event_name }}" = "push" ];
                      } || {
@@ -756,13 +786,13 @@ jobs:
                       MANUAL_TEST_STATUS="⏭️ Skipped"
                       MANUAL_TEST_REASON="disabled for this run"
                   fi
-                  if [ "${{ matrix.os }}" = "ubuntu-latest" ] && [ "${{ env.ORG_GRADLE_PROJECT_includeBuildLang }}" = "true" ]; then
+                  if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
                       if [ "${{ steps.changes.outputs.lang }}" = "true" ]; then
                           LANG_VALIDATION_STATUS="✅ Ran"
-                          LANG_VALIDATION_REASON="lang build enabled and path filter matched"
+                          LANG_VALIDATION_REASON="path filter detected changes under lang/"
                       else
                           LANG_VALIDATION_STATUS="⏭️ Skipped"
-                          LANG_VALIDATION_REASON="lang build enabled but path filter found no relevant changes"
+                          LANG_VALIDATION_REASON="no changes under lang/"
                       fi
                   fi
                   if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/adapter/treesitter/TreeSitterAdapter.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/adapter/treesitter/TreeSitterAdapter.kt
@@ -141,6 +141,16 @@ class TreeSitterAdapter : AbstractAdapter() {
          */
         const val MIN_JAVA_VERSION = 25
 
+        /**
+         * Conservative `http(s)` URL matcher for document-link extraction.
+         * Stops at the first whitespace, quote, angle bracket, or closing paren/bracket --
+         * common sentence-terminating punctuation is then trimmed in [urlTrailingTrim].
+         */
+        private val urlPattern = Regex("""\bhttps?://[^\s<>"'`)\]]+""")
+
+        /** Trailing punctuation stripped from a URL match (sentence-final commas, periods, etc.). */
+        private val urlTrailingTrim = charArrayOf('.', ',', ';', ':', '!', '?', ')', ']', '}')
+
         /** Symbol kinds that represent types (for type-position completion filtering). */
         private val typeSymbolKinds =
             setOf(
@@ -1281,27 +1291,64 @@ class TreeSitterAdapter : AbstractAdapter() {
         return formatter.onTypeFormatting(tree, line, column, ch, config)
     }
 
+    /**
+     * Emit document links for `http(s)` URLs that appear inside comments and string literals.
+     *
+     * Imports deliberately do NOT participate -- navigation between an `import` and its
+     * declaration is the job of `textDocument/definition` (Cmd/Ctrl-click), which is
+     * position-aware and knows the difference between a package component and a type
+     * component. Document links are reserved for free-text content where there is no
+     * AST-level "declaration" to jump to (URLs in `// see https://...`, etc.).
+     */
     override fun getDocumentLinks(
         uri: String,
         content: String,
     ): List<DocumentLink> {
-        logger.info("getDocumentLinks: uri={}, {} bytes", uri.substringAfterLast('/'), content.length)
-        val tree =
-            parsedTrees[uri] ?: run {
-                logger.info("getDocumentLinks: no parsed tree for uri")
-                return emptyList()
+        val tree = parsedTrees[uri] ?: return emptyList()
+        val hosts = queryEngine.findCommentAndStringNodes(tree, uri)
+        val links =
+            buildList {
+                for ((text, loc) in hosts) {
+                    urlPattern.findAll(text).forEach { match ->
+                        // Strip trailing punctuation that's almost never part of the URL itself
+                        // (sentences in comments end with these, e.g. "see https://example.com.")
+                        val trimmed = match.value.trimEnd(*urlTrailingTrim)
+                        if (trimmed.isEmpty()) return@forEach
+                        val range = rangeWithinText(text, match.range.first, trimmed.length, loc)
+                        add(DocumentLink(range, trimmed, trimmed))
+                    }
+                }
             }
-        val imports = queryEngine.findImportLocations(tree, uri)
-        logger.info("getDocumentLinks -> {} links", imports.size)
-        return imports.map { (importPath, loc) ->
-            val simpleName = importPath.substringAfterLast(".")
-            val targetUri =
-                simpleName
-                    .takeIf { indexReady.get() }
-                    ?.let { workspaceIndex.findByName(it).firstOrNull()?.uri }
-            val range = Range(Position(loc.startLine, loc.startColumn), Position(loc.endLine, loc.endColumn))
-            DocumentLink(range, targetUri, "import $importPath")
+        logger.info("getDocumentLinks: {} URL links across {} comment/string nodes", links.size, hosts.size)
+        return links
+    }
+
+    /**
+     * Convert an offset+length within a host node's text into an absolute LSP [Range].
+     * URLs cannot contain whitespace, so the match is always single-line, but the host
+     * node (e.g., a block comment) may span many lines, so we walk the prefix counting
+     * newlines to find the absolute (line, column) for the start.
+     */
+    private fun rangeWithinText(
+        text: String,
+        matchStart: Int,
+        matchLen: Int,
+        host: Location,
+    ): Range {
+        var line = host.startLine
+        var col = host.startColumn
+        for (i in 0 until matchStart) {
+            if (text[i] == '\n') {
+                line++
+                col = 0
+            } else {
+                col++
+            }
         }
+        val startLine = line
+        val startCol = col
+        // URL has no newlines -- end is on the same line, +matchLen columns
+        return Range(Position(startLine, startCol), Position(startLine, startCol + matchLen))
     }
 
     override fun getSemanticTokens(uri: String): SemanticTokens? {

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/SourceRootResolver.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/SourceRootResolver.kt
@@ -1,0 +1,102 @@
+package org.xvm.lsp.server
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Resolves extra `.x` source roots beyond the workspace folders the client opens.
+ *
+ * The workspace indexer only walks `.x` files inside the workspace, so any module that
+ * exists only as a compiled `.xtc` binary (or whose source lives outside the user's open
+ * project) is invisible to navigation. This resolver lets callers point the indexer at
+ * additional source-tree roots so e.g. the XDK standard-library sources can be discovered
+ * even when the user is working on an unrelated project.
+ *
+ * Sources, all merged (dedup, non-existent paths dropped with a warning):
+ *  1. LSP `initializationOptions.xtcSourceRoots` -- an array of paths sent by the client
+ *  2. System property `-Dxtc.sourceRoots=<a>${File.pathSeparator}<b>`
+ *  3. Env var `XTC_SOURCE_ROOTS=<a>${File.pathSeparator}<b>`
+ *
+ * The returned paths are absolute filesystem paths (not URIs), matching the contract of
+ * [org.xvm.lsp.index.WorkspaceIndexer.scanWorkspace].
+ */
+internal object SourceRootResolver {
+    const val INIT_OPTION_KEY = "xtcSourceRoots"
+    const val SYSTEM_PROPERTY = "xtc.sourceRoots"
+    const val ENV_VAR = "XTC_SOURCE_ROOTS"
+
+    private val logger = LoggerFactory.getLogger(SourceRootResolver::class.java)
+
+    /**
+     * Resolve extra source roots from all configured inputs.
+     *
+     * @param initializationOptions raw init-options value from the LSP `initialize` request --
+     *                              accepts `Map<*, *>`, Gson `JsonObject`/`JsonElement`, or null
+     * @param systemProperty        defaults to `System.getProperty("xtc.sourceRoots")`
+     * @param envVar                defaults to `System.getenv("XTC_SOURCE_ROOTS")`
+     */
+    fun resolve(
+        initializationOptions: Any?,
+        systemProperty: String? = System.getProperty(SYSTEM_PROPERTY),
+        envVar: String? = System.getenv(ENV_VAR),
+    ): List<String> {
+        val fromInit = parseInitOptions(initializationOptions)
+        val fromSys = parsePathList(systemProperty)
+        val fromEnv = parsePathList(envVar)
+        val merged = (fromInit + fromSys + fromEnv).distinct()
+        if (merged.isEmpty()) return emptyList()
+
+        val (existing, missing) = merged.partition { Files.isDirectory(Path.of(it)) }
+        if (missing.isNotEmpty()) {
+            logger.warn("source roots: dropping {} non-existent path(s): {}", missing.size, missing)
+        }
+        if (existing.isNotEmpty()) {
+            logger.info(
+                "source roots: {} extra root(s) (init={}, sys={}, env={})",
+                existing.size,
+                fromInit.size,
+                fromSys.size,
+                fromEnv.size,
+            )
+        }
+        return existing
+    }
+
+    private fun parsePathList(raw: String?): List<String> =
+        raw
+            ?.split(File.pathSeparatorChar)
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() }
+            ?: emptyList()
+
+    private fun parseInitOptions(raw: Any?): List<String> {
+        if (raw == null) return emptyList()
+        val array =
+            when (raw) {
+                is Map<*, *> -> raw[INIT_OPTION_KEY]
+                is JsonObject -> raw.get(INIT_OPTION_KEY)
+                is JsonElement -> if (raw.isJsonObject) raw.asJsonObject.get(INIT_OPTION_KEY) else null
+                else -> null
+            } ?: return emptyList()
+
+        return when (array) {
+            is List<*> -> array.mapNotNull { it?.toString()?.trim()?.takeIf(String::isNotEmpty) }
+            is JsonArray -> array.mapNotNull { stringOrNull(it) }
+            is JsonElement -> if (array.isJsonArray) array.asJsonArray.mapNotNull { stringOrNull(it) } else emptyList()
+            else -> emptyList()
+        }
+    }
+
+    private fun stringOrNull(elem: JsonElement?): String? =
+        elem
+            ?.takeUnless { it.isJsonNull }
+            ?.takeIf { it.isJsonPrimitive }
+            ?.asString
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+}

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/XtcLanguageServer.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/XtcLanguageServer.kt
@@ -225,7 +225,7 @@ class XtcLanguageServer(
             logger.warn("initialize: adapter health check failed, skipping workspace indexing")
         } else {
             // Extract workspace folder paths and initialize workspace index
-            val folders =
+            val workspaceFolders =
                 params.workspaceFolders
                     ?.mapNotNull { folder ->
                         runCatching { Path.of(URI(folder.uri)).toString() }
@@ -233,6 +233,11 @@ class XtcLanguageServer(
                             .getOrNull()
                     }
                     ?: emptyList()
+
+            // Extra source roots (XDK source trees, etc.) from init options, sysprop, or env.
+            // Lets the indexer find modules whose sources live outside the user's open project.
+            val extraRoots = SourceRootResolver.resolve(params.initializationOptions)
+            val folders = (workspaceFolders + extraRoots).distinct()
 
             if (folders.isNotEmpty()) {
                 adapter.initializeWorkspace(folders) { message, percent ->
@@ -545,6 +550,10 @@ class XtcLanguageServer(
                 }
             // inlayHintProvider = Either.forLeft(true) // not implemented in TreeSitterAdapter yet
 
+            // Capability advertised so the client routes textDocument/documentLink requests here.
+            // Currently no link providers are wired in -- the adapter returns an empty list -- but
+            // keeping the capability lets us add non-import uses later (URLs in comments,
+            // doc-comment cross-refs, etc.) without renegotiating with running clients.
             documentLinkProvider = DocumentLinkOptions()
 
             signatureHelpProvider = SignatureHelpOptions(listOf("(", ","))

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueries.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueries.kt
@@ -42,6 +42,19 @@ internal object XtcQueries {
         """.trimIndent()
 
     /**
+     * Find comment and string-literal nodes -- the host nodes for free-text content
+     * (URLs, file paths, etc.) that may need document links.
+     */
+    val commentsAndStrings =
+        """
+        (line_comment) @text
+        (block_comment) @text
+        (doc_comment) @text
+        (string_literal) @text
+        (template_string_literal) @text
+        """.trimIndent()
+
+    /**
      * Combined query for all declarations (for document symbols).
      * Uses field-based matching for robust, position-independent queries.
      */

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
@@ -25,6 +25,7 @@ class XtcQueryEngine(
     private val methodDeclarationsQuery: Query = Query(language, XtcQueries.methodDeclarations)
     private val identifiersQuery: Query = Query(language, XtcQueries.identifiers)
     private val importsQuery: Query = Query(language, XtcQueries.imports)
+    private val commentsAndStringsQuery: Query = Query(language, XtcQueries.commentsAndStrings)
 
     /**
      * Find all declarations in the tree for document symbols.
@@ -279,6 +280,27 @@ class XtcQueryEngine(
         }
     }
 
+    /**
+     * Find all comment and string-literal nodes, returned as `(text, location)` pairs.
+     *
+     * These are the host nodes that may contain URLs, file paths, or other free-text
+     * content the editor can hyperlink. Caller is responsible for scanning the text
+     * and computing per-match ranges relative to the host node's start position.
+     */
+    fun findCommentAndStringNodes(
+        tree: XtcTree,
+        uri: String,
+    ): List<Pair<String, Location>> {
+        return buildList {
+            executeQuery("commentsAndStrings", commentsAndStringsQuery, tree) { captures ->
+                val node = captures["text"] ?: return@executeQuery
+                add(node.text to node.toLocation(uri))
+            }
+        }.also { nodes ->
+            logger.info("findCommentAndStringNodes -> {} nodes", nodes.size)
+        }
+    }
+
     private fun executeQuery(
         queryName: String,
         query: Query,
@@ -304,5 +326,6 @@ class XtcQueryEngine(
         methodDeclarationsQuery.close()
         identifiersQuery.close()
         importsQuery.close()
+        commentsAndStringsQuery.close()
     }
 }

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
@@ -279,43 +279,161 @@ class NavigationTest : TreeSitterTestBase() {
     }
 
     // ========================================================================
-    // getDocumentLinks()
+    // getDocumentLinks() -- URLs in comments and strings (NOT imports)
     // ========================================================================
 
     @Nested
     @DisplayName("getDocumentLinks()")
     inner class DocumentLinkTests {
-        /**
-         * After compiling source with `import` statements, `getDocumentLinks` should
-         * find them via `XtcQueryEngine.findImportLocations`. The exact result depends
-         * on whether the grammar nests imports inside the module body or at root level.
-         */
         @Test
-        @DisplayName("should find import links after compile")
-        fun shouldFindImportLinks() {
+        @DisplayName("should link URL in line comment")
+        fun shouldLinkUrlInLineComment() {
             val uri = freshUri()
             val source =
                 """
                 module myapp {
-                    import foo.Bar;
-                    import baz.Qux;
+                    // see https://example.com for details
+                    class Foo {}
                 }
                 """.trimIndent()
-
             ts.compile(uri, source)
 
-            assertThat(ts.getDocumentLinks(uri, source)).isNotNull
+            val links = ts.getDocumentLinks(uri, source)
+
+            assertThat(links).hasSize(1)
+            assertThat(links[0].target).isEqualTo("https://example.com")
+            // Line 1 (0-based), URL starts after "    // see "
+            assertThat(links[0].range.start.line).isEqualTo(1)
+            assertThat(links[0].range.start.column).isEqualTo("    // see ".length)
         }
 
-        /** A module with no imports should produce an empty link list. */
         @Test
-        @DisplayName("should return empty when no imports")
-        fun shouldReturnEmptyWhenNoImports() {
+        @DisplayName("should link URL in block comment, multi-line position correct")
+        fun shouldLinkUrlInBlockComment() {
             val uri = freshUri()
-            val source = "module myapp {}"
+            val source =
+                """
+                module myapp {
+                    /* block comment
+                       with https://anthropic.com on its own line
+                       and more text */
+                    class Foo {}
+                }
+                """.trimIndent()
+            ts.compile(uri, source)
+
+            val links = ts.getDocumentLinks(uri, source)
+
+            assertThat(links).hasSize(1)
+            assertThat(links[0].target).isEqualTo("https://anthropic.com")
+            // URL is on the third line of the source (0-based line 2)
+            assertThat(links[0].range.start.line).isEqualTo(2)
+            // Column is offset of "https" within that line
+            assertThat(links[0].range.start.column).isEqualTo("       with ".length)
+        }
+
+        @Test
+        @DisplayName("should link URL in doc comment")
+        fun shouldLinkUrlInDocComment() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    /** see http://docs.xtclang.org/guide */
+                    class Foo {}
+                }
+                """.trimIndent()
+            ts.compile(uri, source)
+
+            val links = ts.getDocumentLinks(uri, source)
+
+            assertThat(links).hasSize(1)
+            assertThat(links[0].target).isEqualTo("http://docs.xtclang.org/guide")
+        }
+
+        @Test
+        @DisplayName("should link URL in string literal")
+        fun shouldLinkUrlInStringLiteral() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    String home = "https://xtclang.org";
+                }
+                """.trimIndent()
+            ts.compile(uri, source)
+
+            val links = ts.getDocumentLinks(uri, source)
+
+            assertThat(links).hasSize(1)
+            assertThat(links[0].target).isEqualTo("https://xtclang.org")
+        }
+
+        @Test
+        @DisplayName("should find multiple URLs in one comment")
+        fun shouldFindMultipleUrls() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    // links: https://a.test https://b.test
+                    class Foo {}
+                }
+                """.trimIndent()
+            ts.compile(uri, source)
+
+            val links = ts.getDocumentLinks(uri, source)
+
+            assertThat(links).extracting<String>({ it.target }).containsExactlyInAnyOrder(
+                "https://a.test",
+                "https://b.test",
+            )
+        }
+
+        @Test
+        @DisplayName("should strip trailing sentence punctuation")
+        fun shouldStripTrailingPunctuation() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    // visit https://example.com.
+                    class Foo {}
+                }
+                """.trimIndent()
+            ts.compile(uri, source)
+
+            val links = ts.getDocumentLinks(uri, source)
+
+            assertThat(links).hasSize(1)
+            assertThat(links[0].target).isEqualTo("https://example.com")
+            // The matched range should also exclude the trailing dot
+            assertThat(links[0].range.end.column - links[0].range.start.column)
+                .isEqualTo("https://example.com".length)
+        }
+
+        @Test
+        @DisplayName("should NOT link imports")
+        fun shouldNotLinkImports() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    import crypto.CertificateManager;
+                    import json.xtclang.org;
+                }
+                """.trimIndent()
             ts.compile(uri, source)
 
             assertThat(ts.getDocumentLinks(uri, source)).isEmpty()
+        }
+
+        @Test
+        @DisplayName("should return empty when no URLs and no comments/strings")
+        fun shouldReturnEmpty() {
+            val uri = freshUri()
+            ts.compile(uri, "module myapp {}")
+            assertThat(ts.getDocumentLinks(uri, "module myapp {}")).isEmpty()
         }
     }
 

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/LspIntegrationTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/LspIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.eclipse.lsp4j.DefinitionParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.DocumentHighlightParams
-import org.eclipse.lsp4j.DocumentLinkParams
 import org.eclipse.lsp4j.DocumentRangeFormattingParams
 import org.eclipse.lsp4j.DocumentSymbolParams
 import org.eclipse.lsp4j.FoldingRangeRequestParams
@@ -618,32 +617,6 @@ class LspIntegrationTest {
 
             // May return actions or empty, should not crash
             assertThat(actions).isNotNull()
-        }
-    }
-
-    // ========================================================================
-    // Tests: textDocument/documentLink
-    // ========================================================================
-
-    @Nested
-    @DisplayName("textDocument/documentLink")
-    inner class DocumentLinkTests {
-        @Test
-        @DisplayName("should return document links for imports")
-        fun shouldReturnDocumentLinksForImports() {
-            val tf = openFile("TestSimple.x")
-
-            val links =
-                server.textDocumentService
-                    .documentLink(DocumentLinkParams(TextDocumentIdentifier(tf.uri)))
-                    .get()
-
-            // TestSimple.x has imports, so we should get links
-            assertThat(links).isNotNull()
-            // Both adapters should return links if the file has imports
-            if (tf.content.contains("import ")) {
-                assertThat(links).isNotEmpty()
-            }
         }
     }
 

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/SourceRootResolverTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/SourceRootResolverTest.kt
@@ -1,0 +1,149 @@
+package org.xvm.lsp.server
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+@DisplayName("SourceRootResolver")
+class SourceRootResolverTest {
+    @TempDir
+    lateinit var tmp: Path
+
+    /** Create a real directory under [tmp] so the existence-check passes. */
+    private fun realDir(name: String): String =
+        tmp
+            .resolve(name)
+            .also { it.toFile().mkdirs() }
+            .toString()
+
+    private fun pathList(vararg paths: String): String = paths.joinToString(File.pathSeparator)
+
+    @Nested
+    @DisplayName("init options")
+    inner class InitOptionsTests {
+        @Test
+        @DisplayName("should accept Map<String, List<String>> with xtcSourceRoots")
+        fun shouldAcceptMap() {
+            val a = realDir("a")
+            val b = realDir("b")
+            val opts = mapOf("xtcSourceRoots" to listOf(a, b))
+
+            val roots = SourceRootResolver.resolve(opts, systemProperty = null, envVar = null)
+
+            assertThat(roots).containsExactly(a, b)
+        }
+
+        @Test
+        @DisplayName("should accept Gson JsonObject")
+        fun shouldAcceptJsonObject() {
+            val a = realDir("a")
+            val arr = JsonArray().apply { add(JsonPrimitive(a)) }
+            val obj = JsonObject().apply { add("xtcSourceRoots", arr) }
+
+            val roots = SourceRootResolver.resolve(obj, systemProperty = null, envVar = null)
+
+            assertThat(roots).containsExactly(a)
+        }
+
+        @Test
+        @DisplayName("should ignore non-array value at xtcSourceRoots")
+        fun shouldIgnoreNonArrayValue() {
+            val opts = mapOf("xtcSourceRoots" to "not-a-list")
+            assertThat(SourceRootResolver.resolve(opts, systemProperty = null, envVar = null)).isEmpty()
+        }
+
+        @Test
+        @DisplayName("should return empty for null init options")
+        fun shouldReturnEmptyForNull() {
+            assertThat(SourceRootResolver.resolve(null, systemProperty = null, envVar = null)).isEmpty()
+        }
+
+        @Test
+        @DisplayName("should return empty when key absent")
+        fun shouldReturnEmptyWhenKeyAbsent() {
+            val opts = mapOf("otherKey" to listOf("/some/path"))
+            assertThat(SourceRootResolver.resolve(opts, systemProperty = null, envVar = null)).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("system property")
+    inner class SystemPropertyTests {
+        @Test
+        @DisplayName("should parse path-separated list")
+        fun shouldParsePathList() {
+            val a = realDir("a")
+            val b = realDir("b")
+
+            val roots = SourceRootResolver.resolve(null, systemProperty = pathList(a, b), envVar = null)
+
+            assertThat(roots).containsExactly(a, b)
+        }
+
+        @Test
+        @DisplayName("should ignore blank entries")
+        fun shouldIgnoreBlankEntries() {
+            val a = realDir("a")
+
+            val roots = SourceRootResolver.resolve(null, systemProperty = "${File.pathSeparator}$a${File.pathSeparator}", envVar = null)
+
+            assertThat(roots).containsExactly(a)
+        }
+    }
+
+    @Nested
+    @DisplayName("env var")
+    inner class EnvVarTests {
+        @Test
+        @DisplayName("should parse path-separated list")
+        fun shouldParseEnvList() {
+            val a = realDir("a")
+            val roots = SourceRootResolver.resolve(null, systemProperty = null, envVar = a)
+            assertThat(roots).containsExactly(a)
+        }
+    }
+
+    @Nested
+    @DisplayName("merging and filtering")
+    inner class MergingTests {
+        @Test
+        @DisplayName("should merge init options + sysprop + env, dedup")
+        fun shouldMergeAndDedup() {
+            val a = realDir("a")
+            val b = realDir("b")
+            val c = realDir("c")
+            val opts = mapOf("xtcSourceRoots" to listOf(a, b))
+
+            val roots = SourceRootResolver.resolve(opts, systemProperty = pathList(b, c), envVar = a)
+
+            // a, b from init; c new from sysprop; b duplicate; a duplicate from env
+            assertThat(roots).containsExactly(a, b, c)
+        }
+
+        @Test
+        @DisplayName("should drop non-existent paths")
+        fun shouldDropMissingPaths() {
+            val real = realDir("real")
+            val fake = tmp.resolve("does-not-exist").toString()
+            val opts = mapOf("xtcSourceRoots" to listOf(real, fake))
+
+            val roots = SourceRootResolver.resolve(opts, systemProperty = null, envVar = null)
+
+            assertThat(roots).containsExactly(real)
+        }
+
+        @Test
+        @DisplayName("should return empty when all sources are null/empty")
+        fun shouldReturnEmptyForAllNull() {
+            assertThat(SourceRootResolver.resolve(null, systemProperty = null, envVar = null)).isEmpty()
+            assertThat(SourceRootResolver.resolve(null, systemProperty = "", envVar = "")).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three related changes to the XTC language-server's import/navigation behavior, motivated by Gene's report that some `import` lines were inconsistently underlined in the IDE while others were not.

- **Stop emitting document links for `import` statements.** The previous resolver looked up only the trailing simple name (`importPath.substringAfterLast('.')`), so `import crypto.CertificateManager;` got a link (because `CertificateManager` matched a workspace symbol) and `import json.xtclang.org;` did not (because the lookup was for `"org"`). Cmd/Ctrl-click navigation already works for imports via `textDocument/definition`, which is position-aware -- it knows the difference between a package component and a type component, and degrades gracefully when nothing resolves.
- **Add URL document links inside comments and string literals.** That's the kind of free-text content `documentLink` actually exists for. The detector matches `http(s)://...` inside `line_comment`, `block_comment`, `doc_comment`, `string_literal`, and `template_string_literal` nodes, trims trailing sentence punctuation, and computes correct ranges across multi-line block comments.
- **Add `SourceRootResolver` for extra `.x` source roots.** Users whose imported modules live outside their open workspace folders (e.g. XDK standard-library sources in another checkout) can now extend the indexer via LSP `initializationOptions.xtcSourceRoots`, the system property `xtc.sourceRoots`, or the env var `XTC_SOURCE_ROOTS` (path-separator-delimited). Non-existent paths are dropped with a warning. Workspace folders take precedence; extra roots are merged and deduplicated.

The `documentLinkProvider` LSP capability is still advertised so the IntelliJ plugin doesn't have to renegotiate when we plug in additional non-import providers later (file-path links in resource strings, doc-comment cross-references, etc.).

## Test plan

- [x] `./gradlew :lang:lsp-server:test` -- 320+ tests, 19 new (8 URL-link cases, 11 `SourceRootResolver` cases), all green.
- [ ] Manual: open a `.x` file with `import json.xtclang.org;` -- verify no underline.
- [ ] Manual: open a `.x` file with `// see https://example.com` -- verify the URL is underlined and Cmd-click opens the browser.
- [ ] Manual: open a `.x` file with `import crypto.CertificateManager;` -- verify Cmd-click on `CertificateManager` jumps to the class declaration.
- [ ] Manual: launch the LSP with `XTC_SOURCE_ROOTS=/path/to/xtclang2/lib_json/src/main/x` from outside the monorepo -- verify Cmd-click on `json.xtclang.org` resolves into that source tree.

## Notes / follow-ups

- This does **not** index `.xtc` binaries -- a module that exists only in compiled form is still invisible to navigation. Resolving that would require either an XTC binary reader plus a virtual decompiled view, or shipping `.x` sources alongside the install distribution. Out of scope here.
- The IntelliJ plugin doesn't yet expose `xtcSourceRoots` as a settings panel; for now the env var or system property is the practical path. Plugin-side work is a follow-up.