### PR TITLE
LSP: doc-comment landing fix + simplify carry-overs from #446

### DIFF
--- a/lang/doc/MANUAL_TEST_PLAN.md
+++ b/lang/doc/MANUAL_TEST_PLAN.md
@@ -192,12 +192,12 @@ module TestModule {
 | 4.7 | Local shadowing class member | Class with `Boolean whitespace;`. Method declaring `function Boolean(Char) whitespace = ...;` and using `whitespace(test)`. Ctrl+Click on the `whitespace` call | Jumps to the local function-typed variable, NOT to the class field |
 | 4.8 | Inner block shadows outer | `void run() { Int x = 1; if (cond) { Int x = 2; x.toString(); } }`. Ctrl+Click on the inner `x` | Jumps to the inner-block declaration, NOT the outer one |
 | 4.9 | Forward reference not resolved | Method body where a usage of `name` precedes a local declaration of `name`. Ctrl+Click on the usage | Resolves to module-level / outer-scope / workspace `name`, NOT the forward-declared local |
+| 4.10 | Doc-commented target | Ctrl+Click on a class/method/property preceded by a `/** ... */` doc comment | Cursor lands on the declaration line (e.g. `class Foo {`), NOT on the `/**` opener |
 
 **Notes:**
 - Resolution order is: enclosing-scope locals/parameters → class/module members → same-file top-levels → cross-file workspace index.
 - Cross-file definition uses workspace index fallback only when scope-aware resolution finds nothing.
 - Import-path-based resolution is not yet implemented.
-- Known issue (not addressed by current PR): for a class/method/property with a `/** doc comment */` prefix, Ctrl+Click currently jumps to the first line of the doc comment instead of the declaration line.
 
 ---
 

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/adapter/treesitter/TreeSitterAdapter.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/adapter/treesitter/TreeSitterAdapter.kt
@@ -798,10 +798,13 @@ class TreeSitterAdapter : AbstractAdapter() {
     }
 
     /**
-     * TODO: Same-file text matching only. Cannot distinguish shadowed locals.
-     * Cross-file references require compiler's semantic model (Phase 4+).
-     *
      * Finds all identifier nodes with the same text in the current file's AST.
+     * When [includeDeclaration] is false, drops the location matching the
+     * declaration site -- looked up via [XtcQueryEngine.findAllDeclarations],
+     * whose returned location is the identifier-token range, so it compares
+     * equal to the matching entry from [XtcQueryEngine.findAllIdentifiers].
+     *
+     * TODO: Same-file text matching only -- cannot distinguish shadowed locals.
      * A compiler adapter would provide scope-aware, cross-file reference search.
      */
     override fun findReferences(

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/LspJsonOptions.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/LspJsonOptions.kt
@@ -1,0 +1,115 @@
+package org.xvm.lsp.server
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+
+/**
+ * Shared dispatch over the two shapes LSP4J hands us for `initializationOptions` and
+ * `workspace/configuration` payloads.
+ *
+ * LSP4J de-serialises options either as a Java `Map<*, *>` (when gson saw a JSON object
+ * literal in the request) or as a Gson `JsonObject` / `JsonElement` (when the client
+ * payload is opaque). Each consumer of these options has to defensively dispatch over
+ * both shapes to read primitive values. Two callers used to re-implement this dispatch:
+ * [SourceRootResolver.parseInitOptions] (an array of strings) and
+ * [XtcLanguageServer.parseFormattingConfig] (named ints/booleans). They now both
+ * delegate to this helper so the dispatch lives in one place.
+ *
+ * Returns `null` when the requested key is absent, the value is the wrong shape, or the
+ * value cannot be coerced -- callers supply their own defaults.
+ */
+internal object LspJsonOptions {
+    /** Look up [key] on a Map / JsonObject / JsonElement. Returns the raw value or null. */
+    fun lookup(
+        raw: Any?,
+        key: String,
+    ): Any? =
+        when (raw) {
+            null -> null
+            is Map<*, *> -> raw[key]
+            is JsonObject -> raw.get(key)
+            is JsonElement -> if (raw.isJsonObject) raw.asJsonObject.get(key) else null
+            else -> null
+        }
+
+    /** Read [key] as a list of non-blank strings; returns `emptyList()` if missing or wrong shape. */
+    fun stringList(
+        raw: Any?,
+        key: String,
+    ): List<String> {
+        val value = lookup(raw, key) ?: return emptyList()
+        return when (value) {
+            is List<*> -> value.mapNotNull { it?.toString()?.trim()?.takeIf(String::isNotEmpty) }
+            is JsonArray -> value.mapNotNull { stringOrNull(it) }
+            is JsonElement -> if (value.isJsonArray) value.asJsonArray.mapNotNull { stringOrNull(it) } else emptyList()
+            else -> emptyList()
+        }
+    }
+
+    /** Read [key] as an [Int]; coerces from numeric primitives or numeric strings, else returns null. */
+    fun int(
+        raw: Any?,
+        key: String,
+    ): Int? =
+        when (val value = lookup(raw, key)) {
+            is Number -> {
+                value.toInt()
+            }
+
+            is String -> {
+                value.toIntOrNull()
+            }
+
+            is JsonElement -> {
+                value.takeUnless { it.isJsonNull }?.let {
+                    when {
+                        it.isJsonPrimitive && it.asJsonPrimitive.isNumber -> it.asInt
+                        it.isJsonPrimitive && it.asJsonPrimitive.isString -> it.asString.toIntOrNull()
+                        else -> null
+                    }
+                }
+            }
+
+            else -> {
+                null
+            }
+        }
+
+    /** Read [key] as a [Boolean]; coerces from boolean primitives or `"true"`/`"false"` strings. */
+    fun boolean(
+        raw: Any?,
+        key: String,
+    ): Boolean? =
+        when (val value = lookup(raw, key)) {
+            is Boolean -> {
+                value
+            }
+
+            is String -> {
+                value.toBooleanStrictOrNull()
+            }
+
+            is JsonElement -> {
+                value.takeUnless { it.isJsonNull }?.let {
+                    when {
+                        it.isJsonPrimitive && it.asJsonPrimitive.isBoolean -> it.asBoolean
+                        it.isJsonPrimitive && it.asJsonPrimitive.isString -> it.asString.toBooleanStrictOrNull()
+                        else -> null
+                    }
+                }
+            }
+
+            else -> {
+                null
+            }
+        }
+
+    private fun stringOrNull(elem: JsonElement?): String? =
+        elem
+            ?.takeUnless { it.isJsonNull }
+            ?.takeIf { it.isJsonPrimitive }
+            ?.asString
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+}

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/LspJsonOptions.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/LspJsonOptions.kt
@@ -5,33 +5,14 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 
 /**
- * Shared dispatch over the two shapes LSP4J hands us for `initializationOptions` and
- * `workspace/configuration` payloads.
- *
- * LSP4J de-serialises options either as a Java `Map<*, *>` (when gson saw a JSON object
- * literal in the request) or as a Gson `JsonObject` / `JsonElement` (when the client
- * payload is opaque). Each consumer of these options has to defensively dispatch over
- * both shapes to read primitive values. Two callers used to re-implement this dispatch:
- * [SourceRootResolver.parseInitOptions] (an array of strings) and
- * [XtcLanguageServer.parseFormattingConfig] (named ints/booleans). They now both
- * delegate to this helper so the dispatch lives in one place.
- *
- * Returns `null` when the requested key is absent, the value is the wrong shape, or the
- * value cannot be coerced -- callers supply their own defaults.
+ * Reads typed values out of LSP4J `initializationOptions` / `workspace/configuration`
+ * payloads, which arrive as either `Map<*, *>` or Gson `JsonObject` / `JsonElement`
+ * depending on how the client serialises them. Returns `null` when a key is absent,
+ * mistyped, or can't be coerced -- callers supply their own defaults.
  */
 internal object LspJsonOptions {
-    /** Look up [key] on a Map / JsonObject / JsonElement. Returns the raw value or null. */
-    fun lookup(
-        raw: Any?,
-        key: String,
-    ): Any? =
-        when (raw) {
-            null -> null
-            is Map<*, *> -> raw[key]
-            is JsonObject -> raw.get(key)
-            is JsonElement -> if (raw.isJsonObject) raw.asJsonObject.get(key) else null
-            else -> null
-        }
+    /** True iff [raw] is a JSON-object-shaped value (Map, JsonObject, or JsonElement holding an object). */
+    fun isObject(raw: Any?): Boolean = raw is Map<*, *> || raw is JsonObject || (raw is JsonElement && raw.isJsonObject)
 
     /** Read [key] as a list of non-blank strings; returns `emptyList()` if missing or wrong shape. */
     fun stringList(
@@ -103,6 +84,18 @@ internal object LspJsonOptions {
             else -> {
                 null
             }
+        }
+
+    private fun lookup(
+        raw: Any?,
+        key: String,
+    ): Any? =
+        when (raw) {
+            null -> null
+            is Map<*, *> -> raw[key]
+            is JsonObject -> raw.get(key)
+            is JsonElement -> if (raw.isJsonObject) raw.asJsonObject.get(key) else null
+            else -> null
         }
 
     private fun stringOrNull(elem: JsonElement?): String? =

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/SourceRootResolver.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/SourceRootResolver.kt
@@ -1,12 +1,7 @@
 package org.xvm.lsp.server
 
-import com.google.gson.JsonArray
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.Path
 
 /**
  * Resolves extra `.x` source roots beyond the workspace folders the client opens.
@@ -17,13 +12,15 @@ import java.nio.file.Path
  * additional source-tree roots so e.g. the XDK standard-library sources can be discovered
  * even when the user is working on an unrelated project.
  *
- * Sources, all merged (dedup, non-existent paths dropped with a warning):
+ * Sources, all merged (deduped):
  *  1. LSP `initializationOptions.xtcSourceRoots` -- an array of paths sent by the client
  *  2. System property `-Dxtc.sourceRoots=<a>${File.pathSeparator}<b>`
  *  3. Env var `XTC_SOURCE_ROOTS=<a>${File.pathSeparator}<b>`
  *
- * The returned paths are absolute filesystem paths (not URIs), matching the contract of
- * [org.xvm.lsp.index.WorkspaceIndexer.scanWorkspace].
+ * The returned paths are absolute filesystem strings (not URIs), matching the contract of
+ * [org.xvm.lsp.index.WorkspaceIndexer.scanWorkspace]. Non-existent paths are passed through
+ * verbatim -- the indexer is the single warning point for missing directories so we don't
+ * double-log the same dropped path during startup.
  */
 internal object SourceRootResolver {
     const val INIT_OPTION_KEY = "xtcSourceRoots"
@@ -45,26 +42,20 @@ internal object SourceRootResolver {
         systemProperty: String? = System.getProperty(SYSTEM_PROPERTY),
         envVar: String? = System.getenv(ENV_VAR),
     ): List<String> {
-        val fromInit = parseInitOptions(initializationOptions)
+        val fromInit = LspJsonOptions.stringList(initializationOptions, INIT_OPTION_KEY)
         val fromSys = parsePathList(systemProperty)
         val fromEnv = parsePathList(envVar)
         val merged = (fromInit + fromSys + fromEnv).distinct()
-        if (merged.isEmpty()) return emptyList()
-
-        val (existing, missing) = merged.partition { Files.isDirectory(Path.of(it)) }
-        if (missing.isNotEmpty()) {
-            logger.warn("source roots: dropping {} non-existent path(s): {}", missing.size, missing)
-        }
-        if (existing.isNotEmpty()) {
+        if (merged.isNotEmpty()) {
             logger.info(
                 "source roots: {} extra root(s) (init={}, sys={}, env={})",
-                existing.size,
+                merged.size,
                 fromInit.size,
                 fromSys.size,
                 fromEnv.size,
             )
         }
-        return existing
+        return merged
     }
 
     private fun parsePathList(raw: String?): List<String> =
@@ -73,30 +64,4 @@ internal object SourceRootResolver {
             ?.map { it.trim() }
             ?.filter { it.isNotEmpty() }
             ?: emptyList()
-
-    private fun parseInitOptions(raw: Any?): List<String> {
-        if (raw == null) return emptyList()
-        val array =
-            when (raw) {
-                is Map<*, *> -> raw[INIT_OPTION_KEY]
-                is JsonObject -> raw.get(INIT_OPTION_KEY)
-                is JsonElement -> if (raw.isJsonObject) raw.asJsonObject.get(INIT_OPTION_KEY) else null
-                else -> null
-            } ?: return emptyList()
-
-        return when (array) {
-            is List<*> -> array.mapNotNull { it?.toString()?.trim()?.takeIf(String::isNotEmpty) }
-            is JsonArray -> array.mapNotNull { stringOrNull(it) }
-            is JsonElement -> if (array.isJsonArray) array.asJsonArray.mapNotNull { stringOrNull(it) } else emptyList()
-            else -> emptyList()
-        }
-    }
-
-    private fun stringOrNull(elem: JsonElement?): String? =
-        elem
-            ?.takeUnless { it.isJsonNull }
-            ?.takeIf { it.isJsonPrimitive }
-            ?.asString
-            ?.trim()
-            ?.takeIf(String::isNotEmpty)
 }

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/XtcLanguageServer.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/XtcLanguageServer.kt
@@ -301,37 +301,17 @@ class XtcLanguageServer(
     }
 
     private fun parseFormattingConfig(raw: Any?): FormattingConfig? {
-        val map =
-            when (raw) {
-                is Map<*, *> -> {
-                    raw
-                }
+        if (raw == null) return null
+        if (raw !is Map<*, *> && raw !is JsonObject && !(raw is JsonElement && raw.isJsonObject)) return null
 
-                is JsonObject -> {
-                    raw.entrySet().associate { it.key to it.value }
-                }
-
-                is JsonElement -> {
-                    raw
-                        .takeIf { it.isJsonObject }
-                        ?.asJsonObject
-                        ?.entrySet()
-                        ?.associate { it.key to it.value }
-                }
-
-                else -> {
-                    null
-                }
-            } ?: return null
-
-        val indentSize = map.intValue("indentSize") ?: 4
-        val continuationIndentSize = map.intValue("continuationIndentSize") ?: 8
-        val insertSpaces = map.booleanValue("insertSpaces") ?: true
-        val maxLineWidth = map.intValue("maxLineWidth") ?: 120
-        val tabSize = map.intValue("tabSize")
+        val indentSize = LspJsonOptions.int(raw, "indentSize") ?: 4
+        val continuationIndentSize = LspJsonOptions.int(raw, "continuationIndentSize") ?: 8
+        val insertSpaces = LspJsonOptions.boolean(raw, "insertSpaces") ?: true
+        val maxLineWidth = LspJsonOptions.int(raw, "maxLineWidth") ?: 120
+        val tabSize = LspJsonOptions.int(raw, "tabSize")
         logger.info(
             "workspace/configuration: parsed config type={} indentSize={} continuationIndentSize={} tabSize={} insertSpaces={} maxLineWidth={}",
-            raw?.javaClass?.name ?: "null",
+            raw.javaClass.name,
             indentSize,
             continuationIndentSize,
             tabSize,
@@ -345,56 +325,6 @@ class XtcLanguageServer(
             maxLineWidth = maxLineWidth,
         )
     }
-
-    private fun Map<*, *>.intValue(key: String): Int? =
-        when (val value = this[key]) {
-            is Number -> {
-                value.toInt()
-            }
-
-            is String -> {
-                value.toIntOrNull()
-            }
-
-            is JsonElement -> {
-                value.takeUnless { it.isJsonNull }?.let {
-                    when {
-                        it.isJsonPrimitive && it.asJsonPrimitive.isNumber -> it.asInt
-                        it.isJsonPrimitive && it.asJsonPrimitive.isString -> it.asString.toIntOrNull()
-                        else -> null
-                    }
-                }
-            }
-
-            else -> {
-                null
-            }
-        }
-
-    private fun Map<*, *>.booleanValue(key: String): Boolean? =
-        when (val value = this[key]) {
-            is Boolean -> {
-                value
-            }
-
-            is String -> {
-                value.toBooleanStrictOrNull()
-            }
-
-            is JsonElement -> {
-                value.takeUnless { it.isJsonNull }?.let {
-                    when {
-                        it.isJsonPrimitive && it.asJsonPrimitive.isBoolean -> it.asBoolean
-                        it.isJsonPrimitive && it.asJsonPrimitive.isString -> it.asString.toBooleanStrictOrNull()
-                        else -> null
-                    }
-                }
-            }
-
-            else -> {
-                null
-            }
-        }
 
     private fun logServerBanner() {
         val pid = ProcessHandle.current().pid()

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/XtcLanguageServer.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/server/XtcLanguageServer.kt
@@ -1,7 +1,5 @@
 package org.xvm.lsp.server
 
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import org.eclipse.lsp4j.CallHierarchyIncomingCall
 import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams
 import org.eclipse.lsp4j.CallHierarchyItem
@@ -301,8 +299,7 @@ class XtcLanguageServer(
     }
 
     private fun parseFormattingConfig(raw: Any?): FormattingConfig? {
-        if (raw == null) return null
-        if (raw !is Map<*, *> && raw !is JsonObject && !(raw is JsonElement && raw.isJsonObject)) return null
+        if (!LspJsonOptions.isObject(raw)) return null
 
         val indentSize = LspJsonOptions.int(raw, "indentSize") ?: 4
         val continuationIndentSize = LspJsonOptions.int(raw, "continuationIndentSize") ?: 8
@@ -311,7 +308,7 @@ class XtcLanguageServer(
         val tabSize = LspJsonOptions.int(raw, "tabSize")
         logger.info(
             "workspace/configuration: parsed config type={} indentSize={} continuationIndentSize={} tabSize={} insertSpaces={} maxLineWidth={}",
-            raw.javaClass.name,
+            raw?.javaClass?.name,
             indentSize,
             continuationIndentSize,
             tabSize,

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
@@ -348,6 +348,7 @@ class XtcQueryEngine(
             }.toList()
 
     private companion object {
+        // Used by findScopeMembers to recognise declarations inside a body.
         private val memberNodeKinds =
             mapOf(
                 "property_declaration" to SymbolKind.PROPERTY,
@@ -363,6 +364,38 @@ class XtcQueryEngine(
                 "annotation_declaration" to SymbolKind.CLASS,
                 "package_declaration" to SymbolKind.PACKAGE,
                 "typedef_declaration" to SymbolKind.CLASS,
+            )
+
+        // Used by findAllDeclarations to map the allDeclarations query's capture keys to a kind.
+        private val captureKind: Map<String, SymbolKind> =
+            mapOf(
+                "module" to SymbolKind.MODULE,
+                "package" to SymbolKind.PACKAGE,
+                "class" to SymbolKind.CLASS,
+                "interface" to SymbolKind.INTERFACE,
+                "mixin" to SymbolKind.MIXIN,
+                "service" to SymbolKind.SERVICE,
+                "const" to SymbolKind.CONST,
+                "enum" to SymbolKind.ENUM,
+                "method" to SymbolKind.METHOD,
+                "constructor" to SymbolKind.CONSTRUCTOR,
+                "property" to SymbolKind.PROPERTY,
+            )
+
+        // Used by findDeclarationAt for the upward AST walk from the cursor.
+        private val nodeTypeKind: Map<String, SymbolKind> =
+            mapOf(
+                "module_declaration" to SymbolKind.MODULE,
+                "package_declaration" to SymbolKind.PACKAGE,
+                "class_declaration" to SymbolKind.CLASS,
+                "interface_declaration" to SymbolKind.INTERFACE,
+                "mixin_declaration" to SymbolKind.MIXIN,
+                "service_declaration" to SymbolKind.SERVICE,
+                "const_declaration" to SymbolKind.CONST,
+                "enum_declaration" to SymbolKind.ENUM,
+                "method_declaration" to SymbolKind.METHOD,
+                "property_declaration" to SymbolKind.PROPERTY,
+                "variable_declaration" to SymbolKind.PROPERTY,
             )
     }
 
@@ -509,37 +542,5 @@ class XtcQueryEngine(
         identifiersQuery.close()
         importsQuery.close()
         commentsAndStringsQuery.close()
-    }
-
-    companion object {
-        private val captureKind: Map<String, SymbolKind> =
-            mapOf(
-                "module" to SymbolKind.MODULE,
-                "package" to SymbolKind.PACKAGE,
-                "class" to SymbolKind.CLASS,
-                "interface" to SymbolKind.INTERFACE,
-                "mixin" to SymbolKind.MIXIN,
-                "service" to SymbolKind.SERVICE,
-                "const" to SymbolKind.CONST,
-                "enum" to SymbolKind.ENUM,
-                "method" to SymbolKind.METHOD,
-                "constructor" to SymbolKind.CONSTRUCTOR,
-                "property" to SymbolKind.PROPERTY,
-            )
-
-        private val nodeTypeKind: Map<String, SymbolKind> =
-            mapOf(
-                "module_declaration" to SymbolKind.MODULE,
-                "package_declaration" to SymbolKind.PACKAGE,
-                "class_declaration" to SymbolKind.CLASS,
-                "interface_declaration" to SymbolKind.INTERFACE,
-                "mixin_declaration" to SymbolKind.MIXIN,
-                "service_declaration" to SymbolKind.SERVICE,
-                "const_declaration" to SymbolKind.CONST,
-                "enum_declaration" to SymbolKind.ENUM,
-                "method_declaration" to SymbolKind.METHOD,
-                "property_declaration" to SymbolKind.PROPERTY,
-                "variable_declaration" to SymbolKind.PROPERTY,
-            )
     }
 }

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
@@ -40,57 +40,11 @@ class XtcQueryEngine(
                 // Use the name-capture's location (the identifier itself) so cmd-click lands
                 // on the declaration's name -- not on the leading /** doc comment */ when one
                 // is present. The outer declaration node spans the whole declaration including
-                // its doc-comment prefix, which is what the previous code returned.
+                // its doc-comment prefix.
                 val nameNode = captures["name"] ?: return@executeQuery
-                val declaration =
-                    captures.entries.find { (key, _) ->
-                        key in
-                            listOf(
-                                "module",
-                                "package",
-                                "class",
-                                "interface",
-                                "mixin",
-                                "service",
-                                "const",
-                                "enum",
-                                "method",
-                                "constructor",
-                                "property",
-                            )
-                    } ?: return@executeQuery
-
                 val kind =
-                    when (declaration.key) {
-                        "module" -> SymbolKind.MODULE
-                        "package" -> SymbolKind.PACKAGE
-                        "class" -> SymbolKind.CLASS
-                        "interface" -> SymbolKind.INTERFACE
-                        "mixin" -> SymbolKind.MIXIN
-                        "service" -> SymbolKind.SERVICE
-                        "const" -> SymbolKind.CONST
-                        "enum" -> SymbolKind.ENUM
-                        "method" -> SymbolKind.METHOD
-                        "constructor" -> SymbolKind.CONSTRUCTOR
-                        "property" -> SymbolKind.PROPERTY
-                        else -> return@executeQuery
-                    }
-
-                add(
-                    SymbolInfo(
-                        name = nameNode.text,
-                        qualifiedName = nameNode.text,
-                        kind = kind,
-                        location =
-                            Location(
-                                uri = uri,
-                                startLine = nameNode.startLine,
-                                startColumn = nameNode.startColumn,
-                                endLine = nameNode.endLine,
-                                endColumn = nameNode.endColumn,
-                            ),
-                    ),
-                )
+                    captures.keys.firstNotNullOfOrNull { captureKind[it] } ?: return@executeQuery
+                add(nameNode.toSymbolInfo(nameNode.text, kind, uri))
             }
         }.also { symbols ->
             logger.info("findAllDeclarations -> {} symbols", symbols.size)
@@ -119,9 +73,8 @@ class XtcQueryEngine(
         logger.info("findMethodDeclarations: uri={}", uri.substringAfterLast('/'))
         return buildList {
             executeQuery("methodDeclarations", methodDeclarationsQuery, tree) { captures ->
-                val name = captures["name"]?.text ?: return@executeQuery
-                val declaration = captures["declaration"] ?: return@executeQuery
-                add(declaration.toSymbolInfo(name, SymbolKind.METHOD, uri))
+                val nameNode = captures["name"] ?: return@executeQuery
+                add(nameNode.toSymbolInfo(nameNode.text, SymbolKind.METHOD, uri))
             }
         }.also { methods ->
             logger.info("findMethodDeclarations -> {} methods", methods.size)
@@ -437,7 +390,7 @@ class XtcQueryEngine(
                         ?: current.childByType("identifier")
                         ?: current.childByType("type_name")
                         ?: return null
-                return current.toSymbolInfo(nameNode.text, kind, uri).also {
+                return nameNode.toSymbolInfo(nameNode.text, kind, uri).also {
                     logger.info("findDeclarationAt -> '{}' ({})", it.name, kind)
                 }
             }
@@ -447,20 +400,7 @@ class XtcQueryEngine(
         return null
     }
 
-    private fun nodeTypeToSymbolKind(type: String): SymbolKind? =
-        when (type) {
-            "module_declaration" -> SymbolKind.MODULE
-            "package_declaration" -> SymbolKind.PACKAGE
-            "class_declaration" -> SymbolKind.CLASS
-            "interface_declaration" -> SymbolKind.INTERFACE
-            "mixin_declaration" -> SymbolKind.MIXIN
-            "service_declaration" -> SymbolKind.SERVICE
-            "const_declaration" -> SymbolKind.CONST
-            "enum_declaration" -> SymbolKind.ENUM
-            "method_declaration" -> SymbolKind.METHOD
-            "property_declaration", "variable_declaration" -> SymbolKind.PROPERTY
-            else -> null
-        }
+    private fun nodeTypeToSymbolKind(type: String): SymbolKind? = nodeTypeKind[type]
 
     private fun XtcNode.toSymbolInfo(
         name: String,
@@ -569,5 +509,37 @@ class XtcQueryEngine(
         identifiersQuery.close()
         importsQuery.close()
         commentsAndStringsQuery.close()
+    }
+
+    companion object {
+        private val captureKind: Map<String, SymbolKind> =
+            mapOf(
+                "module" to SymbolKind.MODULE,
+                "package" to SymbolKind.PACKAGE,
+                "class" to SymbolKind.CLASS,
+                "interface" to SymbolKind.INTERFACE,
+                "mixin" to SymbolKind.MIXIN,
+                "service" to SymbolKind.SERVICE,
+                "const" to SymbolKind.CONST,
+                "enum" to SymbolKind.ENUM,
+                "method" to SymbolKind.METHOD,
+                "constructor" to SymbolKind.CONSTRUCTOR,
+                "property" to SymbolKind.PROPERTY,
+            )
+
+        private val nodeTypeKind: Map<String, SymbolKind> =
+            mapOf(
+                "module_declaration" to SymbolKind.MODULE,
+                "package_declaration" to SymbolKind.PACKAGE,
+                "class_declaration" to SymbolKind.CLASS,
+                "interface_declaration" to SymbolKind.INTERFACE,
+                "mixin_declaration" to SymbolKind.MIXIN,
+                "service_declaration" to SymbolKind.SERVICE,
+                "const_declaration" to SymbolKind.CONST,
+                "enum_declaration" to SymbolKind.ENUM,
+                "method_declaration" to SymbolKind.METHOD,
+                "property_declaration" to SymbolKind.PROPERTY,
+                "variable_declaration" to SymbolKind.PROPERTY,
+            )
     }
 }

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
@@ -37,7 +37,11 @@ class XtcQueryEngine(
         logger.info("findAllDeclarations: uri={}", uri.substringAfterLast('/'))
         return buildList {
             executeQuery("allDeclarations", allDeclarationsQuery, tree) { captures ->
-                val name = captures["name"]?.text ?: return@executeQuery
+                // Use the name-capture's location (the identifier itself) so cmd-click lands
+                // on the declaration's name -- not on the leading /** doc comment */ when one
+                // is present. The outer declaration node spans the whole declaration including
+                // its doc-comment prefix, which is what the previous code returned.
+                val nameNode = captures["name"] ?: return@executeQuery
                 val declaration =
                     captures.entries.find { (key, _) ->
                         key in
@@ -72,19 +76,18 @@ class XtcQueryEngine(
                         else -> return@executeQuery
                     }
 
-                val node = declaration.value
                 add(
                     SymbolInfo(
-                        name = name,
-                        qualifiedName = name,
+                        name = nameNode.text,
+                        qualifiedName = nameNode.text,
                         kind = kind,
                         location =
                             Location(
                                 uri = uri,
-                                startLine = node.startLine,
-                                startColumn = node.startColumn,
-                                endLine = node.endLine,
-                                endColumn = node.endColumn,
+                                startLine = nameNode.startLine,
+                                startColumn = nameNode.startColumn,
+                                endLine = nameNode.endLine,
+                                endColumn = nameNode.endColumn,
                             ),
                     ),
                 )

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
@@ -63,6 +63,41 @@ class NavigationTest : TreeSitterTestBase() {
         }
 
         /**
+         * Cmd-click on a call to a doc-commented method must land on the
+         * method's identifier line, not on the doc-comment opener -- exercises
+         * the [XtcQueryEngine.findMethodDeclarations] path for call resolution.
+         */
+        @Test
+        @DisplayName("should find doc-commented method definition on the name line")
+        fun shouldFindDocCommentedMethodDefinitionOnNameLine() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    class Calculator {
+                        /**
+                         * Adds two numbers.
+                         */
+                        Int add(Int a, Int b) {
+                            return a + b;
+                        }
+                        void test() {
+                            add(1, 2);
+                        }
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor on 'add' in the call site at line 9
+            val definition = ts.findDefinition(uri, 9, 12)
+
+            assertThat(definition).isNotNull
+            // Doc-comment occupies lines 2-4; the method name is on line 5 (0-indexed).
+            assertThat(definition!!.startLine).isEqualTo(5)
+        }
+
+        /**
          * When the cursor is on a method name at a call site (`add` in `add(1, 2)`),
          * go-to-definition should navigate to the method's declaration line.
          */

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
@@ -283,13 +283,14 @@ class NavigationTest : TreeSitterTestBase() {
     @DisplayName("findReferences()")
     inner class FindReferencesTests {
         /**
-         * Unlike [MockAdapter], [TreeSitterAdapter.findReferences] ignores the
-         * `includeDeclaration` flag -- it always returns every identifier node with the
-         * same text. We verify this by checking that both flag values yield the same count.
+         * `includeDeclaration = false` should drop exactly one location: the declaration
+         * itself. With both flag values exercised on the same source, the `false` result
+         * must contain every identifier-token from the `true` result minus the
+         * declaration site.
          */
         @Test
-        @DisplayName("should find all occurrences regardless of includeDeclaration flag")
-        fun shouldFindAllOccurrences() {
+        @DisplayName("should exclude declaration when includeDeclaration is false")
+        fun shouldExcludeDeclarationWhenIncludeDeclarationIsFalse() {
             val uri = freshUri()
             val source =
                 """
@@ -308,7 +309,10 @@ class NavigationTest : TreeSitterTestBase() {
             val withoutDecl = ts.findReferences(uri, 1, 10, includeDeclaration = false)
 
             assertThat(withDecl).hasSizeGreaterThanOrEqualTo(2)
-            assertThat(withDecl).hasSameSizeAs(withoutDecl)
+            assertThat(withoutDecl).hasSize(withDecl.size - 1)
+            // The dropped location is the class declaration's identifier (line 1, col 10).
+            assertThat(withDecl).anyMatch { it.startLine == 1 && it.startColumn == 10 }
+            assertThat(withoutDecl).noneMatch { it.startLine == 1 && it.startColumn == 10 }
         }
 
         /** Past-EOF has no identifier to match, so the result must be empty. */

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 /**
  * Navigation tests for [TreeSitterAdapter].
@@ -444,89 +448,100 @@ class NavigationTest : TreeSitterTestBase() {
 
     @Nested
     @DisplayName("getDocumentLinks()")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class DocumentLinkTests {
-        @Test
-        @DisplayName("should link URL in line comment")
-        fun shouldLinkUrlInLineComment() {
+        /**
+         * One row per syntactic position the URL detector must recognise (line/block/doc
+         * comment, string literal, trailing-punctuation strip). Assertions are uniform; a
+         * new comment- or string-node type costs one extra row instead of a new method.
+         */
+        @Suppress("unused")
+        fun singleUrlCases(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    "line comment",
+                    """
+                    module myapp {
+                        // see https://example.com for details
+                        class Foo {}
+                    }
+                    """.trimIndent(),
+                    "https://example.com",
+                    1,
+                    "    // see ".length,
+                ),
+                Arguments.of(
+                    "block comment, multi-line",
+                    """
+                    module myapp {
+                        /* block comment
+                           with https://anthropic.com on its own line
+                           and more text */
+                        class Foo {}
+                    }
+                    """.trimIndent(),
+                    "https://anthropic.com",
+                    2,
+                    "       with ".length,
+                ),
+                Arguments.of(
+                    "doc comment",
+                    """
+                    module myapp {
+                        /** see http://docs.xtclang.org/guide */
+                        class Foo {}
+                    }
+                    """.trimIndent(),
+                    "http://docs.xtclang.org/guide",
+                    1,
+                    "    /** see ".length,
+                ),
+                Arguments.of(
+                    "string literal",
+                    """
+                    module myapp {
+                        String home = "https://xtclang.org";
+                    }
+                    """.trimIndent(),
+                    "https://xtclang.org",
+                    1,
+                    "    String home = \"".length,
+                ),
+                Arguments.of(
+                    "trailing punctuation stripped",
+                    """
+                    module myapp {
+                        // visit https://example.com.
+                        class Foo {}
+                    }
+                    """.trimIndent(),
+                    "https://example.com",
+                    1,
+                    "    // visit ".length,
+                ),
+            )
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("singleUrlCases")
+        fun shouldLinkSingleUrl(
+            @Suppress("UNUSED_PARAMETER") name: String,
+            source: String,
+            expectedTarget: String,
+            expectedLine: Int,
+            expectedColumn: Int,
+        ) {
             val uri = freshUri()
-            val source =
-                """
-                module myapp {
-                    // see https://example.com for details
-                    class Foo {}
-                }
-                """.trimIndent()
             ts.compile(uri, source)
 
             val links = ts.getDocumentLinks(uri, source)
 
             assertThat(links).hasSize(1)
-            assertThat(links[0].target).isEqualTo("https://example.com")
-            // Line 1 (0-based), URL starts after "    // see "
-            assertThat(links[0].range.start.line).isEqualTo(1)
-            assertThat(links[0].range.start.column).isEqualTo("    // see ".length)
-        }
-
-        @Test
-        @DisplayName("should link URL in block comment, multi-line position correct")
-        fun shouldLinkUrlInBlockComment() {
-            val uri = freshUri()
-            val source =
-                """
-                module myapp {
-                    /* block comment
-                       with https://anthropic.com on its own line
-                       and more text */
-                    class Foo {}
-                }
-                """.trimIndent()
-            ts.compile(uri, source)
-
-            val links = ts.getDocumentLinks(uri, source)
-
-            assertThat(links).hasSize(1)
-            assertThat(links[0].target).isEqualTo("https://anthropic.com")
-            // URL is on the third line of the source (0-based line 2)
-            assertThat(links[0].range.start.line).isEqualTo(2)
-            // Column is offset of "https" within that line
-            assertThat(links[0].range.start.column).isEqualTo("       with ".length)
-        }
-
-        @Test
-        @DisplayName("should link URL in doc comment")
-        fun shouldLinkUrlInDocComment() {
-            val uri = freshUri()
-            val source =
-                """
-                module myapp {
-                    /** see http://docs.xtclang.org/guide */
-                    class Foo {}
-                }
-                """.trimIndent()
-            ts.compile(uri, source)
-
-            val links = ts.getDocumentLinks(uri, source)
-
-            assertThat(links).hasSize(1)
-            assertThat(links[0].target).isEqualTo("http://docs.xtclang.org/guide")
-        }
-
-        @Test
-        @DisplayName("should link URL in string literal")
-        fun shouldLinkUrlInStringLiteral() {
-            val uri = freshUri()
-            val source =
-                """
-                module myapp {
-                    String home = "https://xtclang.org";
-                }
-                """.trimIndent()
-            ts.compile(uri, source)
-
-            val links = ts.getDocumentLinks(uri, source)
-
-            assertThat(links).hasSize(1)
-            assertThat(links[0].target).isEqualTo("https://xtclang.org")
+            assertThat(links[0].target).isEqualTo(expectedTarget)
+            assertThat(links[0].range.start.line).isEqualTo(expectedLine)
+            assertThat(links[0].range.start.column).isEqualTo(expectedColumn)
+            // The detected range must cover exactly the (post-strip) URL -- catches mistakes
+            // like the trailing-punctuation case where the dot must NOT be in the range.
+            assertThat(links[0].range.end.column - links[0].range.start.column).isEqualTo(expectedTarget.length)
         }
 
         @Test
@@ -548,28 +563,6 @@ class NavigationTest : TreeSitterTestBase() {
                 "https://a.test",
                 "https://b.test",
             )
-        }
-
-        @Test
-        @DisplayName("should strip trailing sentence punctuation")
-        fun shouldStripTrailingPunctuation() {
-            val uri = freshUri()
-            val source =
-                """
-                module myapp {
-                    // visit https://example.com.
-                    class Foo {}
-                }
-                """.trimIndent()
-            ts.compile(uri, source)
-
-            val links = ts.getDocumentLinks(uri, source)
-
-            assertThat(links).hasSize(1)
-            assertThat(links[0].target).isEqualTo("https://example.com")
-            // The matched range should also exclude the trailing dot
-            assertThat(links[0].range.end.column - links[0].range.start.column)
-                .isEqualTo("https://example.com".length)
         }
 
         @Test

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/TreeSitterAdapterTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/TreeSitterAdapterTest.kt
@@ -97,29 +97,25 @@ class TreeSitterAdapterTest : TreeSitterTestBase() {
          * declaration itself. The symbol's location must point at the identifier
          * (`Person`) so cmd-click lands on the `class Person {` line, not on the
          * doc-comment prefix that precedes it.
-         *
-         * Using string concatenation rather than a triple-quoted string because ktlint
-         * mis-tokenises a literal doc-comment opener nested inside a raw string.
          */
         @Test
         @DisplayName("symbol location should be the name identifier, not the doc-comment prefix")
         fun symbolLocationShouldBeNameIdentifierNotDocComment() {
             val uri = freshUri()
-            val docOpen = "/" + "**"
-            val docClose = "*" + "/"
             val source =
-                "module myapp {\n" +
-                    "    $docOpen\n" +
-                    "     * A person.\n" +
-                    "     $docClose\n" +
-                    "    class Person {\n" +
-                    "    }\n" +
-                    "}\n"
+                """
+                module myapp {
+                    /**
+                     * A person.
+                     */
+                    class Person {
+                    }
+                }
+                """.trimIndent()
 
             val result = ts.compile(uri, source)
 
             val person = result.symbols.first { it.name == "Person" }
-            // 0-indexed lines: doc-open=1, doc-body=2, doc-close=3, `class Person {`=4.
             assertThat(person.location.startLine).isEqualTo(4)
         }
 
@@ -322,6 +318,67 @@ class TreeSitterAdapterTest : TreeSitterTestBase() {
             val uri = freshUri()
             ts.compile(uri, "module myapp {}")
             assertThat(ts.findSymbolAt(uri, 100, 0)).isNull()
+        }
+
+        /**
+         * Same doc-comment landing fix as [XtcQueryEngine.findAllDeclarations] but
+         * for the [XtcQueryEngine.findDeclarationAt] path (cursor-inside-a-declaration).
+         * The returned symbol's location must point at the identifier line, not at
+         * the leading doc-comment opener.
+         */
+        @Test
+        @DisplayName("doc-commented method symbol location should be the name identifier")
+        fun docCommentedMethodSymbolShouldLandOnNameLine() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    class Person {
+                        /**
+                         * Returns the name.
+                         */
+                        String getName() {
+                            return "n";
+                        }
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor inside the method body so findDeclarationAt walks up to method_declaration.
+            val symbol = ts.findSymbolAt(uri, 6, 16)
+
+            assertThat(symbol).isNotNull
+            assertThat(symbol!!.name).isEqualTo("getName")
+            // 0-indexed: doc-open=2, doc-body=3, doc-close=4, `String getName()` line = 5.
+            // The name identifier `getName` is on line 5.
+            assertThat(symbol.location.startLine).isEqualTo(5)
+        }
+
+        /** Same as above but for a property declaration. */
+        @Test
+        @DisplayName("doc-commented property symbol location should be the name identifier")
+        fun docCommentedPropertySymbolShouldLandOnNameLine() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    class Person {
+                        /**
+                         * The name.
+                         */
+                        String name;
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor on `name` in the property declaration line.
+            val symbol = ts.findSymbolAt(uri, 5, 15)
+
+            assertThat(symbol).isNotNull
+            assertThat(symbol!!.name).isEqualTo("name")
+            assertThat(symbol.location.startLine).isEqualTo(5)
         }
     }
 

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/TreeSitterAdapterTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/TreeSitterAdapterTest.kt
@@ -93,6 +93,37 @@ class TreeSitterAdapterTest : TreeSitterTestBase() {
         }
 
         /**
+         * Gene's email preamble: navigation jumped to the doc-comment line, not the
+         * declaration itself. The symbol's location must point at the identifier
+         * (`Person`) so cmd-click lands on the `class Person {` line, not on the
+         * doc-comment prefix that precedes it.
+         *
+         * Using string concatenation rather than a triple-quoted string because ktlint
+         * mis-tokenises a literal doc-comment opener nested inside a raw string.
+         */
+        @Test
+        @DisplayName("symbol location should be the name identifier, not the doc-comment prefix")
+        fun symbolLocationShouldBeNameIdentifierNotDocComment() {
+            val uri = freshUri()
+            val docOpen = "/" + "**"
+            val docClose = "*" + "/"
+            val source =
+                "module myapp {\n" +
+                    "    $docOpen\n" +
+                    "     * A person.\n" +
+                    "     $docClose\n" +
+                    "    class Person {\n" +
+                    "    }\n" +
+                    "}\n"
+
+            val result = ts.compile(uri, source)
+
+            val person = result.symbols.first { it.name == "Person" }
+            // 0-indexed lines: doc-open=1, doc-body=2, doc-close=3, `class Person {`=4.
+            assertThat(person.location.startLine).isEqualTo(4)
+        }
+
+        /**
          * Verifies tree-sitter recognizes the `interface` keyword and maps it
          * to [SymbolInfo.SymbolKind.INTERFACE] via `interface_declaration`.
          */

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/LspJsonOptionsTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/LspJsonOptionsTest.kt
@@ -1,0 +1,217 @@
+package org.xvm.lsp.server
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("LspJsonOptions")
+class LspJsonOptionsTest {
+    @Nested
+    @DisplayName("isObject")
+    inner class IsObjectTests {
+        @Test
+        fun `should reject null`() {
+            assertThat(LspJsonOptions.isObject(null)).isFalse()
+        }
+
+        @Test
+        fun `should reject scalar`() {
+            assertThat(LspJsonOptions.isObject("hello")).isFalse()
+            assertThat(LspJsonOptions.isObject(42)).isFalse()
+            assertThat(LspJsonOptions.isObject(listOf("a"))).isFalse()
+        }
+
+        @Test
+        fun `should accept Map`() {
+            assertThat(LspJsonOptions.isObject(mapOf("a" to 1))).isTrue()
+            assertThat(LspJsonOptions.isObject(emptyMap<String, Any>())).isTrue()
+        }
+
+        @Test
+        fun `should accept JsonObject`() {
+            assertThat(LspJsonOptions.isObject(JsonObject())).isTrue()
+        }
+
+        @Test
+        fun `should accept JsonElement holding an object`() {
+            val elem: com.google.gson.JsonElement = JsonObject()
+            assertThat(LspJsonOptions.isObject(elem)).isTrue()
+        }
+
+        @Test
+        fun `should reject JsonElement holding non-object`() {
+            assertThat(LspJsonOptions.isObject(JsonPrimitive("foo"))).isFalse()
+            assertThat(LspJsonOptions.isObject(JsonArray())).isFalse()
+            assertThat(LspJsonOptions.isObject(JsonNull.INSTANCE)).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("stringList")
+    inner class StringListTests {
+        @Test
+        fun `should read List of strings from Map`() {
+            val raw = mapOf("paths" to listOf("/a", "/b"))
+            assertThat(LspJsonOptions.stringList(raw, "paths")).containsExactly("/a", "/b")
+        }
+
+        @Test
+        fun `should read JsonArray of strings from JsonObject`() {
+            val arr =
+                JsonArray().apply {
+                    add(JsonPrimitive("/a"))
+                    add(JsonPrimitive("/b"))
+                }
+            val obj = JsonObject().apply { add("paths", arr) }
+            assertThat(LspJsonOptions.stringList(obj, "paths")).containsExactly("/a", "/b")
+        }
+
+        @Test
+        fun `should drop blank and null entries from List`() {
+            val raw = mapOf("paths" to listOf("/a", "  ", null, "/b"))
+            assertThat(LspJsonOptions.stringList(raw, "paths")).containsExactly("/a", "/b")
+        }
+
+        @Test
+        fun `should drop JsonNull and blank entries from JsonArray`() {
+            val arr =
+                JsonArray().apply {
+                    add(JsonPrimitive("/a"))
+                    add(JsonNull.INSTANCE)
+                    add(JsonPrimitive("  "))
+                    add(JsonPrimitive("/b"))
+                }
+            val obj = JsonObject().apply { add("paths", arr) }
+            assertThat(LspJsonOptions.stringList(obj, "paths")).containsExactly("/a", "/b")
+        }
+
+        @Test
+        fun `should return empty for missing key`() {
+            assertThat(LspJsonOptions.stringList(mapOf("other" to listOf("x")), "paths")).isEmpty()
+        }
+
+        @Test
+        fun `should return empty for non-array value`() {
+            assertThat(LspJsonOptions.stringList(mapOf("paths" to "not-a-list"), "paths")).isEmpty()
+        }
+
+        @Test
+        fun `should return empty for null raw`() {
+            assertThat(LspJsonOptions.stringList(null, "paths")).isEmpty()
+        }
+
+        @Test
+        fun `should coerce non-string list entries via toString`() {
+            val raw = mapOf("vals" to listOf(42, 3.14, true))
+            assertThat(LspJsonOptions.stringList(raw, "vals")).containsExactly("42", "3.14", "true")
+        }
+    }
+
+    @Nested
+    @DisplayName("int")
+    inner class IntTests {
+        @Test
+        fun `should read Int from Map`() {
+            assertThat(LspJsonOptions.int(mapOf("n" to 7), "n")).isEqualTo(7)
+        }
+
+        @Test
+        fun `should coerce Long Number to Int`() {
+            assertThat(LspJsonOptions.int(mapOf("n" to 7L), "n")).isEqualTo(7)
+        }
+
+        @Test
+        fun `should coerce numeric String to Int`() {
+            assertThat(LspJsonOptions.int(mapOf("n" to "12"), "n")).isEqualTo(12)
+        }
+
+        @Test
+        fun `should reject non-numeric String`() {
+            assertThat(LspJsonOptions.int(mapOf("n" to "abc"), "n")).isNull()
+        }
+
+        @Test
+        fun `should read JsonPrimitive number from JsonObject`() {
+            val obj = JsonObject().apply { add("n", JsonPrimitive(42)) }
+            assertThat(LspJsonOptions.int(obj, "n")).isEqualTo(42)
+        }
+
+        @Test
+        fun `should read numeric JsonPrimitive string from JsonObject`() {
+            val obj = JsonObject().apply { add("n", JsonPrimitive("99")) }
+            assertThat(LspJsonOptions.int(obj, "n")).isEqualTo(99)
+        }
+
+        @Test
+        fun `should return null for JsonNull value`() {
+            val obj = JsonObject().apply { add("n", JsonNull.INSTANCE) }
+            assertThat(LspJsonOptions.int(obj, "n")).isNull()
+        }
+
+        @Test
+        fun `should return null for missing key`() {
+            assertThat(LspJsonOptions.int(mapOf("other" to 1), "n")).isNull()
+        }
+
+        @Test
+        fun `should return null for null raw`() {
+            assertThat(LspJsonOptions.int(null, "n")).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("boolean")
+    inner class BooleanTests {
+        @Test
+        fun `should read Boolean from Map`() {
+            assertThat(LspJsonOptions.boolean(mapOf("b" to true), "b")).isTrue()
+            assertThat(LspJsonOptions.boolean(mapOf("b" to false), "b")).isFalse()
+        }
+
+        @Test
+        fun `should coerce true and false strings`() {
+            assertThat(LspJsonOptions.boolean(mapOf("b" to "true"), "b")).isTrue()
+            assertThat(LspJsonOptions.boolean(mapOf("b" to "false"), "b")).isFalse()
+        }
+
+        @Test
+        fun `should reject other strings (strict)`() {
+            assertThat(LspJsonOptions.boolean(mapOf("b" to "yes"), "b")).isNull()
+            assertThat(LspJsonOptions.boolean(mapOf("b" to "1"), "b")).isNull()
+            assertThat(LspJsonOptions.boolean(mapOf("b" to "TRUE"), "b")).isNull()
+        }
+
+        @Test
+        fun `should read JsonPrimitive boolean from JsonObject`() {
+            val obj = JsonObject().apply { add("b", JsonPrimitive(true)) }
+            assertThat(LspJsonOptions.boolean(obj, "b")).isTrue()
+        }
+
+        @Test
+        fun `should read boolean JsonPrimitive string from JsonObject`() {
+            val obj = JsonObject().apply { add("b", JsonPrimitive("false")) }
+            assertThat(LspJsonOptions.boolean(obj, "b")).isFalse()
+        }
+
+        @Test
+        fun `should return null for JsonNull value`() {
+            val obj = JsonObject().apply { add("b", JsonNull.INSTANCE) }
+            assertThat(LspJsonOptions.boolean(obj, "b")).isNull()
+        }
+
+        @Test
+        fun `should return null for missing key`() {
+            assertThat(LspJsonOptions.boolean(mapOf("other" to true), "b")).isNull()
+        }
+
+        @Test
+        fun `should return null for null raw`() {
+            assertThat(LspJsonOptions.boolean(null, "b")).isNull()
+        }
+    }
+}

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/SourceRootResolverTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/server/SourceRootResolverTest.kt
@@ -128,15 +128,15 @@ class SourceRootResolverTest {
         }
 
         @Test
-        @DisplayName("should drop non-existent paths")
-        fun shouldDropMissingPaths() {
+        @DisplayName("should pass non-existent paths through (indexer is the single warning point)")
+        fun shouldPassMissingPathsThrough() {
             val real = realDir("real")
             val fake = tmp.resolve("does-not-exist").toString()
             val opts = mapOf("xtcSourceRoots" to listOf(real, fake))
 
             val roots = SourceRootResolver.resolve(opts, systemProperty = null, envVar = null)
 
-            assertThat(roots).containsExactly(real)
+            assertThat(roots).containsExactly(real, fake)
         }
 
         @Test


### PR DESCRIPTION
## Summary

Follow-up to #448 (Gene's LSP report). Two scoped pieces of work:

### PR D — Doc-comment landing fix
Cmd-click on a class/method/property preceded by a `/** ... */` doc-comment was landing on the first line of the doc-comment instead of the declaration. Fixed in three sibling sites in `XtcQueryEngine`:

- `findAllDeclarations` (powers `textDocument/documentSymbol`, definition fallback, etc.)
- `findMethodDeclarations` (powers cross-reference call resolution)
- `findDeclarationAt` (powers `findSymbolAt` / cursor-inside-declaration lookup)

All three now return the `name` capture's location (identifier-token bounds), the way `resolveByNameInScope` already did. Side-effect cleanup: `TreeSitterAdapter.findReferences` filters declarations by `Location` equality — the previous outer-node location never matched any identifier-token Location, so `includeDeclaration=false` was a silent no-op. The fix correctly drops the declaration site now.

### PR E — Three simplify carry-overs from #446
1. **Drop the redundant directory check in `SourceRootResolver`.** The resolver was partitioning paths by `Files.isDirectory` and warning on miss, but `WorkspaceIndexer.collectXtcFiles` already validates each folder and warns on miss — two warnings for the same nonexistent path. The indexer is now the single warning point.
2. **Extract `LspJsonOptions`** — a small object that reads typed values out of LSP4J `initializationOptions` / `workspace/configuration` payloads (which arrive as either `Map<*,*>` or gson `JsonObject`/`JsonElement`). `SourceRootResolver` and `XtcLanguageServer.parseFormattingConfig` both delegate to it now. ~50 lines added in the helper, ~50 lines removed across the two call sites; one consistent shape, one set of edge cases.
3. **Parameterise the 5 near-identical URL-link tests** in `NavigationTest.kt` into one `@ParameterizedTest` with a `@MethodSource("singleUrlCases")` provider. Adding a new syntactic position (line / block / doc comment, string literal, trailing-punctuation strip) now costs one extra row instead of a new method.

## Test plan

- [x] `./gradlew :lang:lsp-server:test :lang:tree-sitter:validateTreeSitterGrammar -PincludeBuildLang=true -PincludeBuildAttachLang=true` — green: 388 tests, 0 failures, 3 skipped (up from 375 on the pre-rebase tip thanks to #448's merged tests).
- [x] New test coverage:
  - `TreeSitterAdapterTest.symbolLocationShouldBeNameIdentifierNotDocComment` (findAllDeclarations path)
  - `TreeSitterAdapterTest.docCommentedMethodSymbolShouldLandOnNameLine` (findDeclarationAt path)
  - `TreeSitterAdapterTest.docCommentedPropertySymbolShouldLandOnNameLine` (findDeclarationAt path)
  - `NavigationTest.shouldFindDocCommentedMethodDefinitionOnNameLine` (findMethodDeclarations path)
  - `NavigationTest.shouldExcludeDeclarationWhenIncludeDeclarationIsFalse` (renamed; was the `shouldFindAllOccurrences` test which asserted the buggy parity)
  - `LspJsonOptionsTest` — 30 unit tests covering `isObject` / `stringList` / `int` / `boolean` across `Map`, `JsonObject`, `JsonElement`, `JsonNull`, blank strings, missing keys, coercion edges, etc.
- [x] `MANUAL_TEST_PLAN.md` row 4.10 covers the doc-commented go-to-definition behaviour for class/method/property; the "Known issue" bullet about doc-comment landing was removed.

## Notes

- This branch was rebased onto post-#448 master. The conflicts were small: row numbering in `MANUAL_TEST_PLAN.md` (my row 4.5 → 4.10 to make room for #448's 4.5–4.9 scope-aware-nav rows) and a Kotlin-companion-object collision in `XtcQueryEngine.kt` (#448 added a `companion object { memberNodeKinds }`; my simplify pass added another with `captureKind` / `nodeTypeKind` — Kotlin allows only one, so they're now folded into the same companion with a one-line comment per map saying which method consumes it).
- The three kind-maps overlap considerably. Could be unified in a follow-up if it becomes annoying; left separate to keep this PR's scope tight.
- Doesn't address Issue 4 from Gene's email (the 14 `manualTests/*.x` files that fail to parse) — that's a separate grammar campaign (PR C1–C5 in the plan) shipping as its own series.