### PR TITLE
Stop using internal IntelliJ API (resolve own plugin via PluginAwareClassLoader) + gate it in CI

### DIFF
--- a/lang/intellij-plugin/build.gradle.kts
+++ b/lang/intellij-plugin/build.gradle.kts
@@ -427,6 +427,14 @@ intellijPlatform {
     // 2026.1.x patches and 2026.2 EAPs are checked as soon as JetBrains
     // publishes them. failureLevel is explicit so the build fails on real
     // breaks but not on every deprecated/experimental API touch.
+    //
+    // INTERNAL_API_USAGES is included so the build fails if the plugin calls an
+    // IntelliJ API marked @ApiStatus.Internal. Such APIs are not meant for client
+    // plugins and can change without notice; gating on them here is what catches a
+    // regression like a switch to PluginManager.findEnabledPlugin (internal) over
+    // PluginManagerCore.getPlugin (public). Previously these were only logged as
+    // "Compatible. N usages of internal API" and silently passed CI while still
+    // generating a JetBrains verifier email on every Marketplace upload.
     pluginVerification {
         ides {
             recommended()
@@ -436,6 +444,7 @@ intellijPlatform {
                 VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
                 VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
                 VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
+                VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
             )
     }
 }

--- a/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/PluginPaths.kt
+++ b/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/PluginPaths.kt
@@ -1,8 +1,8 @@
 package org.xtclang.idea
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.extensions.PluginDescriptor
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -21,11 +21,23 @@ object PluginPaths {
     private val logger = logger<PluginPaths>()
 
     /**
+     * This plugin's own [PluginDescriptor], or `null` if it cannot be determined.
+     *
+     * Resolved from our own classes' classloader, which the IntelliJ Platform loads
+     * via a [PluginAwareClassLoader] that carries the owning plugin's descriptor. This
+     * is the supported, public way for a plugin to obtain its own descriptor (path,
+     * version, id). It deliberately avoids `PluginManager.findEnabledPlugin(PluginId)`
+     * and `PluginManagerCore.getPlugin(PluginId)`, both of which are marked
+     * `@ApiStatus.Internal` as of 2026.2 and flagged by the Plugin Verifier.
+     */
+    fun selfDescriptor(): PluginDescriptor? = (PluginPaths::class.java.classLoader as? PluginAwareClassLoader)?.pluginDescriptor
+
+    /**
      * Find a server JAR in the plugin's `bin/` directory.
      *
      * Resolution order:
-     * 1. `PluginManager.findEnabledPlugin` plugin path (public IntelliJ Platform API)
-     * 2. Classloader-based fallback (for development/test scenarios)
+     * 1. Own [PluginDescriptor] plugin path (via [selfDescriptor], public API)
+     * 2. Classloader code-source fallback (for development/test scenarios)
      *
      * @param jarName the JAR filename, e.g. `"xtc-lsp-server.jar"` or `"xtc-dap-server.jar"`
      * @throws IllegalStateException if the JAR cannot be found
@@ -33,12 +45,12 @@ object PluginPaths {
     fun findServerJar(jarName: String): Path {
         val searchedPaths = mutableListOf<Path>()
 
-        PluginManager.getInstance().findEnabledPlugin(PluginId.getId(PLUGIN_ID))?.let { plugin ->
-            val candidate = plugin.pluginPath.resolve("bin/$jarName")
+        selfDescriptor()?.pluginPath?.let { pluginPath ->
+            val candidate = pluginPath.resolve("bin/$jarName")
             searchedPaths.add(candidate)
-            resolveInBin(plugin.pluginPath, jarName)?.let { return it }
+            resolveInBin(pluginPath, jarName)?.let { return it }
             logger.warn("$jarName not at expected location: $candidate")
-            logger.warn("Plugin directory contents: ${plugin.pluginPath.toFile().listFiles()?.map { it.name }}")
+            logger.warn("Plugin directory contents: ${pluginPath.toFile().listFiles()?.map { it.name }}")
         }
 
         // Fallback: find via classloader (our class is in lib/, JAR is in bin/)

--- a/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/XtcTextMateBundleProvider.kt
+++ b/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/XtcTextMateBundleProvider.kt
@@ -1,8 +1,6 @@
 package org.xtclang.idea
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import org.jetbrains.plugins.textmate.api.TextMateBundleProvider
 import kotlin.io.path.exists
 
@@ -29,9 +27,9 @@ class XtcTextMateBundleProvider : TextMateBundleProvider {
     override fun getBundles(): List<TextMateBundleProvider.PluginBundle> {
         logger.warn("XtcTextMateBundleProvider.getBundles() called")
 
-        val plugin = PluginManager.getInstance().findEnabledPlugin(PluginId.getId(PluginPaths.PLUGIN_ID))
+        val plugin = PluginPaths.selfDescriptor()
         if (plugin == null) {
-            logger.warn("Ecstasy plugin not found via PluginManager.findEnabledPlugin")
+            logger.warn("Ecstasy plugin descriptor not found via own PluginAwareClassLoader")
             return emptyList()
         }
 

--- a/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/project/XtcNewProjectWizardStep.kt
+++ b/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/project/XtcNewProjectWizardStep.kt
@@ -1,13 +1,11 @@
 package org.xtclang.idea.project
 
 import com.intellij.execution.RunManager
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.ide.wizard.AbstractNewProjectWizardStep
 import com.intellij.ide.wizard.NewProjectWizardBaseData.Companion.baseData
 import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.LocalFileSystem
@@ -51,7 +49,7 @@ class XtcNewProjectWizardStep(
         val base = baseData ?: return logger.error("No base data available")
         val projectPath = Path(base.path).resolve(base.name)
         val xtcVersion =
-            PluginManager.getInstance().findEnabledPlugin(PluginId.getId(PluginPaths.PLUGIN_ID))?.version
+            PluginPaths.selfDescriptor()?.version
                 ?: XtcProjectCreator.DEFAULT_XTC_VERSION
 
         logger.info("Creating Ecstasy project: path=$projectPath, type=$projectType, multiModule=$multiModule, xtcVersion=$xtcVersion")


### PR DESCRIPTION
## What

1. **Removes all internal IntelliJ API usage** from the plugin. The three sites that
   looked up this plugin's own descriptor now go through one helper,
   `PluginPaths.selfDescriptor()`, which reads the descriptor from our own
   `PluginAwareClassLoader` (a **public** interface):
   - `PluginPaths.findServerJar` → `descriptor.pluginPath`
   - `XtcTextMateBundleProvider.getBundles` → `descriptor.pluginPath`
   - `XtcNewProjectWizardStep.setupProject` → `descriptor.version`
2. **Adds a CI gate**: `VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES`, so the
   build now *fails* on any internal-API usage instead of silently logging it.

## Why

The IntelliJ Plugin Verifier reported **"Compatible. 3 usages of internal API"** for
the 2026.2 EAP (`IU-262`), and JetBrains emails that notice on every Marketplace
upload. The usages were:

- `PluginManager.getInstance().findEnabledPlugin(PluginId)` — `@ApiStatus.Internal`,
  introduced in #467 (it replaced the prior public call).
- `PluginManagerCore.getPlugin(PluginId)` — **also** `@ApiStatus.Internal` as of 2026.2.

Both lookup methods are internal in 2026.2 and JetBrains has **not yet shipped a
public replacement** (their forum thread "PluginManagerCore.getPlugin is now
Internal"), so swapping one for the other does not help. The supported public way for
a plugin to obtain its own descriptor is to read it from its own
`PluginAwareClassLoader` — that interface is not `@Internal`, so it satisfies both the
verifier and the email.

This was never a CI *failure* before — the verifier's `failureLevel` didn't gate on
`INTERNAL_API_USAGES` — which is exactly why the #467 regression slipped through.
Adding the gate closes that hole.

### Gate scope note

The gate runs against `recommended()` IDEs, which includes 2026.2 EAP builds — the
strictest setting, catching APIs newly reclassified as internal as early as possible.
Tradeoff: a future JetBrains EAP reclassification can turn the build red and require a
follow-up fix. Accepted deliberately in favour of earliest warning.

## Validation (real tasks)

- `:lang:intellij-plugin:compileKotlin` + `:lang:intellij-plugin:ktlintCheck` — pass.
- `:lang:intellij-plugin:verifyPlugin` (gate active) — `BUILD SUCCESSFUL`, reports
  plain **"Compatible"** with **zero** internal-API usages for **both**
  `IU-261.25134.67` and `IU-262.6653.22` (the EAP that previously reported
  "3 usages of internal API").