### PR TITLE
Fix generated libs.versions.toml pinning a non-resolvable timestamped xtc version

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -147,6 +147,17 @@ jobs:
                   filters: |
                       lang:
                         - 'lang/**'
+                        # Sources that live OUTSIDE lang/ but are synced or bundled INTO the
+                        # lang plugin at build time, so a change to any of them changes the
+                        # plugin's output and must trigger a lang build/test (and, on master,
+                        # an IntelliJ plugin republish). Keep this list in sync with
+                        # lang/intellij-plugin/build.gradle.kts (syncXtcProjectCreator copies
+                        # the Java source; syncGradleWrapperResources bundles the wrapper that
+                        # generated projects ship with).
+                        - 'javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java'
+                        - 'gradlew'
+                        - 'gradlew.bat'
+                        - 'gradle/wrapper/**'
 
             - name: 🌳 Lang validation decision
               shell: bash

--- a/javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java
+++ b/javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.regex.Pattern;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,10 +30,29 @@ public class XtcProjectCreator {
     public static final String DEFAULT_XTC_VERSION = "0.4.4";
 
     /**
-     * Default Gradle version for generated projects.
-     * Should match the version used by the XVM repository.
+     * Compile-time fallback Gradle version, used only to generate a wrapper from scratch when the
+     * composite build's gradle-wrapper.properties is not bundled as a resource (see
+     * {@link #copyWrapperFromResources()}, which otherwise copies that file verbatim). In normal
+     * IDE/CLI builds the bundled wrapper is the single source of truth, so this constant is rarely
+     * hit; keep it roughly in sync with the repo wrapper anyway.
      */
-    public static final String DEFAULT_GRADLE_VERSION = "9.5.0";
+    public static final String DEFAULT_GRADLE_VERSION = "9.5.1";
+
+    /**
+     * Strict pattern for a resolvable XTC version coordinate written into a generated
+     * {@code gradle/libs.versions.toml}: {@code MAJOR.MINOR.PATCH} with an optional
+     * {@code -SNAPSHOT}, {@code -alpha}, or {@code -beta} qualifier -- and nothing else.
+     *
+     * <p>This deliberately rejects publication build-ids that are <em>not</em> resolvable
+     * Maven/Gradle coordinates, e.g. the JetBrains Marketplace plugin version
+     * {@code 0.4.4-SNAPSHOT.20260526090539} (a UTC upload-uniqueness suffix) or the VS Code
+     * packaging version {@code 0.4.4-alpha.20260523T120000}. A {@code -SNAPSHOT} resolves via
+     * Maven metadata ({@code 0.4.4-SNAPSHOT} maps to {@code 0.4.4-<date>.<time>-<n>}); a literal
+     * {@code .<timestamp>} tail turns the string into a fixed release version that was never
+     * published anywhere, so Gradle cannot resolve it.
+     */
+    public static final Pattern XTC_VERSION_PATTERN =
+        Pattern.compile("\\d+\\.\\d+\\.\\d+(-(SNAPSHOT|alpha|beta))?");
 
     /**
      * Project types supported by the creator.
@@ -123,9 +143,40 @@ public class XtcProjectCreator {
         this.projectPath = projectPath;
         this.type = type;
         this.multiModule = multiModule;
-        this.xtcVersion = xtcVersion != null ? xtcVersion : DEFAULT_XTC_VERSION;
+        this.xtcVersion = sanitizeXtcVersion(xtcVersion);
         this.gradleVersion = gradleVersion != null ? gradleVersion : DEFAULT_GRADLE_VERSION;
         this.useLocalAndSnapshotRepos = useLocalAndSnapshotRepos;
+    }
+
+    /**
+     * @param version a version string, may be null
+     * @return {@code true} iff {@code version} is a resolvable XTC version coordinate
+     *         (see {@link #XTC_VERSION_PATTERN}); {@code false} for null, blank, or any
+     *         string carrying a build/timestamp suffix
+     */
+    public static boolean isValidXtcVersion(String version) {
+        return version != null && XTC_VERSION_PATTERN.matcher(version).matches();
+    }
+
+    /**
+     * Reduce a (possibly decorated) build/publication version to the resolvable XTC
+     * coordinate that belongs in a generated version catalog.
+     *
+     * <p>Publication pipelines append a build suffix for upload uniqueness -- JetBrains
+     * Marketplace uses {@code <base>-SNAPSHOT.<utc>} and VS Code packaging uses
+     * {@code <base>-alpha.<utc>}. Those decorated strings are not resolvable coordinates,
+     * so we keep only the leading {@code MAJOR.MINOR.PATCH[-qualifier]} part. Input with no
+     * valid leading coordinate (null, blank, garbage) falls back to {@link #DEFAULT_XTC_VERSION}.
+     *
+     * @param version the raw version (e.g. the installed plugin's own version), may be null
+     * @return a version guaranteed to satisfy {@link #isValidXtcVersion(String)}
+     */
+    public static String sanitizeXtcVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return DEFAULT_XTC_VERSION;
+        }
+        var matcher = XTC_VERSION_PATTERN.matcher(version.trim());
+        return matcher.lookingAt() ? matcher.group() : DEFAULT_XTC_VERSION;
     }
 
     /**
@@ -255,6 +306,15 @@ public class XtcProjectCreator {
     }
 
     private String generateVersionCatalog() {
+        // Defense in depth: never emit a catalog that pins a non-resolvable version. The
+        // constructor sanitizes xtcVersion, so this invariant should always hold; if it does
+        // not, a future change broke it and we fail loudly here rather than ship a project
+        // that cannot resolve its XTC plugin/XDK.
+        if (!isValidXtcVersion(xtcVersion)) {
+            throw new IllegalStateException(
+                "Refusing to generate version catalog with non-resolvable XTC version: '" + xtcVersion
+                    + "'. Expected MAJOR.MINOR.PATCH optionally followed by -SNAPSHOT, -alpha, or -beta.");
+        }
         return """
             [versions]
             xtc = "%s"
@@ -665,10 +725,19 @@ public class XtcProjectCreator {
             }
         }
 
-        // Generate gradle-wrapper.properties with the specified Gradle version
-        // (don't copy from resources - we need the dynamic version)
+        // Copy gradle-wrapper.properties verbatim from the bundled composite-build wrapper so the
+        // generated project uses exactly the Gradle version the XDK is built and tested with -- a
+        // single source of truth, with no hardcoded version that can drift. Fall back to generating
+        // it only if that specific resource is somehow absent.
         Path wrapperDir = projectPath.resolve("gradle/wrapper");
-        writeFile(wrapperDir.resolve("gradle-wrapper.properties"), generateWrapperProperties());
+        Path wrapperProps = wrapperDir.resolve("gradle-wrapper.properties");
+        try (InputStream in = getClass().getResourceAsStream("/gradle-wrapper/gradle/wrapper/gradle-wrapper.properties")) {
+            if (in != null) {
+                Files.copy(in, wrapperProps, StandardCopyOption.REPLACE_EXISTING);
+            } else {
+                writeFile(wrapperProps, generateWrapperProperties());
+            }
+        }
 
         return true;
     }

--- a/javatools/src/test/java/org/xvm/tool/XtcVersionSanityTest.java
+++ b/javatools/src/test/java/org/xvm/tool/XtcVersionSanityTest.java
@@ -1,0 +1,157 @@
+package org.xvm.tool;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Sanity checks for the versions written into a generated {@code gradle/libs.versions.toml}.
+ *
+ * <p>Regression coverage for the auto-updated IntelliJ/VS Code plugin baking its own
+ * publication build-id (base + UTC timestamp, e.g. {@code 0.4.4-SNAPSHOT.20260526090539})
+ * into the catalog, which is not a resolvable Maven/Gradle coordinate. The catalog must only
+ * ever pin a real XTC version: {@code MAJOR.MINOR.PATCH} optionally with {@code -SNAPSHOT},
+ * {@code -alpha}, or {@code -beta} -- and nothing else. Both the snapshot dependency and a
+ * "real" (released) dependency must work.
+ */
+class XtcVersionSanityTest {
+
+    private static final Pattern CATALOG_XTC_VERSION = Pattern.compile("xtc = \"([^\"]+)\"");
+
+    // ---- version validation: real release AND snapshot are both valid ----
+
+    @Test
+    void acceptsRealReleaseAndSnapshotVersions() {
+        for (var v : new String[] {"0.4.4", "0.4.5", "0.4.5-SNAPSHOT", "0.4.4-SNAPSHOT", "0.4.4-alpha", "0.4.4-beta"}) {
+            assertTrue(XtcProjectCreator.isValidXtcVersion(v), v);
+        }
+    }
+
+    @Test
+    void rejectsTimestampedAndMalformedVersions() {
+        for (var v : new String[] {
+                "0.4.4-SNAPSHOT.20260526090539", // JetBrains Marketplace upload id
+                "0.4.4-alpha.20260523T120000",   // VS Code packaging id
+                "0.4.4-20260529.201252-1",       // Maven unique-snapshot backing version
+                "0.4.4-rc1",
+                "0.4",
+                "",
+                "garbage"}) {
+            assertFalse(XtcProjectCreator.isValidXtcVersion(v), v);
+        }
+        assertFalse(XtcProjectCreator.isValidXtcVersion(null), "null");
+    }
+
+    // ---- sanitization ----
+
+    @Test
+    void stripsPublicationBuildSuffixToResolvableCoordinate() {
+        assertEquals("0.4.4-SNAPSHOT", XtcProjectCreator.sanitizeXtcVersion("0.4.4-SNAPSHOT.20260526090539"));
+        assertEquals("0.4.4-alpha", XtcProjectCreator.sanitizeXtcVersion("0.4.4-alpha.20260523T120000"));
+        assertEquals("0.4.4", XtcProjectCreator.sanitizeXtcVersion("0.4.4-20260529.201252-1"));
+    }
+
+    @Test
+    void leavesRealSnapshotAndReleaseVersionsUntouched() {
+        assertEquals("0.4.4-SNAPSHOT", XtcProjectCreator.sanitizeXtcVersion("0.4.4-SNAPSHOT"));
+        assertEquals("0.4.5", XtcProjectCreator.sanitizeXtcVersion("0.4.5"));
+        assertEquals("0.4.4-alpha", XtcProjectCreator.sanitizeXtcVersion("0.4.4-alpha"));
+    }
+
+    @Test
+    void fallsBackToDefaultForUnusableInput() {
+        for (var v : new String[] {null, "", "   ", "garbage", "not-a-version"}) {
+            assertEquals(XtcProjectCreator.DEFAULT_XTC_VERSION, XtcProjectCreator.sanitizeXtcVersion(v), String.valueOf(v));
+        }
+    }
+
+    @Test
+    void sanitizeIsIdempotentAndAlwaysValid() {
+        // Idempotency is what makes the generated catalog stable across CI reruns / republishes:
+        // no matter how many times a decorated version flows through, the pinned coordinate is the same.
+        for (var v : new String[] {
+                "0.4.4-SNAPSHOT.20260526090539", "0.4.4-alpha.20260523T120000",
+                "0.4.4-20260529.201252-1", "0.4.4-SNAPSHOT", "0.4.5", "garbage", null}) {
+            var once = XtcProjectCreator.sanitizeXtcVersion(v);
+            var twice = XtcProjectCreator.sanitizeXtcVersion(once);
+            assertEquals(once, twice, "sanitize not idempotent for " + v);
+            assertTrue(XtcProjectCreator.isValidXtcVersion(once), "sanitize produced invalid version for " + v);
+        }
+    }
+
+    // ---- generated catalog sanity check (the actual libs.versions.toml) ----
+
+    @Test
+    void generatedCatalogStripsMarketplaceTimestampForSnapshot() throws Exception {
+        var catalog = catalogFor("0.4.4-SNAPSHOT.20260526090539");
+        assertTrue(catalog.contains("xtc = \"0.4.4-SNAPSHOT\""), catalog);
+        assertFalse(catalog.contains("20260526090539"), catalog);
+    }
+
+    @Test
+    void generatedCatalogKeepsRealReleaseVersion() throws Exception {
+        var catalog = catalogFor("0.4.5");
+        assertTrue(catalog.contains("xtc = \"0.4.5\""), catalog);
+    }
+
+    @Test
+    void generatedCatalogNeverPinsNonResolvableVersion() throws Exception {
+        for (var raw : new String[] {
+                "0.4.4-SNAPSHOT.20260526090539", "0.4.4-alpha.20260523T120000",
+                "0.4.4-20260529.201252-1", "0.4.5-SNAPSHOT", "0.4.5", "garbage"}) {
+            var pinned = pinnedXtcVersion(catalogFor(raw));
+            assertNotNull(pinned, "no xtc version pinned for input '" + raw + "'");
+            assertTrue(XtcProjectCreator.isValidXtcVersion(pinned),
+                "catalog pinned non-resolvable version '" + pinned + "' for input '" + raw + "'");
+        }
+    }
+
+    // ---- gradle wrapper sourced verbatim from the composite build (no hardcoded drift) ----
+
+    @Test
+    void generatedWrapperMatchesBundledCompositeWrapper() throws Exception {
+        String bundled;
+        try (var in =
+                XtcProjectCreator.class.getResourceAsStream("/gradle-wrapper/gradle/wrapper/gradle-wrapper.properties")) {
+            assumeTrue(in != null, "bundled gradle-wrapper.properties not on the test classpath");
+            bundled = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        var projectPath = newProjectDir();
+        var result = new XtcProjectCreator(projectPath, XtcProjectCreator.ProjectType.APPLICATION, false).create();
+        assertTrue(result.success(), result.message());
+
+        var generated = Files.readString(projectPath.resolve("gradle/wrapper/gradle-wrapper.properties"));
+        assertEquals(bundled, generated, "generated wrapper must match the composite build's bundled wrapper verbatim");
+    }
+
+    // ---- helpers ----
+
+    private static String catalogFor(String xtcVersion) throws Exception {
+        var projectPath = newProjectDir();
+        var creator =
+            new XtcProjectCreator(projectPath, XtcProjectCreator.ProjectType.APPLICATION, false, xtcVersion, null);
+        var result = creator.create();
+        assertTrue(result.success(), String.valueOf(xtcVersion) + ": " + result.message());
+        return Files.readString(projectPath.resolve("gradle/libs.versions.toml"));
+    }
+
+    /** A fresh, empty project directory with a module-name-safe leaf (no hyphens). */
+    private static Path newProjectDir() throws Exception {
+        return Files.createTempDirectory("xtctest").resolve("app");
+    }
+
+    private static String pinnedXtcVersion(String catalog) {
+        var matcher = CATALOG_XTC_VERSION.matcher(catalog);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+}


### PR DESCRIPTION
## TL;DR

The **generated** `gradle/libs.versions.toml` — the one the XTC project creator
writes into a *new user project*, **not** the composite build's own
`gradle/libs.versions.toml` at the repo root — could pin a non-resolvable XTC
version like `0.4.4-SNAPSHOT.20260526090539`, causing:

```
Plugin [id: 'org.xtclang.xtc-plugin', version: '0.4.4-SNAPSHOT.20260526090539'] was not found ...
org.gradle.api.plugins.UnknownPluginException
```

This was fundamentally a **timing / restart-style publication issue** (the
plugin's auto-updated Marketplace build-id leaking into a Maven coordinate slot),
not a bug in the repo's own version catalog. This PR makes the generator only ever
emit a resolvable coordinate, guards the invariant, adds sanity tests, and removes
a drifting hardcoded Gradle version.

## Which file we are talking about (important)

There are two `libs.versions.toml` files and they are easy to conflate:

1. **The composite build's catalog**: `gradle/libs.versions.toml` at the repo root.
   *This was never wrong.* `xdk.version` is `0.4.4-SNAPSHOT` in `version.properties`
   and the platform publishes Maven artifacts under that base coordinate.
2. **The generated catalog**: produced by
   `javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java`
   (`generateVersionCatalog()` → written by `createVersionCatalog()` into a *new
   user project's* `gradle/libs.versions.toml`). **This is the one that broke.**

`XtcProjectCreator` is shared by the IntelliJ New Project wizard, the `xtc init`
CLI, and the VS Code extension, so a fix here covers all three.

## Root cause: a timing/restart publication issue, not a catalog bug

Two independent, individually-correct facts collided:

1. **The wizard has *always* written the installed plugin's own version into the
   generated catalog.** This is original behavior (since the first lang PR), e.g.:
   ```kotlin
   val xtcVersion = PluginManager.getInstance()
       .findEnabledPlugin(PluginId.getId(PluginPaths.PLUGIN_ID))?.version
       ?: XtcProjectCreator.DEFAULT_XTC_VERSION
   ```
2. **The plugin's *published* version gained a UTC build-id suffix** (PR #428,
   "Refine CI artifact promotion and IntelliJ snapshot publishing"). JetBrains
   Marketplace requires a unique, increasing version for every upload, so snapshot
   plugin builds publish as `0.4.4-SNAPSHOT.<yyyyMMddHHmmss>`:
   ```kotlin
   // lang/intellij-plugin/build.gradle.kts
   "$baseVersion.$suffix"   // 0.4.4-SNAPSHOT.20260526090539
   ```

Before #428 these two strings were identical (`0.4.4-SNAPSHOT`), so copying one into
the other was harmless and "magically worked." #428 deliberately **diverged** them:
the Marketplace identity is now decorated, while the Maven artifact is still
published as plain `0.4.4-SNAPSHOT`.

### Why `-SNAPSHOT` resolves but `-SNAPSHOT.<ts>` does not

This is pure Gradle version-string parsing, independent of what is published:

- `0.4.4-SNAPSHOT` **ends in `-SNAPSHOT`** → Gradle treats it as a changing
  snapshot → reads `maven-metadata.xml` → maps to the newest backing
  `0.4.4-<date>.<time>-<n>` → resolves. (Verified live: the base coordinate, the
  plugin marker, and `org.xtclang:xdk` all return HTTP 200 on Maven Central
  snapshots, backed by a real unique-snapshot version.)
- `0.4.4-SNAPSHOT.20260526090539` **does not end in `-SNAPSHOT`** → Gradle treats it
  as a *fixed release* → never consults metadata → looks for a literal
  `…/0.4.4-SNAPSHOT.20260526090539/` directory that was never published to **any**
  repo → fails everywhere (mavenLocal, snapshots, central, plugin portal). Exactly
  the reported trace.

The Marketplace build-id timestamp and Maven's own snapshot timestamp are different
namespaces; the former must never become an artifact coordinate.

### Why it surfaced "suddenly" and looked like a restart/timing problem

The suffix is wall-clock at **publish** time. The defect has been latent in every
snapshot plugin published since #428 (Apr 14). It only became visible when a user
**auto-updated** to a freshly-republished snapshot whose decorated version then got
baked into a newly-generated project. Any master merge that triggers a snapshot
republish produces a new timestamp; whoever updates next inherits it. Released
(non-`-SNAPSHOT`) plugin builds were never affected, because the suffix is only
appended to `-SNAPSHOT` versions.

## How it slipped through CI

- The contract that broke is a **string** the generator writes — there was no test
  asserting the generated `xtc` version is resolvable.
- The only end-to-end test that actually generates a project and runs Gradle
  against live repos (`XtcProjectCreatorIntegrationTest`) is
  `@EnabledIfEnvironmentVariable(RUN_INTEGRATION_TESTS=true)` — **disabled by
  default**, so CI never exercised the generate→resolve path.
- The decorated version only exists for a *published* plugin; local/dev builds
  (`enablePublish=false`) emit the bare base version, so it never reproduced in a
  normal build or in `runIde`.
- CI's lang job runs `:lang:intellij-plugin:verifyPlugin` (binary/compat
  verification), which does not generate or resolve a project.

## What this PR does

All in `javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java`:

1. **Sanitize at the single choke point.** `sanitizeXtcVersion()` reduces any
   decorated build/publication id to a resolvable coordinate:
   `0.4.4-SNAPSHOT.20260526090539` → `0.4.4-SNAPSHOT`,
   `0.4.4-alpha.20260523T120000` → `0.4.4-alpha`. It handles **both** snapshot and
   real release versions, and is **idempotent**, so CI reruns / republishes /
   double-applied suffixes cannot reintroduce the problem. Unusable input (null,
   blank, garbage) falls back to `DEFAULT_XTC_VERSION`.
2. **Strict validation.** `isValidXtcVersion()` + `XTC_VERSION_PATTERN` accept only
   `MAJOR.MINOR.PATCH` optionally followed by `-SNAPSHOT` / `-alpha` / `-beta` — and
   nothing else. (So `0.4.4`, `0.4.5`, `0.4.5-SNAPSHOT` are valid; timestamped or
   malformed strings are not.)
3. **Defense in depth.** `generateVersionCatalog()` throws rather than ever emitting
   a catalog that pins a non-resolvable version — a future regression fails loudly
   at generation instead of shipping a broken project.
4. **Remove a drifting hardcoded Gradle version.** Generated projects now copy the
   composite build's bundled `gradle-wrapper.properties` **verbatim** instead of
   regenerating it from a constant (which had already drifted: constant `9.5.0` vs
   repo wrapper `9.5.1`). The composite build is now the single source of truth for
   the generated project's Gradle version. (The full wrapper — `gradlew`,
   `gradlew.bat`, `gradle-wrapper.jar`, `gradle-wrapper.properties` — is bundled in
   the plugin and copied into the project, so a third-party user with no system
   Gradle is self-bootstrapped; `gradlew` downloads the distribution on first run.)

## Tests

New `javatools/src/test/java/org/xvm/tool/XtcVersionSanityTest.java` (10 tests, all
green; runs under `:javatools:test`, which is part of `check`/CI and is *not* gated
behind `-PincludeBuildLang`):

- accepts real release **and** snapshot versions; rejects timestamped/malformed.
- sanitize strips publication suffixes, leaves real versions untouched, falls back
  on garbage, and is idempotent + always-valid.
- **generated-catalog sanity checks**: snapshot timestamp stripped; real release
  kept; the catalog *never* pins a non-resolvable version for a range of decorated
  inputs.
- generated wrapper matches the composite build's bundled wrapper byte-for-byte.

Existing `XtcProjectCreatorIntegrationTest` still passes; plugin `compileJava`,
`compileTestKotlin`, and `ktlintCheck` are green.

## Why this is future-safe

- **Single choke point.** Every generation path (IDE wizard, `xtc init`, VS Code)
  goes through `XtcProjectCreator`, so the sanitize + guard apply everywhere.
- **Idempotent + guarded.** Decorated versions collapse to the same resolvable
  coordinate no matter how many times they flow through; generation refuses to emit
  a bad catalog.
- **Test gate.** `:javatools:test` now fails the build if anyone reintroduces a
  non-resolvable generated version. The guard is always on (core test, not
  lang-gated).
- **No drift.** Gradle version is sourced from the one bundled wrapper, not a
  constant.
- **Publication path untouched.** The Marketplace decorated version
  (`jetbrainsPublishVersionProvider`) is intentionally unchanged — that timestamp is
  correct for upload uniqueness; we simply stop leaking it into a Maven coordinate.

## Scope note

This PR is strictly about the **generated version catalog**. The separate question
of making the IntelliJ plugin's *build/run invocation* gradlew-agnostic (call the
compiler/runtime API directly, incrementally, like the Java integration) is
captured in a separate planning doc and is **not** part of this change.