### PR TITLE
parameterized typedefs 

### DIFF
--- a/doc/RFC-1-typealias.md
+++ b/doc/RFC-1-typealias.md
@@ -1,0 +1,12 @@
+# RFC-1: Implement typealias with generic type parameters
+
+## Summary
+Parameterized compile-time alias allowing generic type parameters on aliases (e.g., `typealias Name<T, U> = TypeExpr<T, U>`).
+
+## Impact
+- No binary format changes
+- No runtime changes
+- No existing `typedef` changes
+
+## Status
+Proposed for implementation.

--- a/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/TypedefStructure.java
@@ -5,9 +5,20 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.xvm.asm.Constants.Access;
+
+import org.xvm.asm.constants.FormalConstant;
+import org.xvm.asm.constants.PropertyConstant;
 import org.xvm.asm.constants.ConditionalConstant;
+import org.xvm.asm.constants.TerminalTypeConstant;
 import org.xvm.asm.constants.TypeConstant;
 import org.xvm.asm.constants.TypedefConstant;
+
+import org.xvm.util.ListMap;
 
 import static org.xvm.util.Handy.readIndex;
 import static org.xvm.util.Handy.writeMagnitude;
@@ -49,6 +60,11 @@ public class TypedefStructure
         return m_type;
     }
 
+    @Override
+    public boolean isClassContainer() {
+        return true;
+    }
+
     /**
      * Configure the typedef's type.
      *
@@ -57,6 +73,93 @@ public class TypedefStructure
     public void setType(TypeConstant type) {
         assert type != null;
         m_type = type;
+    }
+
+    /**
+     * Add a generic type parameter owned by this typedef.
+     *
+     * @param sName           the parameter name
+     * @param typeConstraint  the parameter constraint
+     *
+     * @return the synthetic property that backs the formal type
+     */
+    public PropertyStructure addTypeParam(String sName, TypeConstant typeConstraint) {
+        ConstantPool pool = getConstantPool();
+
+        if (typeConstraint.getParamsCount() >= 1 &&
+                typeConstraint.isTuple() &&
+                typeConstraint.getParamType(0).getValueString().equals(sName)) {
+            typeConstraint = pool.ensureTypeSequenceTypeConstant();
+        }
+
+        TypeConstant typeConstraintType =
+                pool.ensureClassTypeConstant(pool.clzType(), null, typeConstraint);
+
+        PropertyStructure prop = createProperty(false, Access.PUBLIC, Access.PUBLIC,
+                typeConstraintType, sName);
+        prop.markAsGenericTypeParameter();
+        markModified();
+        return prop;
+    }
+
+    /**
+     * @return the number of type parameters owned by this typedef
+     */
+    public int getTypeParamCount() {
+        return getTypeParamProperties().size();
+    }
+
+    /**
+     * Update (narrow) the constraint type for the specified generic type.
+     *
+     * @param sName           the generic type name
+     * @param typeConstraint  the new constraint type
+     */
+    public void updateConstraint(String sName, TypeConstant typeConstraint) {
+        PropertyStructure prop = (PropertyStructure) getChild(sName);
+        if (prop == null) {
+            throw new IllegalArgumentException("unknown typedef type parameter: " + sName);
+        }
+
+        ConstantPool pool = getConstantPool();
+        TypeConstant typeConstraintType =
+                pool.ensureClassTypeConstant(pool.clzType(), null, typeConstraint);
+
+        prop.setType(typeConstraintType);
+        markModified();
+    }
+
+    /**
+     * Resolve the typedef's formal type parameters against the specified actual types.
+     *
+     * @param typeAlias    the current typedef type template
+     * @param atypeParams  the actual type parameters
+     *
+     * @return the resulting resolved type
+     */
+    public TypeConstant resolveTypeParameters(TypeConstant typeAlias, TypeConstant[] atypeParams) {
+        List<PropertyStructure> listParams = getTypeParamProperties();
+        if (listParams.size() != atypeParams.length) {
+            return typeAlias;
+        }
+
+        Map<FormalConstant, TypeConstant> mapResolve = new ListMap<>();
+        for (int i = 0, c = atypeParams.length; i < c; ++i) {
+            PropertyConstant idFormal = listParams.get(i).getIdentityConstant();
+            mapResolve.put(idFormal, atypeParams[i]);
+        }
+
+        // Preserve typedef identity only for actual parameterized aliases. Zero-arity typedefs
+        // retain the legacy transparent behavior so structural duck typing keeps working.
+        if (atypeParams.length > 0 && typeAlias instanceof TerminalTypeConstant) {
+            // Create a ParameterizedTypeConstant that wraps the typedef constant,
+            // preserving the typedef alias name with its type parameters
+            return getConstantPool().ensureParameterizedTypeConstant(
+                    getConstantPool().ensureTerminalTypeConstant(getIdentityConstant()),
+                    atypeParams);
+        }
+
+        return typeAlias.resolveGenerics(getConstantPool(), GenericTypeResolver.of(mapResolve));
     }
 
 
@@ -88,6 +191,16 @@ public class TypedefStructure
     @Override
     public String getDescription() {
         return "type=" + m_type + ", " + super.getDescription();
+    }
+
+    private List<PropertyStructure> getTypeParamProperties() {
+        List<PropertyStructure> list = new ArrayList<>();
+        for (Component child : getChildByNameMap().values()) {
+            if (child instanceof PropertyStructure prop && prop.isGenericTypeParameter()) {
+                list.add(prop);
+            }
+        }
+        return list;
     }
 
 

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -32,6 +32,16 @@ public class DifferenceTypeConstant
     // ----- constructors --------------------------------------------------------------------------
 
     /**
+     * RFC-1 DEBT: Check if this is a "simple" difference where only Object is being subtracted.
+     * This is a HACK - proper implementation for general DifferenceType constants is still needed.
+     *
+     * @return true if the subtrahend is Object
+     */
+    protected boolean isObjectSubtraction() {
+        return m_constType2.equals(getConstantPool().typeObject());
+    }
+
+    /**
      * Constructor used for deserialization.
      *
      * @param pool    the ConstantPool that will contain this Constant
@@ -445,15 +455,14 @@ public class DifferenceTypeConstant
 
     @Override
     protected boolean isDuckTypeAbleFrom(TypeConstant typeRight) {
-        // RFC-1 DEBT: HACK - for now we only allow a diff to the Object (e.g. Stringable - Object)
-        return m_constType1.isInterfaceType() && m_constType2.equals(getConstantPool().typeObject());
+        // RFC-1 DEBT: HACK - only Object subtraction allowed (see isObjectSubtraction())
+        return m_constType1.isInterfaceType() && isObjectSubtraction();
     }
 
     @Override
     protected Set<SignatureConstant> isInterfaceAssignableFrom(TypeConstant typeRight,
                                                                Access accessLeft, List<TypeConstant> listLeft) {
         // RFC-1 DEBT: HACK - same restriction as isDuckTypeAbleFrom; only Object subtraction allowed
-        // TODO GG: proper implementation for general DifferenceType constants
         return m_constType1.isInterfaceAssignableFrom(typeRight, accessLeft, listLeft);
     }
 

--- a/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/DifferenceTypeConstant.java
@@ -445,15 +445,16 @@ public class DifferenceTypeConstant
 
     @Override
     protected boolean isDuckTypeAbleFrom(TypeConstant typeRight) {
-        // HACK HACK: for now we only allow a diff to the Object (e.g. Stringable - Object)
-        // TODO GG: implement isInterfaceAssignableFrom()
+        // RFC-1 DEBT: HACK - for now we only allow a diff to the Object (e.g. Stringable - Object)
         return m_constType1.isInterfaceType() && m_constType2.equals(getConstantPool().typeObject());
     }
 
     @Override
     protected Set<SignatureConstant> isInterfaceAssignableFrom(TypeConstant typeRight,
                                                                Access accessLeft, List<TypeConstant> listLeft) {
-        return m_constType1.isInterfaceAssignableFrom(typeRight, accessLeft, listLeft); // TODO GG
+        // RFC-1 DEBT: HACK - same restriction as isDuckTypeAbleFrom; only Object subtraction allowed
+        // TODO GG: proper implementation for general DifferenceType constants
+        return m_constType1.isInterfaceAssignableFrom(typeRight, accessLeft, listLeft);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/asm/constants/MethodInfo.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/MethodInfo.java
@@ -551,7 +551,10 @@ public class MethodInfo
             if (body.getImplementation() == Implementation.Capped) {
                 MethodInfo methodNarrowing = infoType.getNarrowingMethod(this);
                 assert methodNarrowing != this;
-                return methodNarrowing.getTopmostMethodStructure(infoType);
+                if (methodNarrowing != null) {
+                    return methodNarrowing.getTopmostMethodStructure(infoType);
+                }
+                continue;
             }
 
             MethodStructure method = body.getMethodStructure();

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyConstant.java
@@ -67,6 +67,7 @@ public class PropertyConstant
         case Package:
         case Class:
         case NativeClass:
+        case Typedef:
         case Property:
         case Method:
             break;

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -11,9 +11,11 @@ import java.lang.classfile.Label;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -978,7 +980,10 @@ public abstract class TypeConstant
                     atype2[i] = te1.combine(pool, te2);
                 }
             }
-            return pool.ensureParameterizedTypeConstant(t2, atype2);
+            TypeConstant typeBase = t2.isRelationalType()
+                    ? t2.getSingleUnderlyingClass(true).getType()
+                    : t2;
+            return pool.ensureParameterizedTypeConstant(typeBase, atype2);
         }
         return null;
     }
@@ -5351,9 +5356,19 @@ public abstract class TypeConstant
             return relation;
         }
 
-        Set<TypeConstant> setInProgress = m_tloInProgress.get();
+        TransientThreadLocal<Set<TypeConstant>>             tloInProgress    = m_tloInProgress;
+        TransientThreadLocal<Deque<RelationBreadcrumb>>     tloBreadcrumbs   = m_tloBreadcrumbs;
+        Set<TypeConstant>                                   setInProgress    =
+                tloInProgress == null ? null : tloInProgress.get();
+        Deque<RelationBreadcrumb>                           dequeBreadcrumbs =
+                tloBreadcrumbs == null ? null : tloBreadcrumbs.get();
 
         if (setInProgress != null && setInProgress.contains(typeLeft)) {
+            if ((typeLeft.containsRecursiveType() || typeRight.containsRecursiveType())
+                    && dequeBreadcrumbs != null && !dequeBreadcrumbs.isEmpty()) {
+                return Relation.IS_A_WEAK;
+            }
+
             // we are in recursion; this can only happen for duck-typing, for example:
             //
             //    interface I { I! foo(); }
@@ -5452,7 +5467,16 @@ public abstract class TypeConstant
         if (setInProgress == null) {
             m_tloInProgress.set(setInProgress = new HashSet<>());
         }
+        if (dequeBreadcrumbs == null) {
+            if (m_tloBreadcrumbs == null) {
+                s_tloBreadcrumbs.compareAndSet(this, null, new TransientThreadLocal<>());
+            }
+            m_tloBreadcrumbs.set(dequeBreadcrumbs = new ArrayDeque<>());
+        }
+
+        RelationBreadcrumb breadcrumb = new RelationBreadcrumb(typeLeft, typeRight);
         setInProgress.add(typeLeft);
+        dequeBreadcrumbs.addLast(breadcrumb);
         try {
             relation = typeRight.calculateRelationToLeft(typeLeft);
 
@@ -5465,9 +5489,18 @@ public abstract class TypeConstant
             mapRelations.remove(typeLeft);
             throw e;
         } finally {
+            RelationBreadcrumb breadcrumbLast = dequeBreadcrumbs.peekLast();
+            if (breadcrumb.equals(breadcrumbLast)) {
+                dequeBreadcrumbs.removeLast();
+            } else {
+                dequeBreadcrumbs.removeLastOccurrence(breadcrumb);
+            }
             setInProgress.remove(typeLeft);
             if (setInProgress.isEmpty()) {
                 m_tloInProgress.remove();
+            }
+            if (dequeBreadcrumbs.isEmpty()) {
+                m_tloBreadcrumbs.remove();
             }
         }
         return relation;
@@ -7300,6 +7333,7 @@ public abstract class TypeConstant
         Map<TypeConstant, Relation> mapRelations = m_mapRelations;
         if (mapRelations == null) {
             s_tloInProgress.compareAndSet(this, null, new TransientThreadLocal<>());
+            s_tloBreadcrumbs.compareAndSet(this, null, new TransientThreadLocal<>());
             mapRelations = m_mapRelations = new ConcurrentHashMap<>();
         }
         return mapRelations;
@@ -7327,14 +7361,17 @@ public abstract class TypeConstant
      * @return false iff the duck-typing is known to be impossible
      */
     protected boolean isDuckTypeAbleFrom(TypeConstant typeRight) {
-        // interfaces are duck-type able except Tuple, Function and Orderable
-        // (the later due to the fact that it has no abstract methods and
-        //  is well-known by the runtime only by its "compare" function)
-        if (!isInterfaceType() || isVirtualChild() || isTuple()) {
+        // RFC-1 DEBT: typedef was intended as the duck typing pillar; restore by unwrapping
+        // typedef via resolveTypedefs() which returns the underlying type for duck check.
+        // Exclude Tuple, Function and Orderable (no abstract methods; runtime-only "compare").
+        if (isVirtualChild() || isTuple()) {
+            return false;
+        }
+        TypeConstant typeLeft = resolveTypedefs();
+        if (!typeLeft.isInterfaceType()) {
             return false;
         }
 
-        TypeConstant typeLeft = this;
         if (typeLeft.isSingleDefiningConstant() && typeRight.isSingleDefiningConstant()
             && typeRight.getDefiningConstant().equals(typeLeft.getDefiningConstant())) {
             // we have just tested the relationship between C<T1> and C<T2> and got
@@ -7469,6 +7506,38 @@ public abstract class TypeConstant
     }
 
     /**
+     * Breadcrumb used to identify a recursive relation edge while unwinding recursive type checks.
+     */
+    private static final class RelationBreadcrumb {
+        private RelationBreadcrumb(TypeConstant typeLeft, TypeConstant typeRight) {
+            this.typeLeft  = typeLeft;
+            this.typeRight = typeRight;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof RelationBreadcrumb that)) {
+                return false;
+            }
+            return typeLeft.equals(that.typeLeft) && typeRight.equals(that.typeRight);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * typeLeft.hashCode() + typeRight.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "left=" + typeLeft.getValueString()
+                 + "; right=" + typeRight.getValueString();
+        }
+
+        private final TypeConstant typeLeft;
+        private final TypeConstant typeRight;
+    }
+
+    /**
      * Consumption/production options.
      */
     public enum Usage {
@@ -7536,6 +7605,13 @@ public abstract class TypeConstant
     private transient volatile TransientThreadLocal<Set<TypeConstant>> m_tloInProgress;
     private static final AtomicReferenceFieldUpdater<TypeConstant, TransientThreadLocal> s_tloInProgress =
             AtomicReferenceFieldUpdater.newUpdater(TypeConstant.class, TransientThreadLocal.class, "m_tloInProgress");
+
+    /**
+     * The stack of in-progress "isA()" relation breadcrumbs.
+     */
+    private transient volatile TransientThreadLocal<Deque<RelationBreadcrumb>> m_tloBreadcrumbs;
+    private static final AtomicReferenceFieldUpdater<TypeConstant, TransientThreadLocal> s_tloBreadcrumbs =
+            AtomicReferenceFieldUpdater.newUpdater(TypeConstant.class, TransientThreadLocal.class, "m_tloBreadcrumbs");
 
     /**
      * A cache of "consumes" responses.

--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -2231,16 +2231,28 @@ public class Parser {
     TypedefStatement parseTypeDefStatement(Expression exprCond, Token tokenAccess) {
         Token keyword = expect(Id.TYPEDEF);
 
-        TypeExpression type = parseExtendedTypeExpression();
+        try (SafeLookAhead attempt = new SafeLookAhead()) {
+            TypeExpression type = parseExtendedTypeExpression();
+            expect(Id.AS);
+            Token simpleName = expect(Id.IDENTIFIER);
+            expect(Id.SEMICOLON);
 
-        // required "as" keyword (note: previously optional)
+            if (attempt.isClean()) {
+                attempt.keepResults();
+                return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess,
+                        null, simpleName, type);
+            }
+        } catch (CompilerException ignore) {
+        }
+
+        Token           alias      = expect(Id.IDENTIFIER);
+        List<Parameter> typeParams = parseTypeParameterList(true);
         expect(Id.AS);
-
-        Token simpleName = expect(Id.IDENTIFIER);
-
+        TypeExpression  type       = parseExtendedTypeExpression();
         expect(Id.SEMICOLON);
 
-        return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess, type, simpleName);
+        return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess,
+                typeParams, alias, type);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NamedTypeExpression.java
@@ -19,6 +19,7 @@ import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
 import org.xvm.asm.MethodStructure;
 import org.xvm.asm.MethodStructure.Code;
+import org.xvm.asm.TypedefStructure;
 
 import org.xvm.asm.ast.ConstantExprAST;
 import org.xvm.asm.ast.ExprAST;
@@ -369,7 +370,14 @@ public class NamedTypeExpression
                 atypeParams[i] = listParams.get(i).ensureTypeConstant(ctx, errs);
             }
 
-            type = pool.ensureParameterizedTypeConstant(type, atypeParams);
+            TypedefStructure typedef = getParameterizedTypedef(constId);
+            if (typedef != null) {
+                if (atypeParams.length == typedef.getTypeParamCount()) {
+                    type = typedef.resolveTypeParameters(type, atypeParams);
+                }
+            } else {
+                type = pool.ensureParameterizedTypeConstant(type, atypeParams);
+            }
         }
 
         if (access != null && access != Access.PUBLIC) {
@@ -638,7 +646,15 @@ public class NamedTypeExpression
             if (atypeParams == null) {
                 return null;
             }
-            if (type.isParamsSpecified()) {
+            TypedefStructure typedef = getParameterizedTypedef(m_constId);
+            if (typedef != null) {
+                if (atypeParams.length != typedef.getTypeParamCount()) {
+                    log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_MISMATCH);
+                    return null;
+                }
+
+                type = typedef.resolveTypeParameters(type, atypeParams);
+            } else if (type.isParamsSpecified()) {
                 TypeConstant[] atypeActual = type.getParamTypesArray();
                 if (!Arrays.equals(atypeActual, atypeParams)) {
                     // this can happen for example, if m_constId is a typedef for a function
@@ -1011,19 +1027,32 @@ public class NamedTypeExpression
             return false;
         }
 
-        if (format == Format.Property || format == Format.Typedef) {
+        if (format == Format.Property) {
             if (paramTypes != null) {
                 log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_UNEXPECTED);
                 return false;
             }
-            if (format == Format.Property &&
-                    (!((PropertyConstant) constId).isFormalType() ||
-                        names != null && names.size() > 1)) {
+            if (!((PropertyConstant) constId).isFormalType() ||
+                    names != null && names.size() > 1) {
                 log(errs, Severity.ERROR, Compiler.INVALID_FORMAL_TYPE_IDENTITY);
                 return false;
             }
         }
+
+        if (format == Format.Typedef && paramTypes != null && getParameterizedTypedef(constId) == null) {
+            log(errs, Severity.ERROR, Compiler.TYPE_PARAMS_UNEXPECTED);
+            return false;
+        }
         return true;
+    }
+
+    private TypedefStructure getParameterizedTypedef(Constant constId) {
+        if (constId instanceof TypedefConstant idTypedef &&
+                idTypedef.getComponent() instanceof TypedefStructure typedef &&
+                typedef.getTypeParamCount() > 0) {
+            return typedef;
+        }
+        return null;
     }
 
 

--- a/javatools/src/main/java/org/xvm/compiler/ast/TypedefStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TypedefStatement.java
@@ -3,6 +3,9 @@ package org.xvm.compiler.ast;
 
 import java.lang.reflect.Field;
 
+import java.util.HashSet;
+import java.util.List;
+
 import org.xvm.asm.Component;
 import org.xvm.asm.Constants.Access;
 import org.xvm.asm.ErrorListener;
@@ -25,13 +28,15 @@ public class TypedefStatement
         extends ComponentStatement {
     // ----- constructors --------------------------------------------------------------------------
 
-    public TypedefStatement(Expression cond, Token keyword, TypeExpression type, Token alias) {
+    public TypedefStatement(Expression cond, Token keyword, List<Parameter> typeParams,
+                            Token alias, TypeExpression type) {
         super(keyword.getStartPosition(), alias.getEndPosition());
 
-        this.cond     = cond;
-        this.modifier = keyword.getId() == Id.TYPEDEF ? null : keyword;
-        this.type     = type;
-        this.alias    = alias;
+        this.cond       = cond;
+        this.modifier   = keyword.getId() == Id.TYPEDEF ? null : keyword;
+        this.typeParams = typeParams;
+        this.alias      = alias;
+        this.type       = type;
     }
 
 
@@ -63,20 +68,69 @@ public class TypedefStatement
 
     @Override
     protected void registerStructures(StageMgr mgr, ErrorListener errs) {
-        // create the structure for this method
+        // create the structure for this typedef
         if (getComponent() == null) {
-            // create a structure for this typedef
             Component container = getParent().getComponent();
             String    sName     = (String) alias.getValue();
             if (container != null && container.isClassContainer()) {
                 Access           access    = getDefaultAccess();
                 TypeConstant     constType = type.ensureTypeConstant();
                 TypedefStructure typedef   = container.createTypedef(access, constType, sName);
+                if (typedef != null && typeParams != null && !typeParams.isEmpty()) {
+                    HashSet<String> setNames = new HashSet<>();
+                    for (Parameter param : typeParams) {
+                        String sParam = param.getName();
+                        if (setNames.add(sParam)) {
+                            TypeExpression exprType  = param.getType();
+                            TypeConstant   constParm = exprType == null
+                                    ? pool().typeObject()
+                                    : exprType.ensureTypeConstant();
+                            typedef.addTypeParam(sParam, constParm);
+                        } else {
+                            log(errs, Severity.ERROR, Compiler.DUPLICATE_TYPE_PARAM, sParam);
+                        }
+                    }
+                }
                 setComponent(typedef);
             } else if (!errs.hasSeriousErrors()) {
                 log(errs, Severity.ERROR, Compiler.TYPEDEF_UNEXPECTED, sName, container);
             }
         }
+    }
+
+    @Override
+    public void resolveNames(StageMgr mgr, ErrorListener errs) {
+        if (!mgr.processChildren()) {
+            mgr.requestRevisit();
+            return;
+        }
+
+        TypedefStructure typedef = (TypedefStructure) getComponent();
+        if (typedef == null) {
+            return;
+        }
+
+        if (typeParams != null && !typeParams.isEmpty()) {
+            for (Parameter param : typeParams) {
+                TypeExpression exprConstraint = param.getType();
+                if (exprConstraint != null) {
+                    TypeConstant typeConstraint = exprConstraint.ensureTypeConstant();
+                    if (typeConstraint.containsUnresolved()) {
+                        mgr.requestRevisit();
+                        return;
+                    }
+                    typedef.updateConstraint(param.getName(), typeConstraint);
+                }
+            }
+        }
+
+        type.resetTypeConstant();
+        TypeConstant constType = type.ensureTypeConstant();
+        if (constType.containsUnresolved()) {
+            mgr.requestRevisit();
+            return;
+        }
+        typedef.setType(constType);
     }
 
     @Override
@@ -106,11 +160,30 @@ public class TypedefStatement
               .append(' ');
         }
 
-        sb.append("typedef ")
-          .append(type)
-          .append(' ')
-          .append(alias.getValue())
-          .append(';');
+        sb.append("typedef ");
+        if (typeParams == null || typeParams.isEmpty()) {
+            sb.append(type)
+              .append(" as ")
+              .append(alias.getValue());
+        } else {
+            sb.append(alias.getValue())
+              .append('<');
+
+            boolean first = true;
+            for (Parameter param : typeParams) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(param.toTypeParamString());
+            }
+
+            sb.append("> as ")
+              .append(type);
+        }
+
+        sb.append(';');
 
         if (cond != null) {
             sb.append(" }");
@@ -129,8 +202,10 @@ public class TypedefStatement
 
     protected Expression     cond;
     protected Token          modifier;
+    protected List<Parameter> typeParams;
     protected Token          alias;
     protected TypeExpression type;
 
-    private static final Field[] CHILD_FIELDS = fieldsForNames(TypedefStatement.class, "cond", "type");
+    private static final Field[] CHILD_FIELDS =
+            fieldsForNames(TypedefStatement.class, "cond", "typeParams", "type");
 }

--- a/javatools/src/test/java/org/xvm/compiler/ParserTest.java
+++ b/javatools/src/test/java/org/xvm/compiler/ParserTest.java
@@ -50,6 +50,53 @@ public class ParserTest {
         parse("class DependentFutureRef delegates Ref(value) {}");
     }
 
+    @Test
+    public void testGenericTypedef() {
+        parse("module Test {class Box<T> {} typedef Alias<T> as Box<T>;}");
+    }
+
+    @Test
+    public void testMixedTypedefProofModule() {
+        parse("""
+                module TestTypedefs {
+                    typedef Join<A, B> as Tuple<A, B>;
+                    typedef Twin<T> as Join<T, T>;
+                    typedef MetaSeries<I, T> as Join<I, function T(I)>;
+                    typedef Series<T> as MetaSeries<Int, T>;
+                    typedef Series2<A, B> as Series<Join<A, B>>;
+
+                    typedef Join<String, String> as ColumnMeta;
+                    typedef function ColumnMeta() as ColumnMetaRef;
+                    typedef Series2<Any?, ColumnMetaRef> as RowVec;
+                    typedef Series<RowVec> as Cursor;
+                    typedef Series<Char> as CharStr;
+                    typedef Series<CharStr> as Corpus;
+                    typedef MetaSeries<ElementState, Set<ElementState>> as LifecycleFSM;
+
+                    enum ElementState {Created, Open, Active, Draining, Closed}
+
+                    void run() {
+                        Series<String> names = (3, i -> i == 0 ? "alpha" : i == 1 ? "beta" : "gamma");
+                        RowVec row = (2, i -> i == 0 ? ("42", () -> ("id", "Int")) : ("bob", () -> ("name", "String")));
+                        Cursor cursor = (1, i -> row);
+                        LifecycleFSM lifecycle = (ElementState.Created, state -> {
+                            switch (state) {
+                            case Created:  return Set:[ElementState.Open];
+                            case Open:     return Set:[ElementState.Active, ElementState.Draining];
+                            case Active:   return Set:[ElementState.Draining];
+                            case Draining: return Set:[ElementState.Closed];
+                            case Closed:   return Set:[ElementState.Closed];
+                            }
+                        });
+
+                        assert names[1](2) == "gamma";
+                        assert cursor[1](0)[1](1)[1]()[0] == "name";
+                        assert lifecycle[1](ElementState.Draining) == Set:[ElementState.Closed];
+                    }
+                }
+                """);
+    }
+
     static void parse(String value) {
             parse(new Source(value));
     }
@@ -66,6 +113,10 @@ public class ParserTest {
                 + errlist.getSeverity() + "):");
 
         errlist.getErrors().forEach(ParserTest::out);
+
+        if (errlist.getSeriousErrorCount() > 0) {
+            throw new AssertionError("parse produced " + errlist.getSeriousErrorCount() + " serious errors");
+        }
     }
 
     /**

--- a/manualTests/src/main/x/TestConfix.x
+++ b/manualTests/src/main/x/TestConfix.x
@@ -1,0 +1,873 @@
+module TestConfix {
+    typedef Join<A, B> as Tuple<A, B>;
+    typedef Twin<T> as Join<T, T>;
+    typedef MetaSeries<I, T> as Join<I, function T(I)>;
+    typedef Series<T> as MetaSeries<Int, T>;
+
+    typedef Join<String, IOMemento> as ColumnMeta;
+    typedef function ColumnMeta() as ColumnMetaRef;
+    typedef Join<Any?, ColumnMetaRef> as Cell;
+    typedef Series<Cell> as RowVec;
+    typedef Series<RowVec> as Cursor;
+    typedef String as CharStr;
+    typedef MetaSeries<ConfixFacet, Any?> as ConfixIndex;
+    typedef Join<Int, IOMemento> as Pending;
+    typedef function Int?(String) as KeyLookup;
+
+    enum IOMemento {
+        IoBoolean,
+        IoInt,
+        IoLong,
+        IoFloat,
+        IoDouble,
+        IoString,
+        IoLocalDate,
+        IoInstant,
+        IoNothing,
+        IoObject,
+        IoArray,
+        IoBytes,
+    }
+
+    enum Syntax {
+        JSON,
+        CBOR,
+        YAML,
+    }
+
+    enum ConfixFacet {
+        Spans,
+        Tags,
+        Depths,
+        DirectChildren,
+        TreeCursor,
+        KeyToChild,
+    }
+
+    void run() {
+        testRecognize();
+        testDecode();
+        testJsonIndex();
+        testJsonTree();
+        testDispatch();
+        testCborIndex();
+    }
+
+    static <A, B> Join<A, B> joinOf(A left, B right) {
+        return (left, right);
+    }
+
+    static <T> Twin<T> twinOf(T left, T right) {
+        return joinOf(left, right);
+    }
+
+    static <I, T> MetaSeries<I, T> metaSeriesOf(I bound, function T(I) indexer) {
+        return joinOf(bound, indexer);
+    }
+
+    static <T> Series<T> seriesOf(Int size, function T(Int) indexer) {
+        return metaSeriesOf(size, indexer);
+    }
+
+    static <T> Series<T> seriesFrom(T[] values) {
+        return seriesOf(values.size, i -> values[i]);
+    }
+
+    static <I, T> I boundOf(MetaSeries<I, T> series) {
+        return series[0];
+    }
+
+    static <I, T> T at(MetaSeries<I, T> series, I index) {
+        return series[1](index);
+    }
+
+    static ColumnMeta metaOf(String name, IOMemento tag) {
+        return joinOf(name, tag);
+    }
+
+    static Cell cellOf(Any? value, String name, IOMemento tag) {
+        ColumnMetaRef meta = () -> metaOf(name, tag);
+        return joinOf(value, meta);
+    }
+
+    static RowVec rowOf(Cell[] cells) {
+        return seriesFrom(cells);
+    }
+
+    static Cursor cursorOf(RowVec[] rows) {
+        return seriesFrom(rows);
+    }
+
+    static CharStr textOf(String text) {
+        return text;
+    }
+
+    static const RowBuilder(Cell[] cells = []) {
+        @Op("+")
+        RowBuilder add(Cell cell) {
+            return new RowBuilder(cells.add(cell));
+        }
+
+        RowVec build() {
+            return rowOf(cells);
+        }
+    }
+
+    static const RowShape {
+        construct(RowVec row) {
+            this.row = row;
+        }
+
+        private RowVec row;
+
+        Int size.get() {
+            return boundOf(row);
+        }
+
+        @Op("[]")
+        Cell getElement(Int index) {
+            return at(row, index);
+        }
+
+        Any? value(Int index) {
+            return getElement(index)[0];
+        }
+
+        ColumnMeta meta(Int index) {
+            return getElement(index)[1]();
+        }
+    }
+
+    static const CursorShape {
+        construct(Cursor cursor) {
+            this.cursor = cursor;
+        }
+
+        private Cursor cursor;
+
+        Int size.get() {
+            return boundOf(cursor);
+        }
+
+        @Op("[]")
+        RowShape getElement(Int index) {
+            return new RowShape(at(cursor, index));
+        }
+    }
+
+    static const ConfixShape {
+        construct(ConfixIndex index) {
+            this.index = index;
+        }
+
+        private ConfixIndex index;
+
+        @Op("[]")
+        Any? getElement(ConfixFacet facet) {
+            return at(index, facet);
+        }
+    }
+
+    static RowBuilder rowBuilder() {
+        return new RowBuilder();
+    }
+
+    static Boolean recognize(Syntax syntax, Byte first) {
+        Char ch = first.toInt().toChar();
+
+        return switch (syntax) {
+            case JSON: ch == '{' || ch == '[' || ch == '"';
+            case CBOR: True;
+            case YAML: ch != '{' && ch != '[';
+        };
+    }
+
+    static Cursor dispatch(Byte[] bytes) {
+        Byte first = bytes[0];
+
+        // Preserve the Kotlin enum ordering: JSON, then CBOR, then YAML.
+        if (recognize(JSON, first)) {
+            return scan(JSON, bytes);
+        }
+
+        if (recognize(CBOR, first)) {
+            return scan(CBOR, bytes);
+        }
+
+        return scan(YAML, bytes);
+    }
+
+    static Cursor scan(Syntax syntax, Byte[] bytes) {
+        return treeCursorOf(syntax == CBOR
+                ? scanCbor(bytes)
+                : scan0(bytes.unpackUtf8()));
+    }
+
+    static CharStr decodeText(CharStr src, Int open, Int close) {
+        Char first = src[open];
+        Char last  = src[close];
+
+        if (first == '"' && last == '"' && close > open + 1) {
+            return textOf(src[open + 1 ..< close]);
+        }
+
+        return textOf(src[open .. close]);
+    }
+
+    static Any? decodeValue(CharStr src, Int open, Int close, IOMemento tag) {
+        return switch (tag) {
+            case IoString:  decodeText(src, open, close);
+            case IoBoolean: src[open] == 't';
+            case IoNothing: Null;
+            case IoDouble:  decodeText(src, open, close);
+            default:        Null;
+        };
+    }
+
+    static ConfixIndex scan0(Byte[] bytes) {
+        return scan0(bytes.unpackUtf8());
+    }
+
+    static ConfixIndex scan0(String src) {
+        Int n = src.size;
+
+        Int[]       opens  = [];
+        Int[]       closes = [];
+        IOMemento[] tags   = [];
+        Pending[]   stack  = [];
+
+        void add(Int open, Int close, IOMemento tag) {
+            opens  += open;
+            closes += close;
+            tags   += tag;
+        }
+
+        void push(Int open, IOMemento tag) {
+            stack += joinOf(open, tag);
+        }
+
+        void pop(Int close) {
+            if (!stack.empty) {
+                Pending pending = stack[stack.size - 1];
+                stack.delete(stack.size - 1);
+                add(pending[0], close, pending[1]);
+            }
+        }
+
+        Boolean inQuote = False;
+        Boolean escaped = False;
+        Int     index   = 0;
+
+        while (index < n) {
+            Char ch = src[index];
+
+            if (inQuote) {
+                if (escaped) {
+                    escaped = False;
+                    if (ch == '"') {
+                        inQuote = False;
+                        pop(index);
+                    }
+                } else if (ch == '\\') {
+                    escaped = True;
+                } else if (ch == '"') {
+                    inQuote = False;
+                    pop(index);
+                }
+            } else {
+                switch (ch) {
+                case '{':
+                    push(index, IoObject);
+                    break;
+
+                case '[':
+                    push(index, IoArray);
+                    break;
+
+                case '}':
+                case ']':
+                    pop(index);
+                    break;
+
+                case '"':
+                    push(index, IoString);
+                    inQuote = True;
+                    break;
+
+                case 't':
+                    if (index + 3 < n &&
+                            src[index + 1] == 'r' &&
+                            src[index + 2] == 'u' &&
+                            src[index + 3] == 'e') {
+                        add(index, index + 3, IoBoolean);
+                        index += 3;
+                    }
+                    break;
+
+                case 'f':
+                    if (index + 4 < n &&
+                            src[index + 1] == 'a' &&
+                            src[index + 2] == 'l' &&
+                            src[index + 3] == 's' &&
+                            src[index + 4] == 'e') {
+                        add(index, index + 4, IoBoolean);
+                        index += 4;
+                    }
+                    break;
+
+                case 'n':
+                    if (index + 3 < n &&
+                            src[index + 1] == 'u' &&
+                            src[index + 2] == 'l' &&
+                            src[index + 3] == 'l') {
+                        add(index, index + 3, IoNothing);
+                        index += 3;
+                    }
+                    break;
+
+                case '-':
+                case '+':
+                case '0'..'9':
+                    Int start = index;
+                    while (index < n) {
+                        Char digit = src[index];
+                        if (!('0' <= digit <= '9') &&
+                                digit != '.' &&
+                                digit != 'e' &&
+                                digit != 'E' &&
+                                digit != '+' &&
+                                digit != '-') {
+                            break;
+                        }
+                        ++index;
+                    }
+                    add(start, index - 1, IoDouble);
+                    continue;
+                }
+            }
+
+            ++index;
+        }
+
+        while (!stack.empty) {
+            Pending pending = stack[stack.size - 1];
+            stack.delete(stack.size - 1);
+            add(pending[0], n - 1, pending[1]);
+        }
+
+        return buildTree(opens, closes, tags, src);
+    }
+
+    static ConfixIndex scanCbor(Byte[] src) {
+        Int n = src.size;
+
+        Int[]       opens  = [];
+        Int[]       closes = [];
+        IOMemento[] tags   = [];
+
+        void add(Int open, Int close, IOMemento tag) {
+            opens  += open;
+            closes += close;
+            tags   += tag;
+        }
+
+        (Int len, Int nextPos) readLen(Int pos, Int ai) {
+            switch (ai) {
+            case 0..23:
+                return ai, pos;
+
+            case 24:
+                return src[pos].toInt() & 0xFF, pos + 1;
+
+            case 25:
+                return ((src[pos    ].toInt() & 0xFF) << 8) |
+                        (src[pos + 1].toInt() & 0xFF), pos + 2;
+
+            case 26:
+                return ((src[pos    ].toInt() & 0xFF) << 24) |
+                       ((src[pos + 1].toInt() & 0xFF) << 16) |
+                       ((src[pos + 2].toInt() & 0xFF) <<  8) |
+                        (src[pos + 3].toInt() & 0xFF), pos + 4;
+
+            case 27:
+                Int len = 0;
+                for (Int i = 0; i < 8; ++i) {
+                    len = (len << 8) | (src[pos + i].toInt() & 0xFF);
+                }
+                return len, pos + 8;
+
+            case 31:
+                return -1, pos;
+
+            default:
+                assert as $"unsupported cbor additional-info {ai}";
+            }
+        }
+
+        Int parseItem(Int pos) {
+            Int open = pos;
+            Int info = src[pos].toInt() & 0xFF;
+            Int mt   = info >> 5;
+            Int ai   = info & 0x1F;
+            Int next = pos + 1;
+
+            switch (mt) {
+            case 0, 1:
+                (Int _, Int end) = readLen(next, ai);
+                add(open, end - 1, IoDouble);
+                return end;
+
+            case 2:
+                (Int len, Int end) = readLen(next, ai);
+                if (len >= 0) {
+                    add(open, end + len - 1, IoBytes);
+                    return end + len;
+                }
+                return end;
+
+            case 3:
+                (Int len, Int end) = readLen(next, ai);
+                if (len >= 0) {
+                    add(open, end + len - 1, IoString);
+                    return end + len;
+                }
+                return end;
+
+            case 4:
+                (Int len, Int end) = readLen(next, ai);
+                Int cursor = end;
+                if (len < 0) {
+                    while (cursor < n && (src[cursor].toInt() & 0xFF) != 0xFF) {
+                        cursor = parseItem(cursor);
+                    }
+                    if (cursor < n) {
+                        ++cursor;
+                    }
+                } else {
+                    for (Int i = 0; i < len; ++i) {
+                        cursor = parseItem(cursor);
+                    }
+                }
+                add(open, cursor - 1, IoArray);
+                return cursor;
+
+            case 5:
+                (Int len, Int end) = readLen(next, ai);
+                Int cursor = end;
+                if (len < 0) {
+                    while (cursor < n && (src[cursor].toInt() & 0xFF) != 0xFF) {
+                        cursor = parseItem(cursor);
+                        cursor = parseItem(cursor);
+                    }
+                    if (cursor < n) {
+                        ++cursor;
+                    }
+                } else {
+                    for (Int i = 0; i < len; ++i) {
+                        cursor = parseItem(cursor);
+                        cursor = parseItem(cursor);
+                    }
+                }
+                add(open, cursor - 1, IoObject);
+                return cursor;
+
+            case 6:
+                (Int _, Int end) = readLen(next, ai);
+                return parseItem(end);
+
+            case 7:
+                IOMemento tag = switch (ai) {
+                    case 20, 21: IoBoolean;
+                    case 22, 23: IoNothing;
+                    case 25, 26, 27: IoDouble;
+                    default: IoNothing;
+                };
+
+                Int size = switch (ai) {
+                    case 24: 1;
+                    case 25: 2;
+                    case 26: 4;
+                    case 27: 8;
+                    default: 0;
+                };
+
+                add(open, open + size, tag);
+                return next + size;
+
+            default:
+                add(open, open, IoNothing);
+                return next;
+            }
+        }
+
+        Int pos = 0;
+        while (pos < n) {
+            pos = parseItem(pos);
+        }
+
+        return buildTree(opens, closes, tags, src);
+    }
+
+    static ConfixIndex buildTree(Int[] opens, Int[] closes, IOMemento[] rawTags, String src) {
+        Int total = opens.size;
+
+        Twin<Int>[] spansArray = new Twin<Int>[total](i -> twinOf(opens[total - 1 - i], closes[total - 1 - i]));
+        IOMemento[] tagArray   = new IOMemento[total](i -> rawTags[total - 1 - i]);
+        Int[]       depthArray = new Int[total];
+
+        for (Int i = 0; i < total; ++i) {
+            Int depth = 0;
+            Int open  = spansArray[i][0];
+            Int close = spansArray[i][1];
+
+            for (Int k = 0; k < total; ++k) {
+                if (k != i &&
+                        spansArray[k][0] < open &&
+                        spansArray[k][1] > close) {
+                    ++depth;
+                }
+            }
+
+            depthArray[i] = depth;
+        }
+
+        Series<Twin<Int>> spanSeries  = seriesFrom(spansArray);
+        Series<IOMemento> tagSeries   = seriesFrom(tagArray);
+        Series<Int>       depthSeries = seriesFrom(depthArray);
+
+        function Series<Int>(Int) childOf = index -> {
+            Int parentOpen  = spansArray[index][0];
+            Int parentClose = spansArray[index][1];
+            Int childDepth  = depthArray[index] + 1;
+            Int[] children  = [];
+
+            for (Int k = 0; k < total; ++k) {
+                if (k != index &&
+                        spansArray[k][0] > parentOpen &&
+                        spansArray[k][1] < parentClose &&
+                        depthArray[k] == childDepth) {
+                    children += k;
+                }
+            }
+
+            return seriesFrom(children);
+        };
+
+        RowVec?[] cache = new RowVec?[total](_ -> Null);
+
+        RowVec row(Int index) {
+            if (RowVec built := cache[index]) {
+                return built;
+            }
+
+            Series<Int> children = childOf(index);
+            RowVec[] childRows   = new RowVec[boundOf(children)](i -> row(at(children, i)));
+            Cursor   cursor      = cursorOf(childRows);
+            Twin<Int> span       = spansArray[index];
+            IOMemento tag        = tagArray[index];
+
+            RowVec value = (rowBuilder()
+                    + cellOf(span[0], "open",     IoInt)
+                    + cellOf(span[1], "close",    IoInt)
+                    + cellOf(tag,     "tag",      IoObject)
+                    + cellOf(cursor,  "children", IoObject))
+                    .build();
+
+            cache[index] = value;
+            return value;
+        }
+
+        Int[] roots = [];
+        for (Int i = 0; i < total; ++i) {
+            if (depthArray[i] == 0) {
+                roots += i;
+            }
+        }
+
+        Cursor treeCursor = cursorOf(new RowVec[roots.size](i -> row(roots[i])));
+
+        KeyLookup keyToChild = key -> {
+            for (Int i = 0; i < total; ++i) {
+                Int open  = spansArray[i][0];
+                Int close = spansArray[i][1];
+
+                if (open >= src.size || src[open] != '"') {
+                    continue;
+                }
+
+                if (close - open - 1 != key.size) {
+                    continue;
+                }
+
+                Boolean match = True;
+                for (Int d = 0; d < key.size; ++d) {
+                    if (src[open + 1 + d] != key[d]) {
+                        match = False;
+                        break;
+                    }
+                }
+
+                if (match) {
+                    return i;
+                }
+            }
+
+            return Null;
+        };
+
+        return metaSeriesOf(ConfixFacet.Spans, facet -> switch (facet) {
+            case Spans:          spanSeries;
+            case Tags:           tagSeries;
+            case Depths:         depthSeries;
+            case DirectChildren: childOf;
+            case TreeCursor:     treeCursor;
+            case KeyToChild:     keyToChild;
+        });
+    }
+
+    static ConfixIndex buildTree(Int[] opens, Int[] closes, IOMemento[] rawTags, Byte[] src) {
+        Int total = opens.size;
+
+        Twin<Int>[] spansArray = new Twin<Int>[total](i -> twinOf(opens[total - 1 - i], closes[total - 1 - i]));
+        IOMemento[] tagArray   = new IOMemento[total](i -> rawTags[total - 1 - i]);
+        Int[]       depthArray = new Int[total];
+
+        for (Int i = 0; i < total; ++i) {
+            Int depth = 0;
+            Int open  = spansArray[i][0];
+            Int close = spansArray[i][1];
+
+            for (Int k = 0; k < total; ++k) {
+                if (k != i &&
+                        spansArray[k][0] < open &&
+                        spansArray[k][1] > close) {
+                    ++depth;
+                }
+            }
+
+            depthArray[i] = depth;
+        }
+
+        Series<Twin<Int>> spanSeries  = seriesFrom(spansArray);
+        Series<IOMemento> tagSeries   = seriesFrom(tagArray);
+        Series<Int>       depthSeries = seriesFrom(depthArray);
+
+        function Series<Int>(Int) childOf = index -> {
+            Int parentOpen  = spansArray[index][0];
+            Int parentClose = spansArray[index][1];
+            Int childDepth  = depthArray[index] + 1;
+            Int[] children  = [];
+
+            for (Int k = 0; k < total; ++k) {
+                if (k != index &&
+                        spansArray[k][0] > parentOpen &&
+                        spansArray[k][1] < parentClose &&
+                        depthArray[k] == childDepth) {
+                    children += k;
+                }
+            }
+
+            return seriesFrom(children);
+        };
+
+        RowVec?[] cache = new RowVec?[total](_ -> Null);
+
+        RowVec row(Int index) {
+            if (RowVec built := cache[index]) {
+                return built;
+            }
+
+            Series<Int> children = childOf(index);
+            RowVec[] childRows   = new RowVec[boundOf(children)](i -> row(at(children, i)));
+            Cursor   cursor      = cursorOf(childRows);
+            Twin<Int> span       = spansArray[index];
+            IOMemento tag        = tagArray[index];
+
+            RowVec value = (rowBuilder()
+                    + cellOf(span[0], "open",     IoInt)
+                    + cellOf(span[1], "close",    IoInt)
+                    + cellOf(tag,     "tag",      IoObject)
+                    + cellOf(cursor,  "children", IoObject))
+                    .build();
+
+            cache[index] = value;
+            return value;
+        }
+
+        Int[] roots = [];
+        for (Int i = 0; i < total; ++i) {
+            if (depthArray[i] == 0) {
+                roots += i;
+            }
+        }
+
+        Cursor treeCursor = cursorOf(new RowVec[roots.size](i -> row(roots[i])));
+
+        KeyLookup keyToChild = key -> {
+            for (Int i = 0; i < total; ++i) {
+                Int open = spansArray[i][0];
+
+                if (((src[open].toInt() & 0xFF) >> 5) != 3) {
+                    continue;
+                }
+
+                Int info = src[open].toInt() & 0xFF;
+                Int ai   = info & 0x1F;
+                (Int len, Int start) = switch (ai) {
+                    case 0..23:
+                        (ai, open + 1);
+
+                    case 24:
+                        (src[open + 1].toInt() & 0xFF, open + 2);
+
+                    default:
+                        (-1, open + 1);
+                };
+
+                if (len != key.size) {
+                    continue;
+                }
+
+                Boolean match = True;
+                for (Int d = 0; d < len; ++d) {
+                    if (src[start + d].toInt().toChar() != key[d]) {
+                        match = False;
+                        break;
+                    }
+                }
+
+                if (match) {
+                    return i;
+                }
+            }
+
+            return Null;
+        };
+
+        return metaSeriesOf(ConfixFacet.Spans, facet -> switch (facet) {
+            case Spans:          spanSeries;
+            case Tags:           tagSeries;
+            case Depths:         depthSeries;
+            case DirectChildren: childOf;
+            case TreeCursor:     treeCursor;
+            case KeyToChild:     keyToChild;
+        });
+    }
+
+    static Series<Twin<Int>> spansOf(ConfixIndex index) {
+        return at(index, Spans).as(Series<Twin<Int>>);
+    }
+
+    static Series<IOMemento> tagsOf(ConfixIndex index) {
+        return at(index, Tags).as(Series<IOMemento>);
+    }
+
+    static Series<Int> depthsOf(ConfixIndex index) {
+        return at(index, Depths).as(Series<Int>);
+    }
+
+    static function Series<Int>(Int) directChildrenOf(ConfixIndex index) {
+        return at(index, DirectChildren).as(function Series<Int>(Int));
+    }
+
+    static Cursor treeCursorOf(ConfixIndex index) {
+        return at(index, TreeCursor).as(Cursor);
+    }
+
+    static KeyLookup keyLookupOf(ConfixIndex index) {
+        return at(index, KeyToChild).as(KeyLookup);
+    }
+
+    void testRecognize() {
+        assert recognize(JSON, '{'.toByte());
+        assert recognize(JSON, '['.toByte());
+        assert recognize(JSON, '"'.toByte());
+        assert !recognize(JSON, 'a'.toByte());
+
+        assert recognize(YAML, 'a'.toByte());
+        assert recognize(YAML, '-'.toByte());
+        assert !recognize(YAML, '{'.toByte());
+
+        assert recognize(CBOR, 0x00.toByte());
+        assert recognize(CBOR, 0xFF.toByte());
+    }
+
+    void testDecode() {
+        assert decodeText("\"hello\"", 0, 6) == "hello";
+        assert decodeText("hello", 0, 4) == "hello";
+        assert decodeValue("\"hello\"", 0, 6, IoString) == "hello";
+        assert decodeValue("true", 0, 3, IoBoolean) == True;
+        assert decodeValue("null", 0, 3, IoNothing) == Null;
+        assert decodeValue("42", 0, 1, IoDouble) == "42";
+    }
+
+    void testJsonIndex() {
+        ConfixIndex index  = scan0("42");
+        Series<Twin<Int>> spans = spansOf(index);
+        Series<IOMemento> tags  = tagsOf(index);
+        Series<Int>       depth = depthsOf(index);
+
+        assert boundOf(spans) == 1;
+        assert at(spans, 0) == twinOf(0, 1);
+        assert at(tags , 0) == IoDouble;
+        assert at(depth, 0) == 0;
+
+        ConfixIndex objectIndex = scan0("{\"key\":\"val\"}");
+        assert boundOf(spansOf(objectIndex)) == 3;
+        assert at(tagsOf(objectIndex), 0) == IoObject;
+
+        Int? child = keyLookupOf(objectIndex)("key");
+        assert child != Null;
+    }
+
+    void testJsonTree() {
+        ConfixIndex index = scan0("[1,2]");
+        CursorShape tree  = new CursorShape(treeCursorOf(index));
+
+        assert tree.size == 1;
+
+        RowShape root = tree[0];
+        assert root.value(0) == 0;
+        assert root.value(2) == IoArray;
+
+        CursorShape children = new CursorShape(root.value(3).as(Cursor));
+        assert children.size == 2;
+        assert children[0].value(2) == IoDouble;
+        assert children[1].value(2) == IoDouble;
+
+        ConfixIndex nested = scan0("{\"x\":1,\"y\":2}");
+        Series<Int> direct = directChildrenOf(nested)(0);
+        assert boundOf(direct) == 4;
+    }
+
+    void testDispatch() {
+        assert boundOf(dispatch("42".utf8())) >= 0;
+        assert boundOf(dispatch("key: value\n".utf8())) >= 0;
+    }
+
+    void testCborIndex() {
+        Byte[] ints = [0x83.toByte(), 0x01.toByte(), 0x02.toByte(), 0x03.toByte()];
+        ConfixIndex arrayIndex = scanCbor(ints);
+        CursorShape arrayTree  = new CursorShape(treeCursorOf(arrayIndex));
+
+        assert arrayTree.size == 1;
+        assert arrayTree[0].value(2) == IoArray;
+        assert new CursorShape(arrayTree[0].value(3).as(Cursor)).size == 3;
+
+        Byte[] map = [
+            0xA1.toByte(),
+            0x65.toByte(),
+            0x68.toByte(),
+            0x65.toByte(),
+            0x6C.toByte(),
+            0x6C.toByte(),
+            0x6F.toByte(),
+            0x01.toByte(),
+        ];
+
+        ConfixIndex mapIndex = scanCbor(map);
+        Int? child = keyLookupOf(mapIndex)("hello");
+        assert child != Null;
+        assert keyLookupOf(mapIndex)("world") == Null;
+    }
+}

--- a/manualTests/src/main/x/typedefs.x
+++ b/manualTests/src/main/x/typedefs.x
@@ -1,0 +1,407 @@
+module TestTypedefs {
+    @Inject ecstasy.io.Console console;
+
+    typedef Join<A, B> as Tuple<A, B>;
+    typedef Twin<T> as Join<T, T>;
+    typedef MetaSeries<I, T> as Join<I, function T(I)>;
+    typedef Series<T> as MetaSeries<Int, T>;
+    typedef Series2<A, B> as Series<Join<A, B>>;
+
+    typedef Join<String, String> as ColumnMeta;
+    typedef function ColumnMeta() as ColumnMetaRef;
+    typedef Join<Any?, ColumnMetaRef> as Cell;
+    typedef function Cell(Any?) as CellFactory;
+    typedef Series<Cell> as RowVec;
+    typedef function RowVec(Any?, Any?) as RowFactory;
+    typedef Series<RowVec> as Cursor;
+
+    typedef Series<Char> as CharStr;
+    typedef Series<CharStr> as Corpus;
+    typedef MetaSeries<ElementState, Set<ElementState>> as LifecycleFSM;
+
+    enum ElementState {Created, Open, Active, Draining, Closed}
+
+    static <A, B> Join<A, B> joinOf(A left, B right) {
+        return (left, right);
+    }
+
+    static <T> Twin<T> twinOf(T left, T right) {
+        return joinOf(left, right);
+    }
+
+    static ColumnMeta metaOf(String name, String type) {
+        return joinOf(name, type);
+    }
+
+    static ColumnMetaRef metaRefOf(String name, String type) {
+        return () -> metaOf(name, type);
+    }
+
+    static <I, T> MetaSeries<I, T> metaSeriesOf(I bound, function T(I) indexer) {
+        return joinOf(bound, indexer);
+    }
+
+    static <T> Series<T> seriesOf(Int size, function T(Int) indexer) {
+        return metaSeriesOf(size, indexer);
+    }
+
+    static Cell cellOf(Any? value, ColumnMetaRef meta) {
+        return joinOf(value, meta);
+    }
+
+    static CellFactory cellFactoryOf(String name, String type) {
+        ColumnMetaRef meta = metaRefOf(name, type);
+        return value -> cellOf(value, meta);
+    }
+
+    static RowFactory rowFactoryOf(CellFactory first, CellFactory second) {
+        return (left, right) -> (rowBuilder() + first(left) + second(right)).build();
+    }
+
+    static RowVec rowOf(Int width, function Cell(Int) cells) {
+        return seriesOf(width, cells);
+    }
+
+    static Cursor cursorOf(Int height, function RowVec(Int) rows) {
+        return seriesOf(height, rows);
+    }
+
+    static RowBuilder rowBuilder() {
+        return new RowBuilder();
+    }
+
+    static CursorBuilder cursorBuilder() {
+        return new CursorBuilder();
+    }
+
+    static CharStr textOf(String text) {
+        return seriesOf(text.size, i -> text[i]);
+    }
+
+    static Corpus corpusOf(Int lines, function CharStr(Int) rows) {
+        return seriesOf(lines, rows);
+    }
+
+    static LifecycleFSM lifecycleOf(ElementState start, function Set<ElementState>(ElementState) next) {
+        return metaSeriesOf(start, next);
+    }
+
+    static <I, T> I boundOf(MetaSeries<I, T> series) {
+        return series[0];
+    }
+
+    static <I, T> T at(MetaSeries<I, T> series, I index) {
+        return series[1](index);
+    }
+
+    static <I, T, U> MetaSeries<I, U> mapSeries(MetaSeries<I, T> series, function U(T) mapper) {
+        return metaSeriesOf(boundOf(series), i -> mapper(at(series, i)));
+    }
+
+    static RowShape rowViewOf(RowVec row) {
+        return new RowShape(row);
+    }
+
+    static CursorShape cursorViewOf(Cursor cursor) {
+        return new CursorShape(cursor);
+    }
+
+    static TextShape textViewOf(CharStr text) {
+        return new TextShape(text);
+    }
+
+    static const RowBuilder(Cell[] cells = []) {
+        @Op("+")
+        RowBuilder add(Cell cell) {
+            return new RowBuilder(cells.add(cell));
+        }
+
+        RowBuilder addVia(CellFactory factory, Any? value) {
+            return add(factory(value));
+        }
+
+        RowBuilder add(String name, String type, Any? value) {
+            return addVia(cellFactoryOf(name, type), value);
+        }
+
+        RowVec build() {
+            return rowOf(cells.size, i -> cells[i]);
+        }
+    }
+
+    static const CursorBuilder(RowVec[] rows = []) {
+        @Op("+")
+        CursorBuilder add(RowVec row) {
+            return new CursorBuilder(rows.add(row));
+        }
+
+        Cursor build() {
+            return cursorOf(rows.size, i -> rows[i]);
+        }
+    }
+
+    static const RowShape(RowVec row) {
+        Int size.get() = boundOf(row);
+
+        @Op("[]")
+        Cell getElement(Int index) {
+            return at(row, index);
+        }
+
+        Any? value(Int index) {
+            return getElement(index)[0];
+        }
+
+        ColumnMeta meta(Int index) {
+            return getElement(index)[1]();
+        }
+    }
+
+    static const CursorShape(Cursor cursor) {
+        Int size.get() = boundOf(cursor);
+
+        @Op("[]")
+        RowShape getElement(Int index) {
+            return rowViewOf(at(cursor, index));
+        }
+    }
+
+    static const TextShape(CharStr text) {
+        Int size.get() = boundOf(text);
+
+        @Op("[]")
+        Char getElement(Int index) {
+            return at(text, index);
+        }
+    }
+
+    static const Shapes() {
+        static <A, B> Join<A, B> join(A left, B right) {
+            return joinOf(left, right);
+        }
+
+        static <T> Series<T> series(Int size, function T(Int) indexer) {
+            return seriesOf(size, indexer);
+        }
+
+        static Cell cell(Any? value, ColumnMetaRef meta) {
+            return cellOf(value, meta);
+        }
+
+        static CellFactory cellFactory(String name, String type) {
+            return cellFactoryOf(name, type);
+        }
+
+        static RowFactory rowFactory(CellFactory first, CellFactory second) {
+            return rowFactoryOf(first, second);
+        }
+
+        static RowVec row(Int width, function Cell(Int) cells) {
+            return rowOf(width, cells);
+        }
+
+        static Cursor cursor(Int height, function RowVec(Int) rows) {
+            return cursorOf(height, rows);
+        }
+
+        static RowBuilder rowBuilder() {
+            return new RowBuilder();
+        }
+
+        static CursorBuilder cursorBuilder() {
+            return new CursorBuilder();
+        }
+
+        static CharStr text(String value) {
+            return textOf(value);
+        }
+
+        static RowShape rowView(RowVec row) {
+            return rowViewOf(row);
+        }
+
+        static CursorShape cursorView(Cursor cursor) {
+            return cursorViewOf(cursor);
+        }
+
+        static TextShape textView(CharStr text) {
+            return textViewOf(text);
+        }
+
+        static <I, T, U> MetaSeries<I, U> map(MetaSeries<I, T> source, function U(T) mapper) {
+            return mapSeries(source, mapper);
+        }
+    }
+
+    void run() {
+        console.print("RFC-1 typedef proof");
+
+        testJoin();
+        testFactories();
+        testInference();
+        testBuilders();
+        testComposition();
+        testShapesWrapper();
+        testLifecycle();
+    }
+
+    void testJoin() {
+        Join<String, Int> pair = ("age", 42);
+        assert pair[0] == "age";
+        assert pair[1] == 42;
+
+        Twin<Int> twin = twinOf(3, 5);
+        assert twin[0] == 3;
+        assert twin[1] == 5;
+    }
+
+    void testFactories() {
+        val names = seriesOf(3, i -> i == 0
+                ? "alpha"
+                : i == 1
+                        ? "beta"
+                        : "gamma");
+        assert boundOf(names) == 3;
+        assert at(names, 0) == "alpha";
+        assert at(names, 2) == "gamma";
+
+        val pairs = seriesOf(2, i -> i == 0
+                ? joinOf("x", 1)
+                : joinOf("y", 2));
+        assert boundOf(pairs) == 2;
+
+        Join<String, Int> second = at(pairs, 1);
+        assert second[0] == "y";
+        assert second[1] == 2;
+
+        ColumnMetaRef idMeta   = metaRefOf("id", "Int");
+        ColumnMetaRef nameMeta = metaRefOf("name", "String");
+        val           row      = rowOf(2, i -> i == 0
+                ? cellOf("42", idMeta)
+                : cellOf("bob", nameMeta));
+        val cursor = cursorOf(1, _ -> row);
+        val hello  = textOf("hello");
+
+        assert boundOf(row) == 2;
+        assert boundOf(cursor) == 1;
+        assert boundOf(hello) == 5;
+        assert at(hello, 1) == 'e';
+
+        Cell       cell0 = at(row, 0);
+        ColumnMeta meta0 = cell0[1]();
+        assert cell0[0] == "42";
+        assert meta0[0] == "id";
+        assert meta0[1] == "Int";
+
+        RowVec     firstRow = at(cursor, 0);
+        Cell       cell1    = at(firstRow, 1);
+        ColumnMeta meta1    = cell1[1]();
+        assert cell1[0] == "bob";
+        assert meta1[0] == "name";
+        assert meta1[1] == "String";
+    }
+
+    void testInference() {
+        val id      = cellFactoryOf("id", "Int");
+        val name    = cellFactoryOf("name", "String");
+        val makeRow = rowFactoryOf(id, name);
+        val row     = makeRow("42", "bob");
+        val cursor  = (cursorBuilder() + row).build();
+
+        assert boundOf(row) == 2;
+        assert boundOf(cursor) == 1;
+        assert at(at(cursor, 0), 0)[0] == "42";
+        assert at(at(cursor, 0), 1)[1]()[0] == "name";
+    }
+
+    void testBuilders() {
+        val id   = cellFactoryOf("id", "Int");
+        val name = cellFactoryOf("name", "String");
+
+        val first  = (rowBuilder() + id("7") + name("eve")).build();
+        val second = rowBuilder()
+                .addVia(id, "8")
+                .addVia(name, "ada")
+                .build();
+        val cursor = (cursorBuilder() + first + second).build();
+
+        assert boundOf(cursor) == 2;
+        assert at(at(cursor, 0), 0)[0] == "7";
+        assert at(at(cursor, 1), 1)[0] == "ada";
+    }
+
+    void testComposition() {
+        val lines = corpusOf(2, i -> i == 0
+                ? textOf("alpha")
+                : textOf("pi"));
+        val lengths = mapSeries(lines, line -> boundOf(line));
+
+        assert boundOf(lengths) == 2;
+        assert at(lengths, 0) == 5;
+        assert at(lengths, 1) == 2;
+
+        ColumnMetaRef labelMeta = metaRefOf("label", "String");
+        val cursor = cursorOf(2, i -> i == 0
+                ? rowOf(1, _ -> cellOf("solo", labelMeta))
+                : rowOf(2, j -> j == 0
+                        ? cellOf("7", metaRefOf("id", "Int"))
+                        : cellOf("eve", metaRefOf("name", "String"))));
+        val widths = mapSeries(cursor, row -> boundOf(row));
+
+        assert boundOf(widths) == 2;
+        assert at(widths, 0) == 1;
+        assert at(widths, 1) == 2;
+    }
+
+    void testShapesWrapper() {
+        val id      = Shapes.cellFactory("id", "Int");
+        val name    = Shapes.cellFactory("name", "String");
+        val makeRow = Shapes.rowFactory(id, name);
+        val rows    = Shapes.cursorView((Shapes.cursorBuilder()
+                + makeRow("42", "bob")
+                + makeRow("7", "eve"))
+                .build());
+
+        assert rows.size == 2;
+        assert rows[0].value(0) == "42";
+        ColumnMeta meta = rows[1].meta(1);
+        assert meta[0] == "name";
+        assert meta[1] == "String";
+
+        val words = Shapes.series(2, i -> i == 0
+                ? Shapes.text("oak")
+                : Shapes.text("elm"));
+        val wordLengths = Shapes.map(words, word -> boundOf(word));
+        val text        = Shapes.textView(Shapes.text("elm"));
+
+        assert boundOf(wordLengths) == 2;
+        assert at(wordLengths, 0) == 3;
+        assert at(wordLengths, 1) == 3;
+        assert text[1] == 'l';
+    }
+
+    void testLifecycle() {
+        LifecycleFSM lifecycle = lifecycleOf(ElementState.Created, state -> {
+            switch (state) {
+            case Created:
+                return Set:[ElementState.Open];
+
+            case Open:
+                return Set:[ElementState.Active, ElementState.Draining];
+
+            case Active:
+                return Set:[ElementState.Draining];
+
+            case Draining:
+                return Set:[ElementState.Closed];
+
+            case Closed:
+                return Set:[ElementState.Closed];
+            }
+        });
+
+        assert boundOf(lifecycle) == ElementState.Created;
+        assert at(lifecycle, ElementState.Open) == Set:[ElementState.Active, ElementState.Draining];
+        assert at(lifecycle, ElementState.Draining) == Set:[ElementState.Closed];
+    }
+}


### PR DESCRIPTION
this reaches typedef parity with kotlin while .x Mixins operate by name -- effectively giving each typealias an identity-free  vtable and hoisting by duck-typing cast.

nexus of inheritance, generics, and typedef sites formerly not laced up together 

Ducktyping and resolution favors non-parameterized original code when  parameter count == 0 