### PR TITLE
CI: fix IntelliJ Marketplace publish (clobbered ZIP version)

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -384,6 +384,14 @@ jobs:
                   echo "release-channel=$RELEASE_CHANNEL" >> $GITHUB_OUTPUT
                   echo "🔖 IntelliJ Marketplace publish version: $PUBLISH_VERSION"
 
+            # NOTE: We deliberately do NOT cache lang/.intellijPlatform/ides via
+            # actions/cache. ~1 GB per IDE distribution would eat a meaningful chunk
+            # of the 10 GB per-repo cache budget that's far more valuable for PR
+            # builds and Gradle/dep caches. The verifier only needs the IDE on the
+            # rare lang/-changed run (PR validation or master publish), and the
+            # IntelliJ Platform Gradle Plugin will redownload it on demand. Slower
+            # by ~1-2 minutes on those runs, but it doesn't displace the caches we
+            # actually rely on for everything else.
             - name: Build the XDK and create a distribution
               shell: bash
               env:
@@ -540,23 +548,6 @@ jobs:
                   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
                   echo "🎉 ALL LANG VALIDATION COMPLETE"
                   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-
-            # Cache the IntelliJ IDE distributions used by the IntelliJ Platform
-            # Gradle Plugin. Keyed on libs.versions.toml so an IDE version bump
-            # forces a fresh download. ~1 GB per cached IDE; reused across runs
-            # by buildPlugin/runIde and verifyPlugin (all of which run in the main
-            # CI build above, never in a separate Gradle invocation).
-            - name: Cache IntelliJ IDE distributions
-              if: |
-                  success() &&
-                  matrix.os == 'ubuntu-latest' &&
-                  steps.publish-flags.outputs.validate-lang == 'true'
-              uses: actions/cache@v4
-              with:
-                  path: lang/.intellijPlatform/ides
-                  key: intellij-ides-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
-                  restore-keys: |
-                      intellij-ides-${{ runner.os }}-
 
             - name: Upload Plugin Verifier reports
               if: |

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -389,6 +389,7 @@ jobs:
               env:
                   GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
                   ENABLE_INTELLIJ_RELEASE_BUILD: ${{ matrix.os == 'ubuntu-latest' && steps.publish-flags.outputs.effective == 'true' }}
+                  ENABLE_INTELLIJ_VERIFY: ${{ matrix.os == 'ubuntu-latest' && steps.publish-flags.outputs.validate-lang == 'true' }}
                   ENABLE_SNAPSHOT_BUNDLE_BUILD: ${{ matrix.os == 'ubuntu-latest' && ((github.ref == 'refs/heads/master' && github.event_name == 'push') || (github.event_name == 'workflow_dispatch' && (github.event.inputs.publish-snapshots == true || github.event.inputs.publish-snapshots == 'true'))) }}
                   ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
                   ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
@@ -430,13 +431,30 @@ jobs:
                     BUILD_PROPS="$BUILD_PROPS -Porg.xtclang.publish.snapshotBundleRepo=$SNAPSHOT_REPO_DIR"
                 fi
 
+                # IntelliJ plugin handling. There is exactly one place in CI that
+                # runs :lang:intellij-plugin:verifyPlugin: this main Gradle invocation.
+                # verifyPlugin depends on buildPlugin (which depends on patchPluginXml),
+                # so re-running verifyPlugin in a separate Gradle invocation rewrites
+                # lang/intellij-plugin/build/distributions/intellij-plugin-*.zip with
+                # whatever properties that second invocation sees -- which is exactly
+                # how a prior CI shape (a standalone "Verify IntelliJ plugin
+                # compatibility" step that did not pass -PenablePublish) silently
+                # clobbered the timestamped Marketplace ZIP with the bare base
+                # version. Keeping verification colocated with the build means the
+                # staged distribution and the verified distribution are always the
+                # same artifact, by construction.
                 if [ "${ENABLE_INTELLIJ_RELEASE_BUILD}" = "true" ]; then
-                    echo "🔌 Building IntelliJ release-grade plugin in main CI build"
+                    echo "🔌 Building release-grade IntelliJ plugin and running verifyPlugin in main CI build"
                     echo "   Reason: ${{ steps.publish-flags.outputs.reason }}"
                     BUILD_TASKS="$BUILD_TASKS :lang:intellij-plugin:buildSearchableOptions :lang:intellij-plugin:buildPlugin :lang:intellij-plugin:verifyPlugin"
                     BUILD_PROPS="$BUILD_PROPS -PincludeBuildLang=true -PincludeBuildAttachLang=true -PenablePublish=true -Pjetbrains.publish.suffix=${{ steps.intellij-version.outputs.suffix }} -Plsp.buildSearchableOptions=true"
+                elif [ "${ENABLE_INTELLIJ_VERIFY}" = "true" ]; then
+                    echo "🔌 Running IntelliJ plugin verifier in main CI build (no Marketplace publication for this run)"
+                    echo "   Reason: ${{ steps.publish-flags.outputs.validate-lang-reason }}"
+                    BUILD_TASKS="$BUILD_TASKS :lang:intellij-plugin:verifyPlugin"
+                    BUILD_PROPS="$BUILD_PROPS -PincludeBuildLang=true -PincludeBuildAttachLang=true"
                 elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-                    echo "⏭️ Not building IntelliJ plugin"
+                    echo "⏭️ Not building or verifying IntelliJ plugin"
                     echo "   Reason: ${{ steps.publish-flags.outputs.reason }}"
                 fi
 
@@ -526,7 +544,8 @@ jobs:
             # Cache the IntelliJ IDE distributions used by the IntelliJ Platform
             # Gradle Plugin. Keyed on libs.versions.toml so an IDE version bump
             # forces a fresh download. ~1 GB per cached IDE; reused across runs
-            # by both buildPlugin/runIde and the verifyPlugin step below.
+            # by buildPlugin/runIde and verifyPlugin (all of which run in the main
+            # CI build above, never in a separate Gradle invocation).
             - name: Cache IntelliJ IDE distributions
               if: |
                   success() &&
@@ -538,42 +557,6 @@ jobs:
                   key: intellij-ides-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
                   restore-keys: |
                       intellij-ides-${{ runner.os }}-
-
-            - name: Skip IntelliJ plugin verifier (no lang validation triggered)
-              if: |
-                  success() &&
-                  matrix.os == 'ubuntu-latest' &&
-                  steps.publish-flags.outputs.validate-lang != 'true'
-              run: |
-                  echo "⏭️ Skipping IntelliJ Plugin Verifier"
-                  echo "Reason: ${{ steps.publish-flags.outputs.validate-lang-reason }}"
-
-            # Run JetBrains Plugin Verifier against every IDE build matching
-            # the plugin's declared compatibility range (since-build "261"+).
-            # Catches binary-incompat regressions (removed APIs, missing classes,
-            # signature changes) BEFORE publication, not after users hit them.
-            # The verifier failure level in lang/intellij-plugin/build.gradle.kts
-            # is set so this fails on COMPATIBILITY_PROBLEMS / INVALID_PLUGIN /
-            # MISSING_DEPENDENCIES; deprecated/experimental API touches stay warnings.
-            - name: Verify IntelliJ plugin compatibility
-              if: |
-                  success() &&
-                  matrix.os == 'ubuntu-latest' &&
-                  steps.publish-flags.outputs.validate-lang == 'true'
-              shell: bash
-              env:
-                  GRADLE_OPTS: ${{ steps.versions.outputs.gradle-jvm-opts }}
-              run: |
-                  GRADLE_OPTIONS="${{ steps.versions.outputs.gradle-options }}"
-                  LANG_OPTS="-PincludeBuildLang=true -PincludeBuildAttachLang=true"
-
-                  echo ""
-                  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-                  echo "🔌 INTELLIJ PLUGIN VERIFIER"
-                  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-
-                  ./gradlew $GRADLE_OPTIONS $LANG_OPTS :lang:intellij-plugin:verifyPlugin
-                  echo "✅ Plugin Verifier: PASSED"
 
             - name: Upload Plugin Verifier reports
               if: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -402,9 +402,42 @@ jobs:
                   ZIP_FILE="${{ steps.artifact.outputs.zip-file }}"
                   XML_ID="${{ steps.artifact.outputs.xml-id }}"
                   CHANNEL="${{ steps.artifact.outputs.release-channel }}"
+                  PUBLISH_VERSION="${{ steps.artifact.outputs.publish-version }}"
                   RESPONSE_FILE="$RUNNER_TEMP/jetbrains-upload-response.json"
 
+                  # Sanity-check what the build actually baked into plugin.xml. Marketplace
+                  # derives the upload version from the ZIP's META-INF/plugin.xml, NOT from
+                  # any form field, so a mismatch here means the build produced a stale or
+                  # bare-versioned ZIP and any "already contains version" response from
+                  # Marketplace is a real failure (silent regression) rather than an
+                  # idempotent re-publish. Fail fast before touching the API.
+                  TMP_EXTRACT=$(mktemp -d)
+                  trap 'rm -rf "$TMP_EXTRACT"' EXIT
+                  unzip -q "$ZIP_FILE" -d "$TMP_EXTRACT"
+                  INNER_JAR=$(find "$TMP_EXTRACT" -path '*/lib/intellij-plugin-*.jar' \
+                      -not -name '*searchableOptions*' | head -1)
+                  ZIP_PLUGIN_VERSION=$(unzip -p "$INNER_JAR" META-INF/plugin.xml 2>/dev/null \
+                      | sed -n 's|.*<version>\([^<]*\)</version>.*|\1|p' | head -1)
+                  if [ "$ZIP_PLUGIN_VERSION" != "$PUBLISH_VERSION" ]; then
+                      echo "❌ Plugin ZIP version mismatch — refusing to publish."
+                      echo "   metadata publishVersion : $PUBLISH_VERSION"
+                      echo "   plugin.xml <version>    : ${ZIP_PLUGIN_VERSION:-<empty>}"
+                      echo ""
+                      echo "The CI build that produced this artifact did not bake the"
+                      echo "timestamped publish version into plugin.xml. Inspect the"
+                      echo "main build's :lang:intellij-plugin:patchPluginXml step and"
+                      echo "ensure -PenablePublish=true plus -Pjetbrains.publish.suffix"
+                      echo "are passed for every Gradle invocation that re-runs"
+                      echo "buildPlugin. Aborting before Marketplace upload — uploading"
+                      echo "the bare base version would collide with the existing"
+                      echo "0.4.4-SNAPSHOT entry on Marketplace."
+                      exit 1
+                  fi
+
                   echo "🚀 Publishing IntelliJ plugin to JetBrains Marketplace alpha..."
+                  echo "   xmlId   : $XML_ID"
+                  echo "   channel : $CHANNEL"
+                  echo "   version : $PUBLISH_VERSION"
                   if curl --fail-with-body --silent --show-error \
                     -H "Authorization: Bearer $JETBRAINS_TOKEN" \
                     -F "xmlId=$XML_ID" \
@@ -416,9 +449,19 @@ jobs:
                   else
                       STATUS=$?
                       RESPONSE=$(cat "$RESPONSE_FILE" 2>/dev/null || true)
-                      if [[ "$RESPONSE" == *"already contains version"* ]]; then
-                          echo "ℹ️ JetBrains Marketplace already has this exact plugin version in channel '$CHANNEL'."
+                      # Treat the response as idempotent ONLY if Marketplace explicitly
+                      # references the version we just tried to upload. The looser
+                      # substring match used previously (any "already contains version"
+                      # message) silently masked a real regression where buildPlugin
+                      # re-patched plugin.xml with the bare base version after the main
+                      # build had staged the timestamped ZIP — Marketplace then said the
+                      # bare version already existed, the script declared success, and
+                      # no new alpha version landed for several days.
+                      if [[ "$RESPONSE" == *"already contains version"*"$PUBLISH_VERSION"* ]]; then
+                          echo "ℹ️ JetBrains Marketplace already has version '$PUBLISH_VERSION' in channel '$CHANNEL'."
                           echo "ℹ️ Continuing so GitHub release assets can still be updated for this CI artifact."
+                          echo "Marketplace response:"
+                          echo "$RESPONSE"
                       else
                           echo "❌ JetBrains Marketplace upload failed"
                           [ -n "$RESPONSE" ] && echo "$RESPONSE"

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -416,12 +416,38 @@ jobs:
                   unzip -q "$ZIP_FILE" -d "$TMP_EXTRACT"
                   INNER_JAR=$(find "$TMP_EXTRACT" -path '*/lib/intellij-plugin-*.jar' \
                       -not -name '*searchableOptions*' | head -1)
+                  if [ -z "$INNER_JAR" ] || [ ! -f "$INNER_JAR" ]; then
+                      echo "❌ Could not locate inner plugin JAR in $ZIP_FILE — refusing to publish."
+                      echo "   Expected: */lib/intellij-plugin-*.jar (excluding *searchableOptions*)"
+                      echo ""
+                      echo "ZIP top-level layout:"
+                      ( cd "$TMP_EXTRACT" && find . -maxdepth 4 -type f | sort | head -40 )
+                      echo ""
+                      echo "This usually means the ZIP layout produced by the IntelliJ"
+                      echo "Platform Gradle Plugin changed (filename pattern, lib/ path,"
+                      echo "or sandbox structure). Update the find expression above to"
+                      echo "match the new layout before re-running."
+                      exit 1
+                  fi
                   ZIP_PLUGIN_VERSION=$(unzip -p "$INNER_JAR" META-INF/plugin.xml 2>/dev/null \
                       | sed -n 's|.*<version>\([^<]*\)</version>.*|\1|p' | head -1)
+                  if [ -z "$ZIP_PLUGIN_VERSION" ]; then
+                      echo "❌ Could not extract <version> from plugin.xml — refusing to publish."
+                      echo "   inner JAR: $INNER_JAR"
+                      echo ""
+                      echo "JAR contents (top 40 entries):"
+                      unzip -l "$INNER_JAR" 2>/dev/null | head -40
+                      echo ""
+                      echo "META-INF/plugin.xml contents (first 80 lines):"
+                      unzip -p "$INNER_JAR" META-INF/plugin.xml 2>/dev/null | head -80 \
+                          || echo "  (META-INF/plugin.xml not present in this JAR)"
+                      exit 1
+                  fi
                   if [ "$ZIP_PLUGIN_VERSION" != "$PUBLISH_VERSION" ]; then
                       echo "❌ Plugin ZIP version mismatch — refusing to publish."
                       echo "   metadata publishVersion : $PUBLISH_VERSION"
-                      echo "   plugin.xml <version>    : ${ZIP_PLUGIN_VERSION:-<empty>}"
+                      echo "   plugin.xml <version>    : $ZIP_PLUGIN_VERSION"
+                      echo "   inner JAR               : $INNER_JAR"
                       echo ""
                       echo "The CI build that produced this artifact did not bake the"
                       echo "timestamped publish version into plugin.xml. Inspect the"


### PR DESCRIPTION
## Summary

- Restores IntelliJ Marketplace alpha publishing on master (broken since 2026-04-30; last successful publish was `0.4.4-SNAPSHOT.20260429204308`).
- Collapses the standalone "Verify IntelliJ plugin compatibility" step into the main build so verification and the staged distribution ZIP are always the same artifact.
- Adds two defenses in `publish-snapshot.yml` so a regression of this class fails loudly instead of going green.

## Root cause

PR #452 added a standalone `Verify IntelliJ plugin compatibility` step that re-ran `:lang:intellij-plugin:verifyPlugin` in a separate Gradle invocation, gated only on `validate-lang == 'true'`. That invocation passed only `-PincludeBuildLang/-PincludeBuildAttachLang` — **not** `-PenablePublish=true` or `-Pjetbrains.publish.suffix=<utc>`. `verifyPlugin` depends on `buildPlugin` which depends on `patchPluginXml`, so the second invocation re-evaluated `jetbrainsPublishVersionProvider` with `publishEnabled=false`, fell into the bare-base-version branch of `lang/intellij-plugin/build.gradle.kts:40-49`, and overwrote `lang/intellij-plugin/build/distributions/intellij-plugin-0.4.4-SNAPSHOT.zip` with a ZIP whose `META-INF/plugin.xml` said `<version>0.4.4-SNAPSHOT</version>` — clobbering the timestamped artifact the main build had just staged for `intellij-plugin-dist-<sha>`.

`publish-snapshot.yml` then promoted that clobbered ZIP. Marketplace correctly returned HTTP 400 with `channel 'alpha' already contains version 0.4.4-SNAPSHOT` (the bare base was already published as id 1016162 when the plugin was first registered). The script's idempotency heuristic substring-matched `"already contains version"` and declared the upload a successful no-op. CI stayed green for two days while no new alpha version landed on Marketplace.

Verified locally:

- `:lang:intellij-plugin:patchPluginXml` with `-PenablePublish=true -Pjetbrains.publish.suffix=20260501TEST` → `<version>0.4.4-SNAPSHOT.20260501TEST</version>`
- Same task without those properties → `<version>0.4.4-SNAPSHOT</version>`

## Fix in `commit.yml`

Collapse to one Gradle invocation that owns both `buildPlugin` and `verifyPlugin`. The main `Build the XDK and create a distribution` step now handles all three IntelliJ paths:

1. `effective == 'true'` (master push with lang/ changes, or manual dispatch with publish flags) — adds `buildSearchableOptions + buildPlugin + verifyPlugin` to `BUILD_TASKS` along with `-PenablePublish` and `-Pjetbrains.publish.suffix`. **Publication path.**
2. `validate-lang == 'true' && effective != 'true'` (PR build with lang/ changes, or manual dispatch with `include-lang`) — adds `verifyPlugin` only, no publish properties. **Verification-only path; nothing is staged for Marketplace.**
3. Otherwise — IntelliJ tasks are not in `BUILD_TASKS` at all. `lang/intellij-plugin/build/distributions/` stays empty, nothing to clobber.

The standalone `Verify IntelliJ plugin compatibility` step and its two `Skip` companion steps are deleted. There is now exactly one place in CI that runs `verifyPlugin`, and the staged distribution ZIP is by construction the same artifact that was just verified.

Marketplace publication trigger is unchanged — the snapshot-publish workflow is kicked off only by master pushes (or manual dispatch), in the same job that fires Homebrew, Docker, and GitHub release updates. PR builds verify the plugin but never publish.

## Fix in `publish-snapshot.yml`

Two defenses so a regression of this class fails loudly:

1. **Pre-upload sanity check.** Extract `<version>` from the ZIP's `META-INF/plugin.xml` and abort if it doesn't match the publishVersion the CI build claimed it baked in. Marketplace derives the upload version from the ZIP, not from any form field, so a mismatch means the build produced a stale or bare-versioned artifact.
2. **Tightened idempotent heuristic.** Only treat an `"already contains version"` 400 as a successful no-op when the response body explicitly references the version we just tried to upload. The previous loose substring match accepted `already contains version 0.4.4-SNAPSHOT` as proof that `0.4.4-SNAPSHOT.<timestamp>` was published — exactly the substitution that hid this regression for two days. Full Marketplace response is now echoed in the idempotent path.

Mismatch check uses `unzip + sed` on the inner plugin JAR — no new tooling required on the runner image.

## Test plan

- [x] `patchPluginXml` with publish props produces timestamped `<version>` (verified locally)
- [x] `patchPluginXml` without publish props produces bare `<version>` (verified — the bug)
- [x] Full `buildSearchableOptions + buildPlugin` with publish props produces inner JAR named `intellij-plugin-0.4.4-SNAPSHOT.<suffix>.jar` (verified locally)
- [x] Sanity check correctly extracts `<version>` from the inner JAR (verified locally)
- [x] Sanity check aborts when ZIP version is bare (today's bug pattern) (verified locally)
- [x] Tightened idempotent heuristic rejects today's response body, accepts a real same-version re-upload (verified locally)
- [x] Both YAMLs parse
- [ ] First master merge after this PR successfully publishes a new alpha version to Marketplace
- [ ] PR build with lang/ changes still runs `verifyPlugin` (now via the consolidated path)