### PR TITLE
Allow custom names for properties in JSON serialization

### DIFF
--- a/lib_json/src/main/x/json/annotations/JsonProperty.x
+++ b/lib_json/src/main/x/json/annotations/JsonProperty.x
@@ -1,0 +1,8 @@
+/**
+ * An annotation to allow customization of the JSON name of a value.
+ *
+ * @param jsonName - the customized name of the field
+ */
+annotation JsonProperty(String jsonName)
+        into Class | Property {
+}

--- a/lib_json/src/main/x/json/annotations/JsonProperty.x
+++ b/lib_json/src/main/x/json/annotations/JsonProperty.x
@@ -1,6 +1,15 @@
 /**
  * An annotation to allow customization of the JSON name of a value.
  *
+ * For example, if the JSON field name for a property needs to be "$data", this is invalid as an
+ * Ecstasy identifier name. The property can be annotated like this:
+ *
+ *   @JsonProperty("$data")
+ *   String data;
+ *
+ * The [ReflectionMapping] will use the value from the annotation to map the JSON field name to the
+ * property name.
+ *
  * @param jsonName - the customized name of the field
  */
 annotation JsonProperty(String jsonName)

--- a/lib_json/src/main/x/json/mappings/ReflectionMapping.x
+++ b/lib_json/src/main/x/json/mappings/ReflectionMapping.x
@@ -1,3 +1,5 @@
+import annotations.JsonProperty;
+
 /**
  * A reflection-based [Mapping] implementation that works for exactly one type, `Serializable`.
  */
@@ -129,15 +131,30 @@ const ReflectionMapping<Serializable, StructType extends Struct>(
             val structType = clazz.StructType;
 
             PropertyMapping<structType.DataType>[] fields = new PropertyMapping[];
+            Set<String>                            names  = new HashSet();
             for (Property<structType.DataType> prop : structType.properties) {
                 if (prop.hasField && !prop.lazy) {
                     assert !prop.isConstant() && !prop.abstract && !prop.injected;
 
                     // TODO CP what if the referent type is the same as "type"? (linked list example)
                     if (Mapping<prop.Referent> valueMapping := schema.findMapping(prop.Referent)) {
-                        // TODO CP - name has to be unique
+                        String name = prop.name;
+                        if (prop.is(JsonProperty)) {
+                            name = prop.jsonName;
+                        }
+                        if (names.contains(name)) {
+                            for (PropertyMapping mapping : fields) {
+                                if (mapping.name == name) {
+                                    throw new IllegalJSON($|Duplicate JSON property name {name} \
+                                                           | {prop} name matches {mapping.property}
+                                                           );
+                                }
+                            }
+                        }
+                        names.add(name);
+
                         fields += new PropertyMapping<structType.DataType, prop.Referent>
-                                        (prop.name, valueMapping, prop);
+                                        (name, valueMapping, prop);
                     }
                 }
             }

--- a/lib_json/src/test/x/JsonTest/annotations/JsonPropertyTest.x
+++ b/lib_json/src/test/x/JsonTest/annotations/JsonPropertyTest.x
@@ -1,0 +1,34 @@
+import json.Mapping;
+import json.ObjectInputStream;
+import json.Parser;
+import json.Schema;
+
+import json.annotations.JsonProperty;
+
+class JsonPropertyTest {
+
+    Schema jsonSchema = Schema.DEFAULT;
+
+    static const Data(@JsonProperty("$data") String? s, String foo) {}
+
+    @Test
+    void shouldParseValueWithCustomPropertyName() {
+        Data   data    = new Data("One", "Two");
+        String jsonStr = \|{"$data":"One", "foo":"Two"}
+                          ;
+        Mapping<Data> valueMapping = jsonSchema.ensureMapping(Data);
+        using (ObjectInputStream stream = new ObjectInputStream(jsonSchema, jsonStr.toReader())) {
+            val parsed = valueMapping.read(stream.ensureElementInput());
+            assert parsed == data;
+        }
+    }
+
+    @Test
+    public void shouldWriteValueWithCustomPropertyName() {
+        StringBuffer buf  = new StringBuffer();
+        Data         data = new Data("One", "Two");
+        jsonSchema.createObjectOutput(buf).write(data);
+        assert buf.toString() == \|{"$data":"One","foo":"Two"}
+                                  ;
+    }
+}


### PR DESCRIPTION
Sometimes we need to use a name for a property in JSON that is not a valid identifier in Ecstasy. We could use a custom mapping for this, but that means hand coding serialisation just for a property name change. This PR adds the `JsonProperty` annotation that can be applied to a property to specify a different name to use when the type is being serialised using the `ReflectionMapping`.
