### PR TITLE
Improve GenericTypeResolver API

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ClassStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ClassStructure.java
@@ -3771,8 +3771,16 @@ public class ClassStructure
         }
 
         @Override
-        public TypeConstant resolveGenericType(String sFormalName) {
-            return extractGenericType(f_pool, sFormalName, m_listActual);
+        public TypeConstant resolveFormalType(FormalConstant constFormal) {
+            if (constFormal.getFormat() == Constant.Format.Property) {
+                return extractGenericType(f_pool, constFormal.getName(), m_listActual);
+            }
+
+            TypeConstant t = extractGenericType(f_pool, constFormal.getName(), m_listActual);
+            if (t != null) {
+                t.report(constFormal, t, null);
+            }
+            return null;
         }
 
         private final ConstantPool f_pool;

--- a/javatools/src/main/java/org/xvm/asm/ClassStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/ClassStructure.java
@@ -3772,15 +3772,10 @@ public class ClassStructure
 
         @Override
         public TypeConstant resolveFormalType(FormalConstant constFormal) {
-            if (constFormal.getFormat() == Constant.Format.Property) {
-                return extractGenericType(f_pool, constFormal.getName(), m_listActual);
-            }
-
-            TypeConstant t = extractGenericType(f_pool, constFormal.getName(), m_listActual);
-            if (t != null) {
-                t.report(constFormal, t, null);
-            }
-            return null;
+            // ideally, we need to check the constant's identity
+            return constFormal.getFormat() == Constant.Format.Property
+                    ? extractGenericType(f_pool, constFormal.getName(), m_listActual)
+                    : null;
         }
 
         private final ConstantPool f_pool;

--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -3526,7 +3526,7 @@ public class ConstantPool
 
     private TypeInfo computeNakedRefInfo(TypeConstant typeReferent) {
         GenericTypeResolver resolver =
-                sFormalName -> "Referent".equals(sFormalName) ? typeReferent : null;
+                constFormal -> "Referent".equals(constFormal.getName()) ? typeReferent : null;
 
         if (m_typeNakedRef == null) {
             throw new IllegalStateException("Mack module (javatools_turtle) is missing");

--- a/javatools/src/main/java/org/xvm/asm/GenericTypeResolver.java
+++ b/javatools/src/main/java/org/xvm/asm/GenericTypeResolver.java
@@ -13,14 +13,6 @@ import org.xvm.asm.constants.TypeConstant;
  */
 @FunctionalInterface
 public interface GenericTypeResolver {
-    /**
-     * Resolve the generic type based on the formal parameter name.
-     *
-     * @param sFormalName  the formal parameter name
-     *
-     * @return a resolved type, or null if it could not be resolved
-     */
-    TypeConstant resolveGenericType(String sFormalName);
 
     /**
      * Resolve the generic type based on the FormalConstant representing a formal parameter.
@@ -29,16 +21,12 @@ public interface GenericTypeResolver {
      *
      * @return a resolved type, or null if it could not be resolved
      */
-    default TypeConstant resolveFormalType(FormalConstant constFormal) {
-        return constFormal instanceof PropertyConstant
-            ? resolveGenericType(constFormal.getName())
-            : null;
-    }
+    TypeConstant resolveFormalType(FormalConstant constFormal);
 
     /**
-     * Create a GenericTypeResolver based on the specified map.
+     * Create a GenericTypeResolver for generic properties based on the specified map.
      */
-    static GenericTypeResolver of(Map<FormalConstant, TypeConstant> mapResolve) {
+    static GenericTypeResolver of(Map<String, TypeConstant> mapResolve) {
         return new TypeParameterResolver(mapResolve);
     }
     /**
@@ -49,23 +37,22 @@ public interface GenericTypeResolver {
     }
 
     /**
-     * Trivial GenericTypeResolver implementation based on a Map<FormalConstant, TypeConstant>.
+     * Trivial GenericTypeResolver implementation for generic properties based on a
+     * Map<String, TypeConstant>.
      */
     class TypeParameterResolver
             implements GenericTypeResolver {
-        public TypeParameterResolver(Map<FormalConstant, TypeConstant> mapResolve) {
+        public TypeParameterResolver(Map<String, TypeConstant> mapResolve) {
             this.mapResolve = mapResolve;
         }
 
-        public TypeConstant resolveGenericType(String sFormalName) {
-            return null;
-        }
-
         public TypeConstant resolveFormalType(FormalConstant constFormal) {
-            return mapResolve.get(constFormal);
+            return constFormal.getFormat() == Constant.Format.Property
+                    ? mapResolve.get(constFormal.getName())
+                    : null;
         }
 
-        private final Map<FormalConstant, TypeConstant> mapResolve;
+        private final Map<String, TypeConstant> mapResolve;
     }
 
     /**
@@ -76,14 +63,6 @@ public interface GenericTypeResolver {
         public ChainResolver(GenericTypeResolver resolver1, GenericTypeResolver resolver2) {
             this.resolver1 = resolver1;
             this.resolver2 = resolver2;
-        }
-
-        @Override
-        public TypeConstant resolveGenericType(String sFormalName) {
-            TypeConstant type = resolver1.resolveGenericType(sFormalName);
-            return type == null
-                    ? resolver2.resolveGenericType(sFormalName)
-                    : type;
         }
 
         @Override

--- a/javatools/src/main/java/org/xvm/asm/MethodStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/MethodStructure.java
@@ -901,10 +901,10 @@ public class MethodStructure
                     typeParam = typeParam.resolveGenerics(pool, typeTarget);
                 }
                 if (!mapTypeGeneric.isEmpty()) {
-                    typeParam = typeParam.resolveGenerics(pool, mapTypeGeneric::get);
+                    typeParam = typeParam.resolveGenerics(pool, GenericTypeResolver.of(mapTypeGeneric));
                 }
                 if (!mapTypeParams.isEmpty()) {
-                    typeParam = typeParam.resolveGenerics(pool, GenericTypeResolver.of(mapTypeParams));
+                    typeParam = typeParam.resolveGenerics(pool, mapTypeParams::get);
                 }
 
                 TypeConstant typeConstraint = typeParam.getParamType(0);
@@ -937,7 +937,8 @@ public class MethodStructure
                 if (typeResolved == null) {
                     // save off a resolved constraint
                     mapTypeGeneric.computeIfAbsent(sName, _ ->
-                            entry.getValue().resolveGenerics(pool, mapTypeGeneric::get));
+                            entry.getValue().resolveGenerics(pool,
+                                GenericTypeResolver.of(mapTypeGeneric)));
                 } else {
                     // take the narrowest type
                     mapTypeGeneric.merge(sName, typeResolved, (typeOld, typeNew) ->
@@ -963,26 +964,18 @@ public class MethodStructure
         if (isLambda() && getTypeParamCount() > 0) {
             SignatureConstant sigOrig = sigResolved;
 
-            sigResolved = sigResolved.resolveGenericTypes(pool, new GenericTypeResolver() {
-                @Override
-                public TypeConstant resolveGenericType(String formalName) {
-                    return null;
-                }
-
-                @Override
-                public TypeConstant resolveFormalType(FormalConstant formalConst) {
-                    MethodConstant methodId = getIdentityConstant();
-                    for (Parameter param : getParamArray()) {
-                        if (param.isTypeParameter() &&
-                                formalConst.equals(param.asTypeParameterConstant(methodId))) {
-                            TypeConstant typeOfType = sigOrig.getRawParams()[param.getIndex()];
-                            assert typeOfType.isTypeOfType();
-                            TypeConstant type = typeOfType.getParamType(0);
-                            return type.isJitPrimitive() ? type : null;
-                        }
+            sigResolved = sigResolved.resolveGenericTypes(pool, formalConst -> {
+                MethodConstant methodId = getIdentityConstant();
+                for (Parameter param : getParamArray()) {
+                    if (param.isTypeParameter() &&
+                            formalConst.equals(param.asTypeParameterConstant(methodId))) {
+                        TypeConstant typeOfType = sigOrig.getRawParams()[param.getIndex()];
+                        assert typeOfType.isTypeOfType();
+                        TypeConstant type = typeOfType.getParamType(0);
+                        return type.isJitPrimitive() ? type : null;
                     }
-                    return null;
                 }
+                return null;
             });
         }
         return sigResolved;

--- a/javatools/src/main/java/org/xvm/asm/Parameter.java
+++ b/javatools/src/main/java/org/xvm/asm/Parameter.java
@@ -251,18 +251,10 @@ public class Parameter
      */
     public GenericTypeResolver asGenericTypeResolver(MethodConstant constMethod, TypeConstant type) {
         assert isTypeParameter();
-        TypeParameterConstant constParam = asTypeParameterConstant(constMethod);
-        return new GenericTypeResolver() {
-            @Override
-            public TypeConstant resolveGenericType(String sFormalName) {
-                return null;
-            }
 
-            @Override
-            public TypeConstant resolveFormalType(FormalConstant constFormal) {
-                return constFormal.equals(constParam) ? type : null;
-            }
-        };
+        TypeParameterConstant constParam = asTypeParameterConstant(constMethod);
+
+        return constFormal -> constFormal.equals(constParam) ? type : null;
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/Parameter.java
+++ b/javatools/src/main/java/org/xvm/asm/Parameter.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import org.xvm.asm.constants.AnnotatedTypeConstant;
-import org.xvm.asm.constants.FormalConstant;
 import org.xvm.asm.constants.MethodConstant;
 import org.xvm.asm.constants.StringConstant;
 import org.xvm.asm.constants.TypeConstant;
@@ -253,7 +252,6 @@ public class Parameter
         assert isTypeParameter();
 
         TypeParameterConstant constParam = asTypeParameterConstant(constMethod);
-
         return constFormal -> constFormal.equals(constParam) ? type : null;
     }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/AbstractDependantChildTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/AbstractDependantChildTypeConstant.java
@@ -156,6 +156,10 @@ public abstract class AbstractDependantChildTypeConstant
         ConstantPool pool       = getConstantPool();
         TypeConstant typeParent = m_typeParent;
 
+        if ("OuterType".equals(sName)) {
+            return typeParent;
+        }
+
         TypeConstant type;
         if (typeParent.containsGenericParam(sName)) {
             // the passed in list applies only to the child and should not be used by the parent

--- a/javatools/src/main/java/org/xvm/asm/constants/AnnotatedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/AnnotatedTypeConstant.java
@@ -165,7 +165,11 @@ public class AnnotatedTypeConstant
                 mapResolve.put(sName, type);
             }
         }
-        return m_typeAnno = typeFormal.resolveGenerics(getConstantPool(), mapResolve::get);
+        return m_typeAnno = typeFormal.resolveGenerics(getConstantPool(), constFormal ->
+            constFormal.getFormat() == Format.Property
+                    ? mapResolve.get(constFormal.getName())
+                    : null
+        );
     }
 
     /**
@@ -341,6 +345,14 @@ public class AnnotatedTypeConstant
         return constResolved == constOriginal || constResolved.isRelationalType()
                 ? this
                 : cloneSingle(pool, constResolved);
+    }
+
+    @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        TypeConstant typeResolved = getAnnotationType().resolveFormalType(constFormal);
+        return typeResolved == null
+                ? super.resolveFormalType(constFormal)
+                : typeResolved;
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -205,6 +205,12 @@ public class DifferenceTypeConstant
     }
 
     @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        // only the left side needs to have it, and it doesn't matter what the right side has
+        return m_constType1.resolveFormalType(constFormal);
+    }
+
+    @Override
     public ResolutionResult resolveContributedName(
             String sName, Access access, MethodConstant idMethod, ResolutionCollector collector) {
         // for the DifferenceType to contribute a name, the first side needs to find it,

--- a/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
@@ -118,8 +118,12 @@ public class DynamicFormalConstant
     }
 
 
-    // ----- DynamicConstant methods ---------------------------------------------------------------
+    // ----- FormalConstant methods ----------------------------------------------------------------
 
+    @Override
+    public String getName() {
+        return m_constFormal.getName();
+    }
 
     @Override
     public TypeConstant getConstraintType() {

--- a/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DynamicFormalConstant.java
@@ -203,7 +203,7 @@ public class DynamicFormalConstant
 
     @Override
     public String getValueString() {
-        return getName() + '.' + m_constFormal.getName();
+        return getName();
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
@@ -130,72 +130,15 @@ public class FormalTypeChildConstant
 
     @Override
     public TypeConstant resolve(GenericTypeResolver resolver) {
-        if (resolver instanceof TypeConstant typeType && typeType.isTypeOfType()) {
-            switch (getName()) {
-            case "DataType":
-                return typeType.getParamType(0);
-            case "OuterType":
-                return typeType.getParamType(1);
-            }
-        }
-
         TypeConstant typeResolved = super.resolve(resolver);
         if (typeResolved != null) {
             return typeResolved;
         }
 
-        FormalConstant constParent = getParentConstant();
-        TypeConstant   typeParent = constParent.resolve(resolver);
-        if (typeParent == null) {
-            return null;
-        }
-
-        TypeConstant type = typeParent.resolveGenericType(getName());
-        if (type == null) {
-            int q= 0;
-        }
-        return type;
-    }
-
-    public TypeConstant resolveOld(GenericTypeResolver resolver) {
-        TypeConstant typeResolved = super.resolve(resolver);
-        if (typeResolved == null) {
-            if (resolver instanceof TypeConstant typeType && typeType.isTypeOfType()) {
-                // this is a formal child (e.g. SubType.Element) resolving against a type of type;
-                // resolve the underlying type and return the corresponding type of type
-                TypeConstant type = typeType.getParamType(0).resolveFormalType(this);
-                if (type != null) {
-                    return type.getType();
-                }
-            }
-            FormalConstant idParent   = getParentConstant();
-            TypeConstant   typeParent = idParent.resolve(resolver);
-
-            if (typeParent == null) {
-                return null;
-            }
-
-            if (typeParent.isFormalType()) {
-                FormalConstant idParentResolved = (FormalConstant) typeParent.getDefiningConstant();
-                if (idParentResolved != idParent) {
-                    switch (idParentResolved.getFormat()) {
-                    case FormalTypeChild:
-                    case TypeParameter:
-                        return idParentResolved.getConstantPool().
-                            ensureFormalTypeChildConstant(idParentResolved, getName()).getType();
-                    }
-                }
-                return null;
-            }
-
-            typeResolved = typeParent.resolveFormalType(this);
-            if (typeResolved == null) {
-                // the formal parent can also be treated as a Type
-                // (see NameResolver.resolveFormalDotName())
-                typeResolved = typeParent.getType().resolveFormalType(this);
-            }
-        }
-        return typeResolved;
+        TypeConstant typeParent = getParentConstant().resolve(resolver);
+        return typeParent == null
+                ? null
+                : typeParent.resolveGenericType(getName());
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
@@ -4,6 +4,8 @@ package org.xvm.asm.constants;
 import java.io.DataInput;
 import java.io.IOException;
 
+import java.util.Collections;
+
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.GenericTypeResolver;
 
@@ -102,7 +104,7 @@ public class FormalTypeChildConstant
             }
 
             TypeConstant type = typeConstraint.getSingleUnderlyingClass(true).getFormalType().
-                                    resolveFormalType(this);
+                                    getGenericParamType(sName, Collections.emptyList());
             assert type.isGenericType();
 
             PropertyConstant idProp = (PropertyConstant) type.getDefiningConstant();

--- a/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
@@ -88,6 +88,7 @@ public class FormalTypeChildConstant
         return true;
     }
 
+    @Override
     public boolean isTypeSequenceTypeParameter() {
         return false;
     }
@@ -157,6 +158,11 @@ public class FormalTypeChildConstant
     @Override
     public FormalConstant getParentConstant() {
         return (FormalConstant) super.getParentConstant();
+    }
+
+    @Override
+    public IdentityConstant getNamespace() {
+        return getTopParent().getNamespace();
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/FormalTypeChildConstant.java
@@ -81,6 +81,18 @@ public class FormalTypeChildConstant
     }
 
 
+    // ----- PropertyConstant methods --------------------------------------------------------------
+
+    @Override
+    public boolean isFormalType() {
+        return true;
+    }
+
+    public boolean isTypeSequenceTypeParameter() {
+        return false;
+    }
+
+
     // ----- FormalConstant methods ----------------------------------------------------------------
 
     @Override
@@ -118,6 +130,34 @@ public class FormalTypeChildConstant
 
     @Override
     public TypeConstant resolve(GenericTypeResolver resolver) {
+        if (resolver instanceof TypeConstant typeType && typeType.isTypeOfType()) {
+            switch (getName()) {
+            case "DataType":
+                return typeType.getParamType(0);
+            case "OuterType":
+                return typeType.getParamType(1);
+            }
+        }
+
+        TypeConstant typeResolved = super.resolve(resolver);
+        if (typeResolved != null) {
+            return typeResolved;
+        }
+
+        FormalConstant constParent = getParentConstant();
+        TypeConstant   typeParent = constParent.resolve(resolver);
+        if (typeParent == null) {
+            return null;
+        }
+
+        TypeConstant type = typeParent.resolveGenericType(getName());
+        if (type == null) {
+            int q= 0;
+        }
+        return type;
+    }
+
+    public TypeConstant resolveOld(GenericTypeResolver resolver) {
         TypeConstant typeResolved = super.resolve(resolver);
         if (typeResolved == null) {
             if (resolver instanceof TypeConstant typeType && typeType.isTypeOfType()) {

--- a/javatools/src/main/java/org/xvm/asm/constants/InnerChildTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/InnerChildTypeConstant.java
@@ -5,6 +5,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import java.util.Collections;
 import java.util.function.Consumer;
 
 import org.xvm.asm.ClassStructure;
@@ -107,6 +108,13 @@ public class InnerChildTypeConstant
     @Override
     protected TypeConstant cloneSingle(ConstantPool pool, TypeConstant type) {
         return pool.ensureInnerChildTypeConstant(type, m_idChild);
+    }
+
+    @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        return constFormal.getFormat() == Format.Property
+                ? getGenericParamType(constFormal.getName(), Collections.emptyList())
+                : null;
     }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/InnerChildTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/InnerChildTypeConstant.java
@@ -6,6 +6,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import java.util.Collections;
+
 import java.util.function.Consumer;
 
 import org.xvm.asm.ClassStructure;

--- a/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/IntersectionTypeConstant.java
@@ -322,6 +322,22 @@ public class IntersectionTypeConstant
     }
 
     @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        // for Intersection types, either side needs to find it, but if both do, take the narrower one
+        TypeConstant typeActual1 = m_constType1.resolveFormalType(constFormal);
+        TypeConstant typeActual2 = m_constType2.resolveFormalType(constFormal);
+
+        if (typeActual1 == null) {
+            return typeActual2;
+        }
+        if (typeActual2 == null) {
+            return typeActual1;
+        }
+
+        return typeActual1.combine(getConstantPool(), typeActual2);
+    }
+
+    @Override
     public ResolutionResult resolveContributedName(
             String sName, Access access, MethodConstant idMethod, ResolutionCollector collector) {
         // for the IntersectionType to contribute a name, either side needs to find it

--- a/javatools/src/main/java/org/xvm/asm/constants/MethodConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/MethodConstant.java
@@ -355,8 +355,9 @@ public class MethodConstant
 
     // ----- GenericTypeResolver interface ---------------------------------------------------------
 
+
     @Override
-    public TypeConstant resolveGenericType(String sFormalName) {
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
         MethodStructure method = (MethodStructure) getComponent();
         if (method != null) {
             // look for a name match only amongst the method's formal type parameters
@@ -364,9 +365,19 @@ public class MethodConstant
             for (int i = 0, c = method.getTypeParamCount(); i < c; i++) {
                 Parameter param = method.getParam(i);
 
-                if (sFormalName.equals(param.getName())) {
-                    return param.asTypeParameterConstant(this).getType();
+                assert param.isTypeParameter();
+
+                TypeParameterConstant constParam = param.asTypeParameterConstant(this);
+                if (constParam.equals(constFormal)) {
+                    return constParam.getType();
                 }
+                if (constFormal instanceof TypeParameterConstant constFormalParam &&
+                        constFormalParam.getRegister() == constParam.getRegister()) {
+                    // ideally, we need to chek the alignment of the methods
+                    return constParam.getType();
+                }
+                // JUST TEMPORARY - REMOVE
+                assert !constFormal.getName().equals(param.getName());
             }
         }
         return null;

--- a/javatools/src/main/java/org/xvm/asm/constants/MethodConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/MethodConstant.java
@@ -373,11 +373,9 @@ public class MethodConstant
                 }
                 if (constFormal instanceof TypeParameterConstant constFormalParam &&
                         constFormalParam.getRegister() == constParam.getRegister()) {
-                    // ideally, we need to chek the alignment of the methods
+                    // ideally, we need to check the alignment of the methods
                     return constParam.getType();
                 }
-                // JUST TEMPORARY - REMOVE
-                assert !constFormal.getName().equals(param.getName());
             }
         }
         return null;

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -194,8 +194,16 @@ public class ParameterizedTypeConstant
             FormalConstant          constParent = constChild.getParentConstant();
             TypeConstant            typeParent  = resolveFormalType(constParent);
             if (typeParent != null) {
-                if (typeParent.isTypeOfType()) {
-                    return typeParent.getParamType(0).resolveGenericType(constChild.getName());
+                // this could be either resolution of the generic type's constraint (e.g.
+                // Serializable.Key in MapMapping.x) or Type's generic type (e.g. Key.DataType in
+                // the same class)
+                String       sName        = constChild.getName();
+                TypeConstant typeResolved = typeParent.resolveGenericType(sName);
+                if (typeResolved == null && !typeParent.isFormalType()) {
+                    typeResolved = typeParent.getType().resolveGenericType(sName);
+                }
+                if (typeResolved != null) {
+                    return typeResolved;
                 }
             }
             break;
@@ -204,15 +212,9 @@ public class ParameterizedTypeConstant
         case TypeParameter: {
             TypeParameterConstant constParam = (TypeParameterConstant) constFormal;
             MethodConstant        idMethod   = constParam.getMethod();
-            // TODO: explain
             if (idMethod.isLambda()) {
-                return resolveGenericType(constFormal.getName());
-            }
-
-            if (this.isTypeOfType()) {
-                // the constant represents a formal type parameter and this is a type of type;
-                // we are most probably resolving the FormalTypeChild (e.g. CompileType.Element)
-                return this;
+                // TODO: explain
+                return resolveGenericType(constParam.getName());
             }
         }
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -184,6 +184,47 @@ public class ParameterizedTypeConstant
     }
 
     @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        switch (constFormal.getFormat()) {
+        case Property:
+            return resolveGenericType(constFormal.getName());
+
+        case FormalTypeChild: {
+            FormalTypeChildConstant constChild  = (FormalTypeChildConstant) constFormal;
+            FormalConstant          constParent = constChild.getParentConstant();
+            TypeConstant            typeParent  = resolveFormalType(constParent);
+            if (typeParent != null) {
+                if (typeParent.isTypeOfType()) {
+                    return typeParent.getParamType(0).resolveGenericType(constChild.getName());
+                }
+            }
+            break;
+        }
+
+        case TypeParameter: {
+            TypeParameterConstant constParam = (TypeParameterConstant) constFormal;
+            MethodConstant        idMethod   = constParam.getMethod();
+            // TODO: explain
+            if (idMethod.isLambda()) {
+                return resolveGenericType(constFormal.getName());
+            }
+
+            if (this.isTypeOfType()) {
+                // the constant represents a formal type parameter and this is a type of type;
+                // we are most probably resolving the FormalTypeChild (e.g. CompileType.Element)
+                return this;
+            }
+        }
+        }
+
+        TypeConstant t = resolveGenericType(constFormal.getName());
+        if (t != null) {
+            report(constFormal, t, null);
+        }
+        return null;
+    }
+
+    @Override
     public boolean isExplicitClassIdentity(boolean fAllowParams) {
         return fAllowParams && getUnderlyingType().isExplicitClassIdentity(false);
     }
@@ -833,7 +874,7 @@ public class ParameterizedTypeConstant
         var             listTypeParams = clz.getTypeParamsAsList();
         var             listContribs   = clz.collectConditionalIncorporates(this);
 
-        TypeConstant typeOrig = m_constType;;
+        TypeConstant typeOrig = m_constType;
         // TODO: REMOVE - compensation for Array handling in TypeConstant#buildJitClassName
         if (typeOrig.isArray() && !getParamType(0).isJitPrimitive()) {
             return pool.ensureArrayType(pool.typeObject());

--- a/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/ParameterizedTypeConstant.java
@@ -199,12 +199,9 @@ public class ParameterizedTypeConstant
                 // the same class)
                 String       sName        = constChild.getName();
                 TypeConstant typeResolved = typeParent.resolveGenericType(sName);
-                if (typeResolved == null && !typeParent.isFormalType()) {
-                    typeResolved = typeParent.getType().resolveGenericType(sName);
-                }
-                if (typeResolved != null) {
-                    return typeResolved;
-                }
+                return typeResolved == null && !typeParent.isFormalType()
+                        ? typeParent.getType().resolveGenericType(sName)
+                        : typeResolved;
             }
             break;
         }
@@ -213,15 +210,11 @@ public class ParameterizedTypeConstant
             TypeParameterConstant constParam = (TypeParameterConstant) constFormal;
             MethodConstant        idMethod   = constParam.getMethod();
             if (idMethod.isLambda()) {
-                // TODO: explain
+                // lambdas capture generic types as formal type parameters of the same name
                 return resolveGenericType(constParam.getName());
             }
+            break;
         }
-        }
-
-        TypeConstant t = resolveGenericType(constFormal.getName());
-        if (t != null) {
-            report(constFormal, t, null);
         }
         return null;
     }

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyClassTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyClassTypeConstant.java
@@ -172,6 +172,19 @@ public class PropertyClassTypeConstant
     }
 
     @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        if (constFormal.getFormat() == Format.Property) {
+            // ideally we need to check if the property's namespace aligns
+            TypeConstant typeResolved = getRefType().resolveFormalType(constFormal);
+            return typeResolved == null
+                    ? getParentType().resolveFormalType(constFormal)
+                    : typeResolved;
+        }
+        return null;
+
+    }
+
+    @Override
     public TypeConstant adoptParameters(ConstantPool pool, TypeConstant[] atypeParams) {
         return this;
     }

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
@@ -156,8 +156,6 @@ public class PropertyConstant
     }
 
     /**
-     * Note, that this yields "false" for FormalChildConstant (e.g. CompileType.Element).
-     *
      * @return true iff this property is a generic type parameter
      */
     public boolean isFormalType() {

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
@@ -156,6 +156,8 @@ public class PropertyConstant
     }
 
     /**
+     * Note, that this yields "false" for FormalChildConstant (e.g. CompileType.Element).
+     *
      * @return true iff this property is a generic type parameter
      */
     public boolean isFormalType() {

--- a/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
@@ -403,14 +403,9 @@ public class TerminalTypeConstant
 
     @Override
     public TypeConstant resolveFormalType(FormalConstant constFormal) {
-        if (constFormal.getFormat() == Format.Property) {
-            return resolveGenericType(constFormal.getName());
-        }
-        TypeConstant t = resolveGenericType(constFormal.getName());
-        if (t != null) {
-            report(constFormal, t, null);
-        }
-        return null;
+        return constFormal.getFormat() == Format.Property
+                ? resolveGenericType(constFormal.getName())
+                : null;
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TerminalTypeConstant.java
@@ -402,6 +402,18 @@ public class TerminalTypeConstant
     }
 
     @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        if (constFormal.getFormat() == Format.Property) {
+            return resolveGenericType(constFormal.getName());
+        }
+        TypeConstant t = resolveGenericType(constFormal.getName());
+        if (t != null) {
+            report(constFormal, t, null);
+        }
+        return null;
+    }
+
+    @Override
     public boolean isAnnotated() {
         TypeConstant type = resolveTypedefs();
         return type != this && type.isAnnotated();

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -151,11 +151,32 @@ public abstract class TypeConstant
     }
 
 
+    public void report(FormalConstant constFormal, TypeConstant tOld, TypeConstant tNew) {
+        if (!isTuple()) {
+            String msg = getValueString() + " used to resolve " +
+                constFormal + " to " + tOld + " now " + tNew;
+            if (REPORTS.add(msg)) {
+                System.err.println("*** " + msg);
+            }
+        }
+    }
+
+    static Set<String> REPORTS = new HashSet<>();
+
+
     // ----- GenericTypeResolver -------------------------------------------------------------------
 
     @Override
-    public TypeConstant resolveGenericType(String sFormalName) {
-        return getGenericParamType(sFormalName, Collections.emptyList());
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        if (isModifyingType()) {
+            return getUnderlyingType().resolveFormalType(constFormal);
+        }
+
+        TypeConstant t = resolveGenericType(constFormal.getName());
+        if (t != null) {
+            report(constFormal, t, null);
+        }
+        return null;
     }
 
 
@@ -476,6 +497,13 @@ public abstract class TypeConstant
      */
     public boolean containsGenericParam(String sName) {
         return isModifyingType() && getUnderlyingType().containsGenericParam(sName);
+    }
+
+    /**
+     * Find the type of the specified formal parameter for this type.
+     */
+    public TypeConstant resolveGenericType(String sFormalName) {
+        return getGenericParamType(sFormalName, Collections.emptyList());
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -151,32 +151,13 @@ public abstract class TypeConstant
     }
 
 
-    public void report(FormalConstant constFormal, TypeConstant tOld, TypeConstant tNew) {
-        if (!isTuple()) {
-            String msg = getValueString() + " used to resolve " +
-                constFormal + " to " + tOld + " now " + tNew;
-            if (REPORTS.add(msg)) {
-                System.err.println("*** " + msg);
-            }
-        }
-    }
-
-    static Set<String> REPORTS = new HashSet<>();
-
-
     // ----- GenericTypeResolver -------------------------------------------------------------------
 
     @Override
     public TypeConstant resolveFormalType(FormalConstant constFormal) {
-        if (isModifyingType()) {
-            return getUnderlyingType().resolveFormalType(constFormal);
-        }
-
-        TypeConstant t = resolveGenericType(constFormal.getName());
-        if (t != null) {
-            report(constFormal, t, null);
-        }
-        return null;
+        return isModifyingType()
+                ? getUnderlyingType().resolveFormalType(constFormal)
+                : null;
     }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeParameterConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeParameterConstant.java
@@ -13,7 +13,6 @@ import org.xvm.asm.ClassStructure;
 import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 
-import org.xvm.asm.GenericTypeResolver;
 import org.xvm.asm.ast.ExprAST;
 
 import org.xvm.compiler.ast.Context;

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeParameterConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeParameterConstant.java
@@ -13,6 +13,7 @@ import org.xvm.asm.ClassStructure;
 import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 
+import org.xvm.asm.GenericTypeResolver;
 import org.xvm.asm.ast.ExprAST;
 
 import org.xvm.compiler.ast.Context;

--- a/javatools/src/main/java/org/xvm/asm/constants/UnionTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/UnionTypeConstant.java
@@ -378,6 +378,22 @@ public class UnionTypeConstant
     }
 
     @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        TypeConstant typeActual1 = m_constType1.resolveFormalType(constFormal);
+        TypeConstant typeActual2 = m_constType2.resolveFormalType(constFormal);
+
+        if (typeActual1 == null || typeActual2 == null) {
+            return null;
+        }
+
+        return typeActual1.isA(typeActual2)
+                ? typeActual2
+                : typeActual2.isA(typeActual1)
+                    ? typeActual1
+                    : getConstantPool().ensureUnionTypeConstant(typeActual1, typeActual2);
+    }
+
+    @Override
     public ResolutionResult resolveContributedName(
             String sName, Access access, MethodConstant idMethod, ResolutionCollector collector) {
         // for the UnionType to contribute a name, either both sides need to find exactly

--- a/javatools/src/main/java/org/xvm/asm/constants/VirtualChildTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/VirtualChildTypeConstant.java
@@ -247,6 +247,17 @@ public class VirtualChildTypeConstant
                 : pool.ensureVirtualChildTypeConstant(typeParentResolved, m_constName.getValue());
     }
 
+    @Override
+    public TypeConstant resolveFormalType(FormalConstant constFormal) {
+        if (constFormal.getFormat() == Format.Property) {
+            // ideally we need to check if the property's namespace aligns
+            TypeConstant typeResolved = resolveGenericType(constFormal.getName());
+            return typeResolved == null
+                    ? getParentType().resolveFormalType(constFormal)
+                    : typeResolved;
+        }
+        return null;
+    }
 
     // ----- type comparison support ---------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/AstNode.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/AstNode.java
@@ -1176,7 +1176,7 @@ public abstract class AstNode
                     // incompatible types
                     continue;
                 }
-                sigMethod = sigMethod.resolveGenericTypes(pool, GenericTypeResolver.of(mapTypeParams));
+                sigMethod = sigMethod.resolveGenericTypes(pool, mapTypeParams::get);
             }
 
             TypeConstant[] atypeParam = sigMethod.getRawParams();
@@ -1261,7 +1261,7 @@ public abstract class AstNode
 
                     fit = TypeFit.NoFit;
                 } else {
-                    sigMethod = sigMethod.resolveGenericTypes(pool, GenericTypeResolver.of(mapTypeParams));
+                    sigMethod = sigMethod.resolveGenericTypes(pool, mapTypeParams::get);
                 }
             }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/Context.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Context.java
@@ -1502,26 +1502,6 @@ public class Context {
                         : extractElementType(arg);
             }
 
-            @Override
-            public TypeConstant resolveGenericType(String sFormalName) {
-                // in the absence of any additional information, only pick generic types
-                for (Map.Entry<FormalConstant, TypeConstant> entry :
-                            getFormalTypeMap(branch).entrySet()) {
-                    FormalConstant constFormal = entry.getKey();
-                    if (constFormal instanceof PropertyConstant &&
-                            constFormal.getName().equals(sFormalName)) {
-                        return entry.getValue();
-                    }
-                }
-
-                Argument arg = getLocalVar(sFormalName, branch);
-                return arg == null
-                        ? isFunction()
-                                ? null
-                                : getThisClass().getFormalType().resolveGenericType(sFormalName)
-                        : extractElementType(arg);
-            }
-
             private TypeConstant extractElementType(Argument arg) {
                 TypeConstant typeType = arg.getType();
                 return typeType.isTypeOfType()

--- a/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/Expression.java
@@ -13,6 +13,7 @@ import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
+import org.xvm.asm.GenericTypeResolver;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.MethodStructure.Code;
 import org.xvm.asm.Op;
@@ -698,7 +699,7 @@ public abstract class Expression
 
         return mapResolve.isEmpty()
             ? null
-            : clz.getFormalType().resolveGenerics(pool(), mapResolve::get);
+            : clz.getFormalType().resolveGenerics(pool(), GenericTypeResolver.of(mapResolve));
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/InvocationExpression.java
@@ -849,8 +849,7 @@ public class InvocationExpression
                         // previous type parameters, for example:
                         //   <T1 extends Base, T2 extends T1> foo(T1 v1, T2 v2) {...}
                         if (typeConstraint.containsTypeParameter(true)) {
-                            typeConstraint = typeConstraint.resolveGenerics(pool,
-                                                GenericTypeResolver.of(mapTypeParams));
+                            typeConstraint = typeConstraint.resolveGenerics(pool, mapTypeParams::get);
                         }
 
                         if (!typeArg.isA(typeConstraint)) {
@@ -874,8 +873,7 @@ public class InvocationExpression
                         sigMethod = sigMethod.resolveAutoNarrowing(pool, typeLeft, null);
                     }
                     if (!mapTypeParams.isEmpty()) {
-                        sigMethod = sigMethod.resolveGenericTypes(pool,
-                                        GenericTypeResolver.of(mapTypeParams));
+                        sigMethod = sigMethod.resolveGenericTypes(pool, mapTypeParams::get);
                     }
                     atypeResult = sigMethod.getRawReturns();
 
@@ -921,7 +919,7 @@ public class InvocationExpression
                     }
 
                     if (!mapTypeParams.isEmpty()) {
-                        typeFn = typeFn.resolveGenerics(pool, GenericTypeResolver.of(mapTypeParams));
+                        typeFn = typeFn.resolveGenerics(pool, mapTypeParams::get);
                     }
 
                     atypeResult = new TypeConstant[] {typeFn};
@@ -2890,7 +2888,7 @@ public class InvocationExpression
                 method.resolveTypeParameters(pool(), typeTarget, atypeArgs, atypeReturn, fAllowPending);
 
         if (mapTypeParams.size() == method.getTypeParamCount()) {
-            return GenericTypeResolver.of(mapTypeParams);
+            return mapTypeParams::get;
         }
 
         log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_UNRESOLVABLE,

--- a/javatools/src/main/java/org/xvm/compiler/ast/LambdaExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/LambdaExpression.java
@@ -1149,17 +1149,7 @@ public class LambdaExpression
                 asParams    = asAllParams;
 
                 if (!mapRedefine.isEmpty()) {
-                    GenericTypeResolver resolver = new GenericTypeResolver() {
-                        @Override
-                        public TypeConstant resolveGenericType(String sFormalName) {
-                            return null;
-                        }
-
-                        @Override
-                        public TypeConstant resolveFormalType(FormalConstant constFormal) {
-                            return mapRedefine.get(constFormal);
-                        }
-                    };
+                    GenericTypeResolver resolver = mapRedefine::get;
 
                     for (int i = cTypeParams, c = atypeParams.length; i < c; i++) {
                         TypeConstant typeOld = atypeParams[i].resolveTypedefs();
@@ -1489,11 +1479,6 @@ public class LambdaExpression
                     return constDynamic.getConstraintType();
                 }
             }
-            return null;
-        }
-
-        @Override
-        public TypeConstant resolveGenericType(String sFormalName) {
             return null;
         }
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -2801,7 +2801,7 @@ public class NameExpression
                     }
 
                     // resolve the function signature against all the types we know by now
-                    typeFn          = typeFn.resolveGenerics(pool, GenericTypeResolver.of(mapTypeParams));
+                    typeFn          = typeFn.resolveGenerics(pool, mapTypeParams::get);
                     m_mapTypeParams = mapTypeParams;
                 }
 
@@ -2908,20 +2908,10 @@ public class NameExpression
                 // if the property type contains a generic type and that
                 // generic type belongs to the left argument, replace it with
                 // a corresponding dynamic type
-                GenericTypeResolver resolver = new GenericTypeResolver() {
-                    @Override
-                    public TypeConstant resolveGenericType(String sFormalName) {
-                        return typeResolved.resolveGenericType(sFormalName);
-                    }
-
-                    @Override
-                    public TypeConstant resolveFormalType(FormalConstant idFormal) {
-                        return idFormal.getParentConstant().equals(idParent)
-                            ? pool.ensureDynamicFormal(
-                                idMethod, regLeft, idFormal, sName).getType()
-                            : resolveGenericType(idFormal.getName());
-                    }
-                };
+                GenericTypeResolver resolver = idFormal ->
+                    idFormal.getParentConstant().equals(idParent)
+                        ? pool.ensureDynamicFormal(idMethod, regLeft, idFormal, sName).getType()
+                        : null; // typeResolved.resolveGenericType(idFormal.getName());
 
                 return typeProp.resolveGenerics(pool, resolver);
             }

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -2905,13 +2905,12 @@ public class NameExpression
                             idMethod, regLeft, idFormal, sName).getType();
                 }
             } else if (typeProp.containsGenericType(true)) {
-                // if the property type contains a generic type and that
-                // generic type belongs to the left argument, replace it with
-                // a corresponding dynamic type
+                // if the property type contains a generic type and that generic type belongs to the
+                // left argument, replace it with a corresponding dynamic type
                 GenericTypeResolver resolver = idFormal ->
                     idFormal.getParentConstant().equals(idParent)
                         ? pool.ensureDynamicFormal(idMethod, regLeft, idFormal, sName).getType()
-                        : null; // typeResolved.resolveGenericType(idFormal.getName());
+                        : null;
 
                 return typeProp.resolveGenerics(pool, resolver);
             }

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -803,9 +803,9 @@ public class NameExpression
         }
 
         // if the type could fully be resolved in the current context, do it now
-        if (type != null && type.isGenericType()) {
+        if (type != null && type.containsGenericType(true)) {
             TypeConstant typeResolved = type.resolveGenerics(pool, ctx.getThisType());
-            if (!typeResolved.isGenericType()) {
+            if (!typeResolved.containsGenericType(true)) {
                 type = typeResolved;
             }
         }

--- a/javatools/src/main/java/org/xvm/compiler/ast/PropertyDeclarationStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/PropertyDeclarationStatement.java
@@ -17,6 +17,7 @@ import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
+import org.xvm.asm.GenericTypeResolver;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.MethodStructure.Code;
 import org.xvm.asm.Parameter;
@@ -618,7 +619,7 @@ public class PropertyDeclarationStatement
                         }
                     }
                 }
-                typeAnno = clzAnno.getFormalType().resolveGenerics(pool, mapResolved::get);
+                typeAnno = clzAnno.getFormalType().resolveGenerics(pool, GenericTypeResolver.of(mapResolved));
             } else {
                 typeAnno = clzAnno.getCanonicalType();
             }

--- a/javatools/src/main/java/org/xvm/javajit/BuildContext.java
+++ b/javatools/src/main/java/org/xvm/javajit/BuildContext.java
@@ -3072,11 +3072,6 @@ public class BuildContext {
     public GenericTypeResolver createTypeResolver(MethodStructure method, int[] argIds) {
         return new GenericTypeResolver() {
             @Override
-            public TypeConstant resolveGenericType(String sFormalName) {
-                return null;
-            }
-
-            @Override
             public TypeConstant resolveFormalType(FormalConstant constFormal) {
                 MethodConstant methodId = method.getIdentityConstant();
                 for (Parameter param : method.getParamArray()) {
@@ -3106,17 +3101,7 @@ public class BuildContext {
             }
 
             if (type.containsFormalType(true)) {
-                type = type.resolveGenerics(pool(), new GenericTypeResolver() {
-                    @Override
-                    public TypeConstant resolveGenericType(String formalName) {
-                        return jitType.resolveGenericType(formalName);
-                    }
-
-                    @Override
-                    public TypeConstant resolveFormalType(FormalConstant formalConst) {
-                        return BuildContext.this.resolveFormalType(formalConst);
-                    }
-                });
+                type = type.resolveGenerics(pool(), BuildContext.this::resolveFormalType);
             }
         }
         return type;

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -2564,9 +2564,15 @@ public class Frame
                 ? frame.f_ahVar[nTargetReg].getType()
                 : frame.getLocalType(nTargetReg, null);
 
-            return constProperty.isFormalType() && constProperty.getFormat() == Constant.Format.Property
-                ? typeTarget.resolveFormalType(constProperty).getType()
-                : constProperty.getType().resolveGenerics(pool, frame.getGenericsResolver(false));
+            boolean fFormal = constProperty.isFormalType();
+            if (fFormal && constProperty.getFormat() == Constant.Format.Property) {
+                return typeTarget.resolveFormalType(constProperty).getType();
+            }
+            TypeConstant typeResolved = constProperty.getType().
+                resolveGenerics(pool, frame.getGenericsResolver(false));
+            return fFormal
+                ? typeResolved.getType()
+                : typeResolved;
         }
     };
 

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -2564,7 +2564,7 @@ public class Frame
                 ? frame.f_ahVar[nTargetReg].getType()
                 : frame.getLocalType(nTargetReg, null);
 
-            return constProperty.isFormalType()
+            return constProperty.isFormalType() && constProperty.getFormat() == Constant.Format.Property
                 ? typeTarget.resolveFormalType(constProperty).getType()
                 : constProperty.getType().resolveGenerics(pool, frame.getGenericsResolver(false));
         }

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -2566,9 +2566,9 @@ public class Frame
                 ? frame.f_ahVar[nTargetReg].getType()
                 : frame.getLocalType(nTargetReg, null);
 
-            return constProperty.isFormalType()
+            return constProperty.isFormalType() // is it a generic type?
                 ? constProperty.getFormalType().resolveGenerics(pool, typeTarget).getType()
-                : constProperty.getType().resolveGenerics(pool, typeTarget);
+                : constProperty.getType().resolveGenerics(pool, frame.getGenericsResolver(false));
         }
     };
 

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -2449,16 +2449,17 @@ public class Frame
         public TypeConstant getType() {
             TypeConstant type = m_type;
             if ((m_nStyle & RESOLVED_TYPE) == 0) {
+                boolean fDynamic;
                 if (type == null) {
                     assert m_resolver != null;
                     type = m_resolver.resolve(Frame.this, m_nTargetId, m_nTypeId);
+                    fDynamic = type.containsDynamicType();
+                } else {
+                    fDynamic = type.containsDynamicType();
+                    type = type.resolveGenerics(poolContext(), getGenericsResolver(fDynamic));
                 }
 
                 // don't cache dynamic types
-                boolean fDynamic = type.containsDynamicType();
-
-                type = type.resolveGenerics(poolContext(), getGenericsResolver(fDynamic));
-
                 if (fDynamic) {
                     m_nStyle |= TYPE_DYNAMIC;
                 } else {
@@ -2548,7 +2549,8 @@ public class Frame
                 typeArray = frame.getLocalType(nTargetReg, null);
             }
 
-            return typeArray.getParamType(typeArray.isTuple() ? iAuxId : 0);
+            TypeConstant typeEl = typeArray.getParamType(typeArray.isTuple() ? iAuxId : 0);
+            return typeEl.resolveGenerics(frame.poolContext(), frame.getGenericsResolver(false));
         }
     };
 

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -21,6 +21,7 @@ import org.xvm.asm.Parameter;
 import org.xvm.asm.constants.ClassConstant;
 import org.xvm.asm.constants.DynamicFormalConstant;
 import org.xvm.asm.constants.FormalConstant;
+import org.xvm.asm.constants.FormalTypeChildConstant;
 import org.xvm.asm.constants.IdentityConstant;
 import org.xvm.asm.constants.MethodConstant;
 import org.xvm.asm.constants.ModuleConstant;
@@ -922,7 +923,7 @@ public class Frame
                         // arrays allow to delegate to instances of different types using views
                         break;
                     }
-                    System.err.println("WARNING: suspicious assignment at " + this +
+                    System.err.println("WARNING: suspicious assignment " + this +
                         " from: " + typeFrom.getValueString() + " to: " + typeTo.getValueString());
                     break;
                 }
@@ -1889,13 +1890,6 @@ public class Frame
     }
 
     @Override
-    public TypeConstant resolveGenericType(String sFormalName) {
-        return f_hThis == null
-                ? null
-                : f_hThis.getType().resolveGenericType(sFormalName);
-    }
-
-    @Override
     public TypeConstant resolveFormalType(FormalConstant constFormal) {
         Frame frame = this;
         int   nRegister;
@@ -1917,7 +1911,9 @@ public class Frame
                 }
                 return null;
             }
-            return resolveGenericType(sFormalName);
+            return f_hThis == null
+                ? null
+                : f_hThis.getType().resolveGenericType(sFormalName);
         }
 
         case TypeParameter: {
@@ -2568,8 +2564,8 @@ public class Frame
                 ? frame.f_ahVar[nTargetReg].getType()
                 : frame.getLocalType(nTargetReg, null);
 
-            return constProperty.isFormalType() // is it a generic type?
-                ? constProperty.getFormalType().resolveGenerics(pool, typeTarget).getType()
+            return constProperty.isFormalType()
+                ? typeTarget.resolveFormalType(constProperty).getType()
                 : constProperty.getType().resolveGenerics(pool, frame.getGenericsResolver(false));
         }
     };

--- a/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
+++ b/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
@@ -1374,28 +1374,20 @@ public class ServiceContext {
             return i -> atype[i];
         }
 
-        GenericTypeResolver resolver = new GenericTypeResolver() {
-            @Override
-            public TypeConstant resolveGenericType(String sFormalName) {
-                return null;
-            }
-
-            @Override
-            public TypeConstant resolveFormalType(FormalConstant constFormal) {
-                if (constFormal instanceof TypeParameterConstant constTypeParam) {
-                    int             nRegister = constTypeParam.getRegister();
-                    MethodConstant  idMethod  = hFunction.getMethodId();
-                    MethodStructure method    = idMethod == null
-                            ? null
-                            : (MethodStructure) idMethod.getComponent();
-                    if (method != null && nRegister < method.getTypeParamCount() &&
-                            method.getParam(nRegister).getName().equals(constTypeParam.getName())) {
-                        return ahArg[nRegister].getType().getParamType(0);
-                    }
+        GenericTypeResolver resolver = constFormal -> {
+            if (constFormal instanceof TypeParameterConstant constTypeParam) {
+                int             nRegister = constTypeParam.getRegister();
+                MethodConstant  idMethod  = hFunction.getMethodId();
+                MethodStructure method    = idMethod == null
+                        ? null
+                        : (MethodStructure) idMethod.getComponent();
+                if (method != null && nRegister < method.getTypeParamCount() &&
+                        method.getParam(nRegister).getName().equals(constTypeParam.getName())) {
+                    return ahArg[nRegister].getType().getParamType(0);
                 }
-
-                return null;
             }
+
+            return null;
         };
 
         return i -> {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -11,6 +11,7 @@ import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
+import org.xvm.asm.GenericTypeResolver;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.Op;
 import org.xvm.asm.PackageStructure;
@@ -196,16 +197,19 @@ public class xRTType
     public int getPropertyValue(Frame frame, ObjectHandle hTarget, PropertyConstant idProp, int iReturn) {
         TypeHandle hType = (TypeHandle) hTarget;
 
-        if (idProp instanceof FormalTypeChildConstant) {
-            TypeConstant typeTarget = hType.getDataType();
-            TypeConstant typeValue  =
-                "OuterType".equals(idProp.getName()) && typeTarget.isVirtualChild()
-                    ? typeTarget.getParentType()
-                    : typeTarget.resolveFormalType(idProp);
+        // this is almost identical to FTC.resolve(GTR) except it returns the "unsafe" type
+        GenericTypeResolver resolver = constFormal ->
+            switch (constFormal.getName()) {
+                case "DataType"  -> hType.getUnsafeDataType();
+                case "OuterType" -> hType.getOuterType();
+                default          -> null;
+            };
 
+        if (idProp.isFormalType()) {
+            TypeConstant typeValue = idProp.resolve(resolver);
             return typeValue == null
                 ? frame.raiseException(xException.invalidType(frame,
-                    "Unknown formal type: " + idProp.getName()))
+                        "Unknown formal type: " + idProp.getName()))
                 : frame.assignValue(iReturn, typeValue.ensureTypeHandle(frame.f_context.f_container));
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -11,7 +11,6 @@ import org.xvm.asm.Constant;
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
-import org.xvm.asm.GenericTypeResolver;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.Op;
 import org.xvm.asm.PackageStructure;
@@ -20,6 +19,7 @@ import org.xvm.asm.Parameter;
 import org.xvm.asm.constants.ArrayConstant;
 import org.xvm.asm.constants.ChildInfo;
 import org.xvm.asm.constants.ClassConstant;
+import org.xvm.asm.constants.FormalConstant;
 import org.xvm.asm.constants.FormalTypeChildConstant;
 import org.xvm.asm.constants.IdentityConstant;
 import org.xvm.asm.constants.MethodConstant;
@@ -197,25 +197,31 @@ public class xRTType
     public int getPropertyValue(Frame frame, ObjectHandle hTarget, PropertyConstant idProp, int iReturn) {
         TypeHandle hType = (TypeHandle) hTarget;
 
-        // this is almost identical to FTC.resolve(GTR) except it returns the "unsafe" type
-        GenericTypeResolver resolver = constFormal ->
-            switch (constFormal.getName()) {
-                case "DataType"  -> hType.getUnsafeDataType();
-                case "OuterType" -> hType.getOuterType();
-                default          -> null;
-            };
-
+        // the property could be either:
+        //  1) a regular property on RTType
+        //  2) a formal child property of the type's data type (CompileType.Element)
+        //  3) a generic property of Type (DataType, OuterType)
         if (idProp.isFormalType()) {
-            TypeConstant typeValue = idProp.resolve(resolver);
+            String sName = idProp.getName();
+            TypeConstant typeValue = null;
+            if (idProp.getFormat() == Constant.Format.Property) {
+                // this is almost identical to FTC.resolve(GTR) except it returns the "unsafe" type
+                typeValue = switch (idProp.getName()) {
+                    case "DataType"  -> hType.getUnsafeDataType();
+                    case "OuterType" -> hType.getOuterType();
+                    default          -> null;
+                };
+            } else {
+                typeValue = hType.getUnsafeDataType().resolveGenericType(sName);
+                if (typeValue == null) {
+                    typeValue = hType.getType().resolveGenericType(sName);
+                }
+            }
+
             return typeValue == null
                 ? frame.raiseException(xException.invalidType(frame,
                         "Unknown formal type: " + idProp.getName()))
                 : frame.assignValue(iReturn, typeValue.ensureTypeHandle(frame.f_context.f_container));
-        }
-
-        if ("DataType".equals(idProp.getName())) {
-            TypeConstant typeResult = hType.getUnsafeDataType();
-            return frame.assignValue(iReturn, typeResult.ensureTypeHandle(frame.f_context.f_container));
         }
         return super.getPropertyValue(frame, hTarget, idProp, iReturn);
     }

--- a/lib_ecstasy/src/main/x/ecstasy/maps/deferred/DeferredMap.x
+++ b/lib_ecstasy/src/main/x/ecstasy/maps/deferred/DeferredMap.x
@@ -335,7 +335,7 @@
     @Override
     MapCollector<Key, Value, Map<Key, Value>> defaultCollector() {
         // unwind to the original original map
-        Map? original = this.original;
+        Map<Key, Object>? original = this.original;
         while (original.is(DeferredMap<Key, Object>)) {
             original = original.original;
         }

--- a/manualTests/src/main/x/innerouter.x
+++ b/manualTests/src/main/x/innerouter.x
@@ -2,9 +2,9 @@ module TestInnerOuter {
     @Inject Console console;
 
     void run() {
-//        testSimple();
-//        testStaticIface();
-//        testAnonInner();
+        testSimple();
+        testStaticIface();
+        testAnonInner();
         testFunky();
     }
 

--- a/manualTests/src/main/x/innerouter.x
+++ b/manualTests/src/main/x/innerouter.x
@@ -2,9 +2,9 @@ module TestInnerOuter {
     @Inject Console console;
 
     void run() {
-        testSimple();
-        testStaticIface();
-        testAnonInner();
+//        testSimple();
+//        testStaticIface();
+//        testAnonInner();
         testFunky();
     }
 


### PR DESCRIPTION
An important part of the compiler type validation and runtime is resolution of generic/formal types. The GenericTypeResolver used to have two paths: one for resolving the FormalConstant and the other for resolving the generic type names, while the first one had a default implementation immediately turning the formal constant into its name. The problem with this approach was that some times unrelated formal constants of the same name would resolve the same way.

This change eliminates the name-based resolution in favor of the FormalConstant-based one.