### PR TITLE
RFC-1 debt: typedef downtowning on current master

### DIFF
--- a/doc/RFC-1-typealias.md
+++ b/doc/RFC-1-typealias.md
@@ -1,0 +1,12 @@
+# RFC-1: Implement typealias with generic type parameters
+
+## Summary
+Parameterized compile-time alias allowing generic type parameters on aliases (e.g., `typealias Name<T, U> = TypeExpr<T, U>`).
+
+## Impact
+- No binary format changes
+- No runtime changes
+- No existing `typedef` changes
+
+## Status
+Proposed for implementation.

--- a/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
@@ -109,27 +109,6 @@ public class TypedefStructure
     }
 
     /**
-     * @return true iff this typedef declares generic type parameters
-     */
-    public boolean isParameterized() {
-        return getTypeParamCount() > 0;
-    }
-
-    /**
-     * Obtain the type parameters for this typedef in declaration order.
-     *
-     * @return the ordered list of type parameter names and constraint types
-     */
-    public List<Map.Entry<String, TypeConstant>> getTypeParamsAsList() {
-        List<PropertyStructure> listProps = getTypeParamProperties();
-        List<Map.Entry<String, TypeConstant>> list = new ArrayList<>(listProps.size());
-        for (PropertyStructure prop : listProps) {
-            list.add(Map.entry(prop.getName(), extractConstraint(prop)));
-        }
-        return list;
-    }
-
-    /**
      * Update (narrow) the constraint type for the specified generic type.
      *
      * @param sName           the generic type name
@@ -211,10 +190,6 @@ public class TypedefStructure
             }
         }
         return list;
-    }
-
-    private TypeConstant extractConstraint(PropertyStructure prop) {
-        return prop.getType().getParamType(0);
     }
 
 

--- a/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
@@ -5,9 +5,19 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.xvm.asm.Constants.Access;
+
+import org.xvm.asm.constants.FormalConstant;
+import org.xvm.asm.constants.PropertyConstant;
 import org.xvm.asm.constants.ConditionalConstant;
 import org.xvm.asm.constants.TypeConstant;
 import org.xvm.asm.constants.TypedefConstant;
+
+import org.xvm.util.ListMap;
 
 import static org.xvm.util.Handy.readIndex;
 import static org.xvm.util.Handy.writeMagnitude;
@@ -49,6 +59,11 @@ public class TypedefStructure
         return m_type;
     }
 
+    @Override
+    public boolean isClassContainer() {
+        return true;
+    }
+
     /**
      * Configure the typedef's type.
      *
@@ -57,6 +72,104 @@ public class TypedefStructure
     public void setType(TypeConstant type) {
         assert type != null;
         m_type = type;
+    }
+
+    /**
+     * Add a generic type parameter owned by this typedef.
+     *
+     * @param sName           the parameter name
+     * @param typeConstraint  the parameter constraint
+     *
+     * @return the synthetic property that backs the formal type
+     */
+    public PropertyStructure addTypeParam(String sName, TypeConstant typeConstraint) {
+        ConstantPool pool = getConstantPool();
+
+        if (typeConstraint.getParamsCount() >= 1 &&
+                typeConstraint.isTuple() &&
+                typeConstraint.getParamType(0).getValueString().equals(sName)) {
+            typeConstraint = pool.ensureTypeSequenceTypeConstant();
+        }
+
+        TypeConstant typeConstraintType =
+                pool.ensureClassTypeConstant(pool.clzType(), null, typeConstraint);
+
+        PropertyStructure prop = createProperty(false, Access.PUBLIC, Access.PUBLIC,
+                typeConstraintType, sName);
+        prop.markAsGenericTypeParameter();
+        markModified();
+        return prop;
+    }
+
+    /**
+     * @return the number of type parameters owned by this typedef
+     */
+    public int getTypeParamCount() {
+        return getTypeParamProperties().size();
+    }
+
+    /**
+     * @return true iff this typedef declares generic type parameters
+     */
+    public boolean isParameterized() {
+        return getTypeParamCount() > 0;
+    }
+
+    /**
+     * Obtain the type parameters for this typedef in declaration order.
+     *
+     * @return the ordered list of type parameter names and constraint types
+     */
+    public List<Map.Entry<String, TypeConstant>> getTypeParamsAsList() {
+        List<PropertyStructure> listProps = getTypeParamProperties();
+        List<Map.Entry<String, TypeConstant>> list = new ArrayList<>(listProps.size());
+        for (PropertyStructure prop : listProps) {
+            list.add(Map.entry(prop.getName(), extractConstraint(prop)));
+        }
+        return list;
+    }
+
+    /**
+     * Update (narrow) the constraint type for the specified generic type.
+     *
+     * @param sName           the generic type name
+     * @param typeConstraint  the new constraint type
+     */
+    public void updateConstraint(String sName, TypeConstant typeConstraint) {
+        PropertyStructure prop = (PropertyStructure) getChild(sName);
+        if (prop == null) {
+            throw new IllegalArgumentException("unknown typedef type parameter: " + sName);
+        }
+
+        ConstantPool pool = getConstantPool();
+        TypeConstant typeConstraintType =
+                pool.ensureClassTypeConstant(pool.clzType(), null, typeConstraint);
+
+        prop.setType(typeConstraintType);
+        markModified();
+    }
+
+    /**
+     * Resolve the typedef's formal type parameters against the specified actual types.
+     *
+     * @param typeAlias    the current typedef type template
+     * @param atypeParams  the actual type parameters
+     *
+     * @return the resulting resolved type
+     */
+    public TypeConstant resolveTypeParameters(TypeConstant typeAlias, TypeConstant[] atypeParams) {
+        List<PropertyStructure> listParams = getTypeParamProperties();
+        if (listParams.size() != atypeParams.length) {
+            return typeAlias;
+        }
+
+        Map<FormalConstant, TypeConstant> mapResolve = new ListMap<>();
+        for (int i = 0, c = atypeParams.length; i < c; ++i) {
+            PropertyConstant idFormal = listParams.get(i).getIdentityConstant();
+            mapResolve.put(idFormal, atypeParams[i]);
+        }
+
+        return typeAlias.resolveGenerics(getConstantPool(), GenericTypeResolver.of(mapResolve));
     }
 
 
@@ -88,6 +201,20 @@ public class TypedefStructure
     @Override
     public String getDescription() {
         return "type=" + m_type + ", " + super.getDescription();
+    }
+
+    private List<PropertyStructure> getTypeParamProperties() {
+        List<PropertyStructure> list = new ArrayList<>();
+        for (Component child : getChildByNameMap().values()) {
+            if (child instanceof PropertyStructure prop && prop.isGenericTypeParameter()) {
+                list.add(prop);
+            }
+        }
+        return list;
+    }
+
+    private TypeConstant extractConstraint(PropertyStructure prop) {
+        return prop.getType().getParamType(0);
     }
 
 

--- a/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
@@ -14,6 +14,7 @@ import org.xvm.asm.Constants.Access;
 import org.xvm.asm.constants.FormalConstant;
 import org.xvm.asm.constants.PropertyConstant;
 import org.xvm.asm.constants.ConditionalConstant;
+import org.xvm.asm.constants.TerminalTypeConstant;
 import org.xvm.asm.constants.TypeConstant;
 import org.xvm.asm.constants.TypedefConstant;
 
@@ -146,6 +147,18 @@ public class TypedefStructure
         for (int i = 0, c = atypeParams.length; i < c; ++i) {
             PropertyConstant idFormal = listParams.get(i).getIdentityConstant();
             mapResolve.put(idFormal, atypeParams[i]);
+        }
+
+        // If the resolved type is from a typedef with type parameters, preserve the typedef identity
+        // by wrapping the typedef constant with the resolved type parameters. This ensures
+        // type.toString() returns the typedef alias form (e.g., "Series<Int>") rather than the
+        // underlying type (e.g., "MetaSeries<Int, Int>"), which is critical for JSON serialization.
+        if (typeAlias instanceof TerminalTypeConstant) {
+            // Create a ParameterizedTypeConstant that wraps the typedef constant,
+            // preserving the typedef alias name with its type parameters
+            return getConstantPool().ensureParameterizedTypeConstant(
+                    getConstantPool().ensureTerminalTypeConstant(getIdentityConstant()),
+                    atypeParams);
         }
 
         return typeAlias.resolveGenerics(getConstantPool(), GenericTypeResolver.of(mapResolve));

--- a/javatools/src/main/java/org/xvm/asm/constants/MethodInfo.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/MethodInfo.java
@@ -551,7 +551,10 @@ public class MethodInfo
             if (body.getImplementation() == Implementation.Capped) {
                 MethodInfo methodNarrowing = infoType.getNarrowingMethod(this);
                 assert methodNarrowing != this;
-                return methodNarrowing.getTopmostMethodStructure(infoType);
+                if (methodNarrowing != null) {
+                    return methodNarrowing.getTopmostMethodStructure(infoType);
+                }
+                continue;
             }
 
             MethodStructure method = body.getMethodStructure();

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
@@ -67,6 +67,7 @@ public class PropertyConstant
         case Package:
         case Class:
         case NativeClass:
+        case Typedef:
         case Property:
         case Method:
             break;

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -978,7 +978,10 @@ public abstract class TypeConstant
                     atype2[i] = te1.combine(pool, te2);
                 }
             }
-            return pool.ensureParameterizedTypeConstant(t2, atype2);
+            TypeConstant typeBase = t2.isRelationalType()
+                    ? t2.getSingleUnderlyingClass(true).getType()
+                    : t2;
+            return pool.ensureParameterizedTypeConstant(typeBase, atype2);
         }
         return null;
     }

--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -2231,30 +2231,28 @@ public class Parser {
     TypedefStatement parseTypeDefStatement(Expression exprCond, Token tokenAccess) {
         Token keyword = expect(Id.TYPEDEF);
 
-        Mark mark = mark();
-        if (peek(Id.IDENTIFIER)) {
-            Token           alias      = expect(Id.IDENTIFIER);
-            List<Parameter> typeParams = peek(Id.COMP_LT) ? parseTypeParameterList(true) : null;
-            if (typeParams != null && match(Id.AS) != null) {
-                TypeExpression type = parseExtendedTypeExpression();
-                expect(Id.SEMICOLON);
+        try (SafeLookAhead attempt = new SafeLookAhead()) {
+            TypeExpression type = parseExtendedTypeExpression();
+            expect(Id.AS);
+            Token simpleName = expect(Id.IDENTIFIER);
+            expect(Id.SEMICOLON);
+
+            if (attempt.isClean()) {
+                attempt.keepResults();
                 return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess,
-                        typeParams, alias, type);
+                        null, simpleName, type);
             }
-            restore(mark);
+        } catch (CompilerException ignore) {
         }
 
-        TypeExpression type = parseExtendedTypeExpression();
-
-        // required "as" keyword (note: previously optional)
+        Token           alias      = expect(Id.IDENTIFIER);
+        List<Parameter> typeParams = parseTypeParameterList(true);
         expect(Id.AS);
-
-        Token simpleName = expect(Id.IDENTIFIER);
-
+        TypeExpression  type       = parseExtendedTypeExpression();
         expect(Id.SEMICOLON);
 
         return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess,
-                null, simpleName, type);
+                typeParams, alias, type);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -2231,6 +2231,19 @@ public class Parser {
     TypedefStatement parseTypeDefStatement(Expression exprCond, Token tokenAccess) {
         Token keyword = expect(Id.TYPEDEF);
 
+        Mark mark = mark();
+        if (peek(Id.IDENTIFIER)) {
+            Token           alias      = expect(Id.IDENTIFIER);
+            List<Parameter> typeParams = peek(Id.COMP_LT) ? parseTypeParameterList(true) : null;
+            if (typeParams != null && match(Id.AS) != null) {
+                TypeExpression type = parseExtendedTypeExpression();
+                expect(Id.SEMICOLON);
+                return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess,
+                        typeParams, alias, type);
+            }
+            restore(mark);
+        }
+
         TypeExpression type = parseExtendedTypeExpression();
 
         // required "as" keyword (note: previously optional)
@@ -2240,7 +2253,8 @@ public class Parser {
 
         expect(Id.SEMICOLON);
 
-        return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess, type, simpleName);
+        return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess,
+                null, simpleName, type);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
@@ -19,6 +19,7 @@ import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.MethodStructure.Code;
+import org.xvm.asm.TypedefStructure;
 
 import org.xvm.asm.ast.ConstantExprAST;
 import org.xvm.asm.ast.ExprAST;
@@ -369,7 +370,14 @@ public class NamedTypeExpression
                 atypeParams[i] = listParams.get(i).ensureTypeConstant(ctx, errs);
             }
 
-            type = pool.ensureParameterizedTypeConstant(type, atypeParams);
+            TypedefStructure typedef = getParameterizedTypedef(constId);
+            if (typedef != null) {
+                if (atypeParams.length == typedef.getTypeParamCount()) {
+                    type = typedef.resolveTypeParameters(type, atypeParams);
+                }
+            } else {
+                type = pool.ensureParameterizedTypeConstant(type, atypeParams);
+            }
         }
 
         if (access != null && access != Access.PUBLIC) {
@@ -638,7 +646,15 @@ public class NamedTypeExpression
             if (atypeParams == null) {
                 return null;
             }
-            if (type.isParamsSpecified()) {
+            TypedefStructure typedef = getParameterizedTypedef(m_constId);
+            if (typedef != null) {
+                if (atypeParams.length != typedef.getTypeParamCount()) {
+                    log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_MISMATCH);
+                    return null;
+                }
+
+                type = typedef.resolveTypeParameters(type, atypeParams);
+            } else if (type.isParamsSpecified()) {
                 TypeConstant[] atypeActual = type.getParamTypesArray();
                 if (!Arrays.equals(atypeActual, atypeParams)) {
                     // this can happen for example, if m_constId is a typedef for a function
@@ -1011,19 +1027,32 @@ public class NamedTypeExpression
             return false;
         }
 
-        if (format == Format.Property || format == Format.Typedef) {
+        if (format == Format.Property) {
             if (paramTypes != null) {
                 log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_UNEXPECTED);
                 return false;
             }
-            if (format == Format.Property &&
-                    (!((PropertyConstant) constId).isFormalType() ||
-                        names != null && names.size() > 1)) {
+            if (!((PropertyConstant) constId).isFormalType() ||
+                    names != null && names.size() > 1) {
                 log(errs, Severity.ERROR, Compiler.INVALID_FORMAL_TYPE_IDENTITY);
                 return false;
             }
         }
+
+        if (format == Format.Typedef && paramTypes != null && getParameterizedTypedef(constId) == null) {
+            log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_UNEXPECTED);
+            return false;
+        }
         return true;
+    }
+
+    private TypedefStructure getParameterizedTypedef(Constant constId) {
+        if (constId instanceof TypedefConstant idTypedef &&
+                idTypedef.getComponent() instanceof TypedefStructure typedef &&
+                typedef.isParameterized()) {
+            return typedef;
+        }
+        return null;
     }
 
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
@@ -1049,7 +1049,7 @@ public class NamedTypeExpression
     private TypedefStructure getParameterizedTypedef(Constant constId) {
         if (constId instanceof TypedefConstant idTypedef &&
                 idTypedef.getComponent() instanceof TypedefStructure typedef &&
-                typedef.isParameterized()) {
+                typedef.getTypeParamCount() > 0) {
             return typedef;
         }
         return null;

--- a/javatools/src/main/java/org/xvm/compiler/ast/TypedefStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TypedefStatement.java
@@ -3,6 +3,9 @@ package org.xvm.compiler.ast;
 
 import java.lang.reflect.Field;
 
+import java.util.HashSet;
+import java.util.List;
+
 import org.xvm.asm.Component;
 import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
@@ -25,13 +28,15 @@ public class TypedefStatement
         extends ComponentStatement {
     // ----- constructors --------------------------------------------------------------------------
 
-    public TypedefStatement(Expression cond, Token keyword, TypeExpression type, Token alias) {
+    public TypedefStatement(Expression cond, Token keyword, List<Parameter> typeParams,
+                            Token alias, TypeExpression type) {
         super(keyword.getStartPosition(), alias.getEndPosition());
 
-        this.cond     = cond;
-        this.modifier = keyword.getId() == Id.TYPEDEF ? null : keyword;
-        this.type     = type;
-        this.alias    = alias;
+        this.cond       = cond;
+        this.modifier   = keyword.getId() == Id.TYPEDEF ? null : keyword;
+        this.typeParams = typeParams;
+        this.alias      = alias;
+        this.type       = type;
     }
 
 
@@ -63,20 +68,69 @@ public class TypedefStatement
 
     @Override
     protected void registerStructures(StageMgr mgr, ErrorListener errs) {
-        // create the structure for this method
+        // create the structure for this typedef
         if (getComponent() == null) {
-            // create a structure for this typedef
             Component container = getParent().getComponent();
             String    sName     = (String) alias.getValue();
             if (container != null && container.isClassContainer()) {
                 Access           access    = getDefaultAccess();
                 TypeConstant     constType = type.ensureTypeConstant();
                 TypedefStructure typedef   = container.createTypedef(access, constType, sName);
+                if (typedef != null && typeParams != null && !typeParams.isEmpty()) {
+                    HashSet<String> setNames = new HashSet<>();
+                    for (Parameter param : typeParams) {
+                        String sParam = param.getName();
+                        if (setNames.add(sParam)) {
+                            TypeExpression exprType  = param.getType();
+                            TypeConstant   constParm = exprType == null
+                                    ? pool().typeObject()
+                                    : exprType.ensureTypeConstant();
+                            typedef.addTypeParam(sParam, constParm);
+                        } else {
+                            log(errs, Severity.ERROR, Compiler.DUPLICATE_TYPE_PARAM, sParam);
+                        }
+                    }
+                }
                 setComponent(typedef);
             } else if (!errs.hasSeriousErrors()) {
                 log(errs, Severity.ERROR, Compiler.TYPEDEF_UNEXPECTED, sName, container);
             }
         }
+    }
+
+    @Override
+    public void resolveNames(StageMgr mgr, ErrorListener errs) {
+        if (!mgr.processChildren()) {
+            mgr.requestRevisit();
+            return;
+        }
+
+        TypedefStructure typedef = (TypedefStructure) getComponent();
+        if (typedef == null) {
+            return;
+        }
+
+        if (typeParams != null && !typeParams.isEmpty()) {
+            for (Parameter param : typeParams) {
+                TypeExpression exprConstraint = param.getType();
+                if (exprConstraint != null) {
+                    TypeConstant typeConstraint = exprConstraint.ensureTypeConstant();
+                    if (typeConstraint.containsUnresolved()) {
+                        mgr.requestRevisit();
+                        return;
+                    }
+                    typedef.updateConstraint(param.getName(), typeConstraint);
+                }
+            }
+        }
+
+        type.resetTypeConstant();
+        TypeConstant constType = type.ensureTypeConstant();
+        if (constType.containsUnresolved()) {
+            mgr.requestRevisit();
+            return;
+        }
+        typedef.setType(constType);
     }
 
     @Override
@@ -106,11 +160,30 @@ public class TypedefStatement
               .append(' ');
         }
 
-        sb.append("typedef ")
-          .append(type)
-          .append(' ')
-          .append(alias.getValue())
-          .append(';');
+        sb.append("typedef ");
+        if (typeParams == null || typeParams.isEmpty()) {
+            sb.append(type)
+              .append(" as ")
+              .append(alias.getValue());
+        } else {
+            sb.append(alias.getValue())
+              .append('<');
+
+            boolean first = true;
+            for (Parameter param : typeParams) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(param.toTypeParamString());
+            }
+
+            sb.append("> as ")
+              .append(type);
+        }
+
+        sb.append(';');
 
         if (cond != null) {
             sb.append(" }");
@@ -129,8 +202,10 @@ public class TypedefStatement
 
     protected Expression     cond;
     protected Token          modifier;
+    protected List<Parameter> typeParams;
     protected Token          alias;
     protected TypeExpression type;
 
-    private static final Field[] CHILD_FIELDS = fieldsForNames(TypedefStatement.class, "cond", "type");
+    private static final Field[] CHILD_FIELDS =
+            fieldsForNames(TypedefStatement.class, "cond", "typeParams", "type");
 }

--- a/javatools/src/test/java/org/xvm/compiler/ParserTest.java
+++ b/javatools/src/test/java/org/xvm/compiler/ParserTest.java
@@ -55,6 +55,48 @@ public class ParserTest {
         parse("module Test {class Box<T> {} typedef Alias<T> as Box<T>;}");
     }
 
+    @Test
+    public void testMixedTypedefProofModule() {
+        parse("""
+                module TestTypedefs {
+                    typedef Join<A, B> as Tuple<A, B>;
+                    typedef Twin<T> as Join<T, T>;
+                    typedef MetaSeries<I, T> as Join<I, function T(I)>;
+                    typedef Series<T> as MetaSeries<Int, T>;
+                    typedef Series2<A, B> as Series<Join<A, B>>;
+
+                    typedef Join<String, String> as ColumnMeta;
+                    typedef function ColumnMeta() as ColumnMetaRef;
+                    typedef Series2<Any?, ColumnMetaRef> as RowVec;
+                    typedef Series<RowVec> as Cursor;
+                    typedef Series<Char> as CharStr;
+                    typedef Series<CharStr> as Corpus;
+                    typedef MetaSeries<ElementState, Set<ElementState>> as LifecycleFSM;
+
+                    enum ElementState {Created, Open, Active, Draining, Closed}
+
+                    void run() {
+                        Series<String> names = (3, i -> i == 0 ? "alpha" : i == 1 ? "beta" : "gamma");
+                        RowVec row = (2, i -> i == 0 ? ("42", () -> ("id", "Int")) : ("bob", () -> ("name", "String")));
+                        Cursor cursor = (1, i -> row);
+                        LifecycleFSM lifecycle = (ElementState.Created, state -> {
+                            switch (state) {
+                            case Created:  return Set:[ElementState.Open];
+                            case Open:     return Set:[ElementState.Active, ElementState.Draining];
+                            case Active:   return Set:[ElementState.Draining];
+                            case Draining: return Set:[ElementState.Closed];
+                            case Closed:   return Set:[ElementState.Closed];
+                            }
+                        });
+
+                        assert names[1](2) == "gamma";
+                        assert cursor[1](0)[1](1)[1]()[0] == "name";
+                        assert lifecycle[1](ElementState.Draining) == Set:[ElementState.Closed];
+                    }
+                }
+                """);
+    }
+
     static void parse(String value) {
             parse(new Source(value));
     }
@@ -71,6 +113,10 @@ public class ParserTest {
                 + errlist.getSeverity() + "):");
 
         errlist.getErrors().forEach(ParserTest::out);
+
+        if (errlist.getSeriousErrorCount() > 0) {
+            throw new AssertionError("parse produced " + errlist.getSeriousErrorCount() + " serious errors");
+        }
     }
 
     /**

--- a/javatools/src/test/java/org/xvm/compiler/ParserTest.java
+++ b/javatools/src/test/java/org/xvm/compiler/ParserTest.java
@@ -50,6 +50,11 @@ public class ParserTest {
         parse("class DependentFutureRef delegates Ref(value) {}");
     }
 
+    @Test
+    public void testGenericTypedef() {
+        parse("module Test {class Box<T> {} typedef Alias<T> as Box<T>;}");
+    }
+
     static void parse(String value) {
             parse(new Source(value));
     }


### PR DESCRIPTION
## Summary
- rebase the RFC-1 typedef work onto current `xtclang/xvm` `master`
- keep the parser and compiler-side typedef changes only
- expose the remaining `lib_json` fallout as compile debt instead of masking it with source-layer swaps

## Verification
- `./gradlew :xdk:lib-json:compileXtc`

## Current debt
- compiler crash is removed by the compiler-side narrowing fix
- `:xdk:lib-json:compileXtc` still fails with typedef identity mismatches in `lib_json`
- this branch is intended to show that bill cleanly for follow-on RFC work