### PR TITLE
Fix HMAC key sizes for HmacSHA256 and HmacSHA512

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
@@ -243,7 +243,15 @@ public class xRTAlgorithms
                 };
 
             case "HmacSHA1", "HmacSHA256", "HmacSHA512":
-                // fall through
+                return switch (keyForm) {
+                    case PublicOrSecret, PrivateOrSecret ->
+                        new SecretKeySpec(abRaw, sAlgorithm);
+
+                    default ->
+                        throw new GeneralSecurityException(
+                            sAlgorithm + " algorithm only supports secret keys");
+                };
+
             default:
                 // unlike specific cases above, default implementation uses generic "SecretKeySpec"
                 return switch (keyForm) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
@@ -95,7 +95,7 @@ public class xRTSigner
                 byte[]  abData = xRTUInt8Delegate.getBytes(haData);
 
                 Key privateKey = xRTAlgorithms.extractKey(frame, hKey,
-                                        mac.getAlgorithm(), KeyForm.Private);
+                                        mac.getAlgorithm(), KeyForm.PrivateOrSecret);
                 mac.init(privateKey);
                 abSig = mac.doFinal(abData);
             } else {

--- a/javatools_bridge/src/main/x/_native/crypto/RTAlgorithms.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTAlgorithms.x
@@ -124,8 +124,8 @@ service RTAlgorithms {
      */
     static Tuple<String, KeySize>[] macs = [
         ("HmacSHA1",    16),
-        ("HmacSHA256", [16, 128]),
-        ("HmacSHA512", [32, 128]),
+        ("HmacSHA256", [16, 32, 44]),
+        ("HmacSHA512", [32, 64]),
     ];
 
     /**

--- a/javatools_bridge/src/main/x/_native/crypto/RTAlgorithms.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTAlgorithms.x
@@ -124,8 +124,8 @@ service RTAlgorithms {
      */
     static Tuple<String, KeySize>[] macs = [
         ("HmacSHA1",    16),
-        ("HmacSHA256", [16, 32]),
-        ("HmacSHA512", [32, 64]),
+        ("HmacSHA256", [16, 128]),
+        ("HmacSHA512", [32, 128]),
     ];
 
     /**


### PR DESCRIPTION
Added 44 bytes HmacSHA256 secret key length to alllow AWS SigC4 keys
Enhance HMAC key handling to support PublicOrSecret and PrivateOrSecret forms
Update key extraction to support PrivateOrSecret form in xRTSigner
