### PR TITLE
Add typedef template parameter test cases

### DIFF
--- a/javatools/src/main/java/org/xvm/compiler/Parser.java
+++ b/javatools/src/main/java/org/xvm/compiler/Parser.java
@@ -2231,16 +2231,20 @@ public class Parser {
     TypedefStatement parseTypeDefStatement(Expression exprCond, Token tokenAccess) {
         Token keyword = expect(Id.TYPEDEF);
 
+        // Optional template parameter list: <T1, T2 extends Bound>
+        List<Parameter> templateParams = parseTypeParameterList(false);
+
         TypeExpression type = parseExtendedTypeExpression();
 
         // required "as" keyword (note: previously optional)
         expect(Id.AS);
 
-        Token simpleName = expect(Id.IDENTIFIER);
+        // Parse the alias name - could be a simple identifier or a parameterized type like Pair<A,B>
+        TypeExpression aliasType = parseNamedTypeExpression(null);
 
         expect(Id.SEMICOLON);
 
-        return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess, type, simpleName);
+        return new TypedefStatement(exprCond, tokenAccess == null ? keyword : tokenAccess, templateParams, type, aliasType);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/compiler/ast/TypedefStatement.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/TypedefStatement.java
@@ -1,136 +1,151 @@
 package org.xvm.compiler.ast;
-
-
-import java.lang.reflect.Field;
-
-import org.xvm.asm.Component;
-import org.xvm.asm.Constants.Access;
-import org.xvm.asm.ErrorListener;
-import org.xvm.asm.MethodStructure.Code;
-import org.xvm.asm.TypedefStructure;
-
-import org.xvm.asm.constants.TypeConstant;
-
-import org.xvm.compiler.Compiler;
-import org.xvm.compiler.Token;
-import org.xvm.compiler.Token.Id;
-
-import org.xvm.util.Severity;
-
-
-/**
- * A typedef statement specifies a type to alias as a simple name.
- */
-public class TypedefStatement
-        extends ComponentStatement {
-    // ----- constructors --------------------------------------------------------------------------
-
-    public TypedefStatement(Expression cond, Token keyword, TypeExpression type, Token alias) {
-        super(keyword.getStartPosition(), alias.getEndPosition());
-
-        this.cond     = cond;
-        this.modifier = keyword.getId() == Id.TYPEDEF ? null : keyword;
-        this.type     = type;
-        this.alias    = alias;
-    }
-
-
-    // ----- accessors -----------------------------------------------------------------------------
-
-    @Override
-    public Access getDefaultAccess() {
-        if (modifier != null) {
-            switch (modifier.getId()) {
-            case PUBLIC:
-                return Access.PUBLIC;
-            case PROTECTED:
-                return Access.PROTECTED;
-            case PRIVATE:
-                return Access.PRIVATE;
-            }
-        }
-
-        return super.getDefaultAccess();
-    }
-
-    @Override
-    protected Field[] getChildFields() {
-        return CHILD_FIELDS;
-    }
-
-
-    // ----- compile phases ------------------------------------------------------------------------
-
-    @Override
-    protected void registerStructures(StageMgr mgr, ErrorListener errs) {
-        // create the structure for this method
-        if (getComponent() == null) {
-            // create a structure for this typedef
-            Component container = getParent().getComponent();
-            String    sName     = (String) alias.getValue();
-            if (container != null && container.isClassContainer()) {
-                Access           access    = getDefaultAccess();
-                TypeConstant     constType = type.ensureTypeConstant();
-                TypedefStructure typedef   = container.createTypedef(access, constType, sName);
-                setComponent(typedef);
-            } else if (!errs.hasSeriousErrors()) {
-                log(errs, Severity.ERROR, Compiler.TYPEDEF_UNEXPECTED, sName, container);
-            }
-        }
-    }
-
-    @Override
-    protected Statement validateImpl(Context ctx, ErrorListener errs) {
-        return this;
-    }
-
-    @Override
-    protected boolean emit(Context ctx, boolean fReachable, Code code, ErrorListener errs) {
-        return true;
-    }
-
-    // ----- debugging assistance ------------------------------------------------------------------
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-
-        if (cond != null) {
-            sb.append("if (")
-              .append(cond)
-              .append(") { ");
-        }
-
-        if (modifier != null) {
-            sb.append(modifier)
-              .append(' ');
-        }
-
-        sb.append("typedef ")
-          .append(type)
-          .append(' ')
-          .append(alias.getValue())
-          .append(';');
-
-        if (cond != null) {
-            sb.append(" }");
-        }
-
-        return sb.toString();
-    }
-
-    @Override
-    public String getDumpDesc() {
-        return toString();
-    }
-
-
-    // ----- fields --------------------------------------------------------------------------------
-
-    protected Expression     cond;
-    protected Token          modifier;
-    protected Token          alias;
-    protected TypeExpression type;
-
-    private static final Field[] CHILD_FIELDS = fieldsForNames(TypedefStatement.class, "cond", "type");
-}
+ 
+ 
+ import java.lang.reflect.Field;
+ import java.util.List;
+ import java.util.stream.Collectors;
+ 
+ import org.xvm.asm.Component;
+ import org.xvm.asm.Constants.Access;
+ import org.xvm.asm.ErrorListener;
+ import org.xvm.asm.MethodStructure.Code;
+ import org.xvm.compiler.ast.Parameter;
+ import org.xvm.asm.TypedefStructure;
+ 
+ import org.xvm.asm.constants.TypeConstant;
+ 
+ import org.xvm.compiler.Compiler;
+ import org.xvm.compiler.Token;
+ import org.xvm.compiler.Token.Id;
+ 
+ import org.xvm.util.Severity;
+ 
+ 
+ /**
+  * A typedef statement specifies a type to alias as a simple name.
+  */
+ public class TypedefStatement
+         extends ComponentStatement {
+     // ----- constructors --------------------------------------------------------------------------
+ 
+     public TypedefStatement(Expression cond, Token keyword, List<Parameter> templateParams, TypeExpression type, TypeExpression aliasType) {
+         super(keyword.getStartPosition(), aliasType.getEndPosition());
+ 
+         this.cond         = cond;
+         this.modifier     = keyword.getId() == Id.TYPEDEF ? null : keyword;
+         this.templateParams = templateParams;
+         this.type         = type;
+         this.aliasType    = aliasType;
+     }
+ 
+ 
+     // ----- accessors -----------------------------------------------------------------------------
+ 
+     @Override
+     public Access getDefaultAccess() {
+         if (modifier != null) {
+             switch (modifier.getId()) {
+             case PUBLIC:
+                 return Access.PUBLIC;
+             case PROTECTED:
+                 return Access.PROTECTED;
+             case PRIVATE:
+                 return Access.PRIVATE;
+             }
+         }
+ 
+         return super.getDefaultAccess();
+     }
+ 
+     public List<Parameter> getTemplateParams() {
+         return templateParams;
+     }
+ 
+     @Override
+     protected Field[] getChildFields() {
+         return CHILD_FIELDS;
+     }
+ 
+ 
+     // ----- compile phases ------------------------------------------------------------------------
+ 
+     @Override
+     protected void registerStructures(StageMgr mgr, ErrorListener errs) {
+         // create the structure for this method
+         if (getComponent() == null) {
+             // create a structure for this typedef
+             Component container = getParent().getComponent();
+             String    sName     = aliasType.toString();
+             if (container != null && container.isClassContainer()) {
+                 Access           access    = getDefaultAccess();
+                 TypeConstant     constType = type.ensureTypeConstant();
+                 TypedefStructure typedef   = container.createTypedef(access, constType, sName);
+                 setComponent(typedef);
+             } else if (!errs.hasSeriousErrors()) {
+                 log(errs, Severity.ERROR, Compiler.TYPEDEF_UNEXPECTED, sName, container);
+             }
+         }
+     }
+ 
+     @Override
+     protected Statement validateImpl(Context ctx, ErrorListener errs) {
+         return this;
+     }
+ 
+     @Override
+     protected boolean emit(Context ctx, boolean fReachable, Code code, ErrorListener errs) {
+         return true;
+     }
+ 
+     // ----- debugging assistance ------------------------------------------------------------------
+ 
+     @Override
+     public String toString() {
+         StringBuilder sb = new StringBuilder();
+ 
+         if (cond != null) {
+             sb.append("if (")
+               .append(cond)
+               .append(") { ");
+         }
+ 
+         if (modifier != null) {
+             sb.append(modifier)
+               .append(' ');
+         }
+ 
+         sb.append("typedef ");
+         if (templateParams != null && !templateParams.isEmpty()) {
+             sb.append('<')
+               .append(templateParams.stream().map(Object::toString).collect(Collectors.joining(", ")))
+               .append('>');
+         }
+         sb.append(' ')
+           .append(type)
+           .append(" as ")
+           .append(aliasType)
+           .append(';');
+ 
+         if (cond != null) {
+             sb.append(" }");
+         }
+ 
+         return sb.toString();
+     }
+ 
+     @Override
+     public String getDumpDesc() {
+         return toString();
+     }
+ 
+ 
+     // ----- fields --------------------------------------------------------------------------------
+ 
+     protected Expression           cond;
+     protected Token                modifier;
+     protected List<Parameter>      templateParams;
+     protected TypeExpression       type;
+     protected TypeExpression       aliasType;
+ 
+     private static final Field[] CHILD_FIELDS = fieldsForNames(TypedefStatement.class, "cond", "templateParams", "type", "aliasType");
+ }

--- a/javatools/src/test/java/org/xvm/compiler/ParserTest.java
+++ b/javatools/src/test/java/org/xvm/compiler/ParserTest.java
@@ -50,6 +50,11 @@ public class ParserTest {
         parse("class DependentFutureRef delegates Ref(value) {}");
     }
 
+    @Test
+    public void testTypedefTemplateParams() {
+        parse("module Test { typedef <T> List<T> as MyList<T>; void run() {} }");
+    }
+
     static void parse(String value) {
             parse(new Source(value));
     }

--- a/javatools/src/test/x/typedefs/test_basic.x
+++ b/javatools/src/test/x/typedefs/test_basic.x
@@ -1,0 +1,7 @@
+module test_basic {
+    typedef <T> List<T> as MyList<T>;
+
+    void run() {
+        MyList<Int> list = MyList<Int>();
+    }
+}

--- a/javatools/src/test/x/typedefs/test_bounded.x
+++ b/javatools/src/test/x/typedefs/test_bounded.x
@@ -1,0 +1,7 @@
+module test_bounded {
+    typedef <T extends Number> T as NumRef<T>;
+
+    void run() {
+        NumRef<Int> n = NumRef<Int>(42);
+    }
+}

--- a/javatools/src/test/x/typedefs/test_chained.x
+++ b/javatools/src/test/x/typedefs/test_chained.x
@@ -1,0 +1,8 @@
+module test_chained {
+    typedef <A, B> Tuple<A, B> as Pair<A, B>;
+    typedef <A> Pair<A, A> as Twin<A>;
+
+    void run() {
+        Twin<Int> t = (1, 2);
+    }
+}

--- a/javatools/src/test/x/typedefs/test_mixin.x
+++ b/javatools/src/test/x/typedefs/test_mixin.x
@@ -1,0 +1,15 @@
+module test_mixin {
+    typedef <A, B> Tuple<A, B> as Pair<A, B>;
+    typedef <A> Pair<A, A> as Twin<A>;
+
+    mixin Xor into Twin<Int> {
+        Int xor() {
+            return this[0] ^ this[1];
+        }
+    }
+
+    void run() {
+        Twin<Int> t = (5, 3);
+        Int result = t.xor();
+    }
+}

--- a/javatools/src/test/x/typedefs/test_multi.x
+++ b/javatools/src/test/x/typedefs/test_multi.x
@@ -1,0 +1,7 @@
+module test_multi {
+    typedef <K, V> Map<K, V> as Dict<K, V>;
+
+    void run() {
+        Dict<String, Int> dict = Dict<String, Int>();
+    }
+}

--- a/javatools/src/test/x/typedefs/test_partial.x
+++ b/javatools/src/test/x/typedefs/test_partial.x
@@ -1,0 +1,10 @@
+module test_partial {
+    typedef <K, V> Map<K, V> as Dictionary<K, V>;
+
+    // Partial application - provide only K, V remains open
+    typealias StringMap<V> = Dictionary<String, V>;
+
+    void run() {
+        StringMap<Int> map = StringMap<Int>();
+    }
+}


### PR DESCRIPTION
This is the tests including parts of an imagined java generics expressions defining super-typedef templates when the typedef is not exclusively reification. 

the AST changes to 

`typedef [<A,...>] Name1 [<A,...>] as Name2[< A,...>] `

all three param tuples shown with optional block braces.  the simplest hueristic i can come up with is that the shown tuples specialize the /site generality/ into the slot specificity. the first tuple defined becomes the tacit /site generality/ also.