### PR TITLE
Fix local docker:buildAll: default to docker + more overrides

### DIFF
--- a/build-logic/common-plugins/build.gradle.kts
+++ b/build-logic/common-plugins/build.gradle.kts
@@ -37,4 +37,9 @@ dependencies {
     // Archive handling for native library builds (XZ/tar support)
     implementation("org.apache.commons:commons-compress:${libs.versions.apache.commons.compress.get()}")
     implementation("org.tukaani:xz:${libs.versions.tukaani.xz.get()}")
+
+    // git-version: compileOnly so the convention plugin can reference the
+    // public VersionDetails interface directly (no reflection). The plugin
+    // itself is applied by consumers (e.g. docker/build.gradle.kts).
+    compileOnly("com.palantir.gradle.gitversion:gradle-git-version:${libs.versions.palantir.git.version.get()}")
 }

--- a/build-logic/common-plugins/src/main/kotlin/DockerTasks.kt
+++ b/build-logic/common-plugins/src/main/kotlin/DockerTasks.kt
@@ -76,6 +76,9 @@ abstract class DockerTask : DefaultTask() {
     @get:Input
     abstract val dockerCommand: Property<String>
 
+    @get:Input
+    abstract val baseImage: Property<String>
+
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val dockerDir: DirectoryProperty
@@ -117,7 +120,7 @@ abstract class DockerTask : DefaultTask() {
         try {
             // Docker command construction with proper tag computation
             val platformArg = platforms.get().joinToString(",")
-            val baseImage = "ghcr.io/xtclang/xvm"
+            val image = baseImage.get()
 
             // Git info provided via Palantir plugin (local) or CI env vars (GH_COMMIT/GH_BRANCH)
             val commit = gitCommit.get()
@@ -155,7 +158,7 @@ abstract class DockerTask : DefaultTask() {
                       listOf("--progress=${dockerProgress.get()}") +
                       listOf("--build-arg", "JAVA_VERSION=${jdkVersion.get()}") +
                       listOf("--build-arg", "DIST_ZIP_URL=xdk-dist.zip") +
-                      computedTags.flatMap { tag -> listOf("--tag", "$baseImage:$tag") } +
+                      computedTags.flatMap { tag -> listOf("--tag", "$image:$tag") } +
                       listOf("--label", "org.opencontainers.image.revision=$commit") +
                       listOf("--label", "org.opencontainers.image.version=$version") +
                       listOf("--label", "org.opencontainers.image.source=https://github.com/xtclang/xvm/tree/$branch") +

--- a/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.docker.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.docker.gradle.kts
@@ -2,9 +2,11 @@
  * Docker convention plugin for XVM project.
  * Provides configuration cache compatible Docker build tasks.
  *
- * Requires palantir-git-version plugin to be applied in the consuming project
- * for git info (applied via docker/build.gradle.kts).
+ * Requires a git-version plugin to be applied in the consuming project for
+ * git info (applied via docker/build.gradle.kts).
  */
+
+import com.palantir.gradle.gitversion.VersionDetails
 
 plugins {
     id("org.xtclang.build.xdk.properties")
@@ -48,33 +50,21 @@ fun createDockerBuildTask(
         this.jdkVersion.set(project.xdkProperties.int("org.xtclang.java.jdk"))
         this.architectureCheck.set(architectureCheck ?: "")
 
-        // Wire git information from Palantir plugin (available for local builds) or CI env vars
-        // CI sets GH_COMMIT/GH_BRANCH, local builds use Palantir versionDetails
-        // Helper to get Palantir versionDetails property using reflection (avoids compile-time dependency)
-        // VersionDetailsImpl is non-public, so resolve the method via its public interface
-        // (or fall back to setAccessible) to avoid IllegalAccessException at invoke time.
-        fun getVersionDetailsProperty(methodName: String, fallback: String): String? {
-            return try {
-                @Suppress("UNCHECKED_CAST")
-                val versionDetails = (project.extensions.extraProperties["versionDetails"] as groovy.lang.Closure<*>).call()
-                val klass = versionDetails::class.java
-                val method = klass.interfaces.firstNotNullOfOrNull { iface ->
-                    runCatching { iface.getMethod(methodName) }.getOrNull()
-                } ?: klass.getMethod(methodName).also { it.isAccessible = true }
-                method.invoke(versionDetails) as? String ?: fallback
-            } catch (e: Exception) {
-                logger.warn("Failed to get $methodName from Palantir plugin: ${e.message}")
-                fallback
-            }
-        }
+        // Wire git information: CI sets GH_COMMIT/GH_BRANCH; local builds read it
+        // from the `versionDetails` closure on project.ext when a git-version
+        // plugin is applied.
+        fun versionDetails(): VersionDetails? = runCatching {
+            @Suppress("UNCHECKED_CAST")
+            (project.extensions.extraProperties["versionDetails"] as groovy.lang.Closure<VersionDetails>).call()
+        }.getOrNull()
 
         this.gitCommit.set(
             providers.environmentVariable("GH_COMMIT")
-                .orElse(providers.provider { getVersionDetailsProperty("getGitHashFull", "unknown") })
+                .orElse(providers.provider { versionDetails()?.gitHashFull ?: "unknown" })
         )
         this.gitBranch.set(
             providers.environmentVariable("GH_BRANCH")
-                .orElse(providers.provider { getVersionDetailsProperty("getBranchName", "detached-head") })
+                .orElse(providers.provider { versionDetails()?.branchName ?: "detached-head" })
         )
 
         this.projectVersion.set(providers.provider { project.version.toString() })

--- a/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.docker.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.docker.gradle.kts
@@ -51,11 +51,17 @@ fun createDockerBuildTask(
         // Wire git information from Palantir plugin (available for local builds) or CI env vars
         // CI sets GH_COMMIT/GH_BRANCH, local builds use Palantir versionDetails
         // Helper to get Palantir versionDetails property using reflection (avoids compile-time dependency)
+        // VersionDetailsImpl is non-public, so resolve the method via its public interface
+        // (or fall back to setAccessible) to avoid IllegalAccessException at invoke time.
         fun getVersionDetailsProperty(methodName: String, fallback: String): String? {
             return try {
                 @Suppress("UNCHECKED_CAST")
                 val versionDetails = (project.extensions.extraProperties["versionDetails"] as groovy.lang.Closure<*>).call()
-                versionDetails::class.java.getMethod(methodName).invoke(versionDetails) as? String ?: fallback
+                val klass = versionDetails::class.java
+                val method = klass.interfaces.firstNotNullOfOrNull { iface ->
+                    runCatching { iface.getMethod(methodName) }.getOrNull()
+                } ?: klass.getMethod(methodName).also { it.isAccessible = true }
+                method.invoke(versionDetails) as? String ?: fallback
             } catch (e: Exception) {
                 logger.warn("Failed to get $methodName from Palantir plugin: ${e.message}")
                 fallback
@@ -82,6 +88,7 @@ fun createDockerBuildTask(
         ciMode.set(providers.environmentVariable("CI").map { it == "true" }.orElse(false))
         userHome.set(providers.systemProperty("user.home"))
         dockerCommand.set(project.xdkProperties.string("org.xtclang.docker.command", "docker"))
+        baseImage.set(project.xdkProperties.string("org.xtclang.docker.image", "ghcr.io/xtclang/xvm"))
         dockerDir.set(layout.projectDirectory)
 
         // Output marker file for caching

--- a/docker/README.md
+++ b/docker/README.md
@@ -140,6 +140,44 @@ docker buildx build --build-arg DIST_ZIP_URL=/path/to/xdk-dist.zip -t xvm:latest
 - `DIST_ZIP_URL` (required) - Path to XDK distribution ZIP file or download URL
 - `JAVA_VERSION` (default: 25) - Java version to use for runtime
 
+### Local Build Overrides (Gradle properties)
+
+The gradle docker tasks (`docker:buildAmd64` / `docker:buildArm64` / `docker:buildAll`, etc.) read several `-P` properties from the command line or `xdk.properties`. These apply to **local builds only** — CI ignores them and uses its own hardcoded values.
+
+| Property | Default | Purpose |
+|---|---|---|
+| `org.xtclang.docker.command` | `docker` | The container CLI to invoke. Set to `podman` if you have podman installed instead of docker. |
+| `org.xtclang.docker.image` | `ghcr.io/xtclang/xvm` | Base image name (registry + repository) used in the resulting tags. Override to publish to a different registry or repo namespace, e.g. `mlocal/xvm`. |
+| `org.xtclang.docker.allowEmulation` | `false` | If `false`, the per-arch tasks (`buildAmd64` / `buildArm64`) refuse to build a non-host architecture. Set to `true` to allow QEMU emulation for cross-arch builds. |
+
+Tag suffix `-local` is appended automatically to all locally-built tags (`<branch>-local`, `<commit>-local`) so they can never collide with anything CI publishes.
+
+#### Examples
+
+```bash
+# Build with podman instead of docker
+./gradlew docker:buildAmd64 -Porg.xtclang.docker.command=podman
+
+# Build under a different image name (useful for testing without touching ghcr.io/xtclang/xvm)
+./gradlew docker:buildAmd64 -Porg.xtclang.docker.image=mlocal/xvm
+# -> produces mlocal/xvm:<branch>-local and mlocal/xvm:<commit>-local
+
+# Allow cross-arch emulation
+./gradlew docker:buildArm64 -Porg.xtclang.docker.allowEmulation=true
+```
+
+You can also set these persistently in your personal `~/.gradle/gradle.properties` rather than passing `-P` every time.
+
+#### Seeing the exact `docker buildx` command
+
+The task logs the full container command at `info` level just before exec. To see (and copy-paste) it:
+
+```bash
+./gradlew docker:buildAmd64 --info --rerun 2>&1 | grep "Executing Docker command:"
+```
+
+`--rerun` is needed because the task is `@CacheableTask` and will be UP-TO-DATE on a second invocation. The args are space-joined without shell quoting; none of the assembled args contain spaces, so the line is paste-ready into a shell.
+
 ## Direct Docker Commands (Alternative to Gradle)
 
 If you prefer using Docker commands directly instead of Gradle tasks, you must first build the XDK distribution:

--- a/xdk.properties
+++ b/xdk.properties
@@ -11,9 +11,11 @@
 #
 # Should Docker builds allow emulation for cross-platform builds? (default is false, will only build native docker architecture)
 # Docker/Podman command (use "podman" to use podman instead of docker) locally. The CI ignores this.
+# Base image name for local builds (default ghcr.io/xtclang/xvm). Override e.g. with -Porg.xtclang.docker.image=mlocal/xvm.
 #
 org.xtclang.docker.allowEmulation=false
-org.xtclang.docker.command=podman
+org.xtclang.docker.command=docker
+# org.xtclang.docker.image=ghcr.io/xtclang/xvm
 
 #
 # Java Properties; used by the XTC precompiled Java convention plugin.


### PR DESCRIPTION
## Summary

Two small fixes for `./gradlew docker:buildAll` on machines with Docker (not Podman) installed.

1. **`xdk.properties`** — flip `org.xtclang.docker.command` from `podman` to `docker`. The comment on the line above already documents docker as the default ("use `podman` to use podman instead of docker"); the checked-in value contradicted that and forced everyone onto podman unless they overrode it. Users who actually want podman can set it in their personal `~/.gradle/gradle.properties` or pass `-Porg.xtclang.docker.command=podman`.

2. **`org.xtclang.build.docker.gradle.kts`** — `VersionDetailsImpl` from the Palantir git-version plugin is a non-public class, so `Method.invoke()` against `versionDetails::class.java.getMethod(...)` threw `IllegalAccessException` ("cannot access a member of class ... with modifiers public"). The helper then fell through to its fallbacks, producing tags like `detached-head-local` and `unknown-local`. Now resolve the method via the public `VersionDetails` interface first (with a `setAccessible` fallback for safety), so `getBranchName` / `getGitHashFull` return real values for local builds.

## Repro (before this fix)

```
ubuntu@host:~/xvm$ ./gradlew docker:buildAll
Failed to get getBranchName from Palantir plugin: ... cannot access a member ... with modifiers "public"
Failed to get getGitHashFull from Palantir plugin: ...
Computing Docker tags: branch=detached-head, version=0.4.4-SNAPSHOT, commit=unknown
Generated tags: detached-head-local, unknown-local
> A problem occurred starting process 'command 'podman''
```

## Test plan

- [ ] `./gradlew docker:buildAmd64` on a Linux/amd64 host with docker installed and no podman — should invoke `docker buildx build` and produce sensible tags (`<branch>-local`, `<commit>-local`).
- [ ] Confirm log shows `branch=<your-branch>` and `commit=<full-sha>` (not `detached-head` / `unknown`).
- [ ] Override still works: `./gradlew docker:buildAmd64 -Porg.xtclang.docker.command=podman` invokes podman.
- [ ] CI Docker workflow unaffected (it sets `GH_COMMIT` / `GH_BRANCH` env vars and never reads `org.xtclang.docker.command`).