### PR TITLE
Fix a compiler exception

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/UnresolvedNameConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/UnresolvedNameConstant.java
@@ -8,6 +8,9 @@ import java.util.function.Consumer;
 
 import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
+
+import org.xvm.compiler.CompilerException;
+
 import org.xvm.util.Hash;
 
 
@@ -182,6 +185,11 @@ public class UnresolvedNameConstant
             }
         }
         return null;
+    }
+
+    @Override
+    public TypeConstant getType() {
+        throw new CompilerException(getName());
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/UnresolvedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/UnresolvedTypeConstant.java
@@ -16,6 +16,7 @@ import org.xvm.asm.ErrorListener;
 import org.xvm.asm.GenericTypeResolver;
 
 import org.xvm.compiler.Compiler;
+import org.xvm.compiler.CompilerException;
 
 import org.xvm.util.Hash;
 import org.xvm.util.Severity;
@@ -122,7 +123,7 @@ public class UnresolvedTypeConstant
         if (isTypeResolved()) {
             return m_type;
         }
-        throw new IllegalStateException();
+        throw new CompilerException(m_constId.getName());
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/compiler/ast/StageMgr.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/StageMgr.java
@@ -14,6 +14,7 @@ import org.xvm.asm.constants.IdentityConstant;
 
 import org.xvm.compiler.Compiler;
 import org.xvm.compiler.Compiler.Stage;
+import org.xvm.compiler.CompilerException;
 
 import org.xvm.compiler.ast.AstNode.ChildIterator;
 
@@ -74,14 +75,24 @@ public class StageMgr {
      *         target stage
      */
     public boolean processComplete() {
-        if (getErrorListener().isAbortDesired()) {
+        ErrorListener errs = m_errs;
+        if (errs.isAbortDesired()) {
             return false;
         }
 
         if (m_listRevisit != null) {
             for (AstNode node : takeRevisitList()) {
-                processInternal(node);
-                if (getErrorListener().isAbortDesired()) {
+                try {
+                    processInternal(node);
+                } catch (CompilerException e) {
+                    // there is a possibility that during the "resolveName" phase we have not
+                    // resolved some annotation parameters and moved to the "validateContent" phase;
+                    // now if class A validation relies on class B with unresolved annotations
+                    // it may throw the CompilerException (see UnresolvedName#getType)
+                    node.log(errs, Severity.ERROR, Compiler.NAME_UNRESOLVABLE, e.getMessage());
+                    return false;
+                }
+                if (errs.isAbortDesired()) {
                     return false;
                 }
             }

--- a/manualTests/src/main/x/annos.x
+++ b/manualTests/src/main/x/annos.x
@@ -5,6 +5,7 @@ module TestAnnotations {
         testWatch();
         testAnnotations();
         testAnnotations2();
+        testAnnotations3();
         testMethodAnno();
         testClassAnno();
         testDefaultParams();
@@ -130,6 +131,29 @@ module TestAnnotations {
                 }
             }
         }
+    }
+
+    void testAnnotations3() {
+        interface Predicate {
+            Boolean eval();
+        }
+
+        annotation PreComputed(Boolean value = False) into Predicate {
+            @Override Boolean eval() = value;
+        }
+
+        @PreComputed(True)
+        class ClassA implements Predicate {
+            ClassB b = new ClassB();
+
+            @Override
+            Boolean eval() = b.eval();
+        }
+
+        @PreComputed(True)
+        class ClassB implements Predicate {}
+
+       assert new ClassA().eval() == True;
     }
 
     @Tagged(weight=1)


### PR DESCRIPTION
This issues was [reported by Dima on Discord](https://discord.com/channels/837372142576205885/1406009322307190834/1505484174197260468).

The gist of the problem lies in the flow of processing by the StageManager:

1) during the "resolveName" stage, we resolve all the names with a possible exception of the annotation parameters, since they could be represented by expressions and need to be "validated"

2) during the "validateContent" stage, we validate those "left behind" annotation parameters; if detect that some of them are on not-yet-validated, we repeat the cycle via `mgr.requestRevisit()` API

The problem arises when the validation requires using the TypeInfo for classes that depend on those "not-yet-validated" ones. In that case, the `UnresolvedNameConstant` or `UnresolvedTypeConstant` would throw an `UnsupportedOperationException`, causing the compiler termination.

The proposed fix replaces the `UnsupportedOperationException` with the `CompilerException` and handles it in the `StageManager` in the same way a standard "Name not resolved" error