### PR TITLE
Bundle SLF4J no-op provider in javatools

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ jakarta-xml-bind-api = "4.0.5"
 jaxb-runtime = "4.0.9"
 jetbrains-annotations = "26.1.0"
 jline = "4.0.15"
+slf4j = "2.0.18"
 
 # =============================================================================
 # Build tooling & publishing
@@ -172,6 +173,7 @@ jakarta-xml-bind-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", versi
 jaxb-runtime = { module = "org.glassfish.jaxb:jaxb-runtime", version.ref = "jaxb-runtime" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 jline = { module = "org.jline:jline", version.ref = "jline" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
 
 # =============================================================================
 # Testing (shared across XDK and lang)

--- a/javatools/build.gradle.kts
+++ b/javatools/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.acme4j.client)
     implementation(libs.bouncycastle.pkix)
     implementation(libs.bouncycastle.provider)
+    implementation(libs.slf4j.nop) // to avoid startup warnings while preserving no-op logging
     testCompileOnly(libs.jetbrains.annotations)
     testImplementation(libs.javatools.utils)
 }
@@ -226,12 +227,12 @@ val jar by tasks.existing(Jar::class) {
 val versionOutputTest by tasks.registering(Test::class) {
     description = "Run tests that verify version output contains git and API information"
     group = VERIFICATION_GROUP
-    
+
     dependsOn(jar, tasks.test)
-    
+
     // Only run the version-related tests
     include("**/BuildInfoTest.class", "**/LauncherVersionTest.class")
-    
+
     doFirst {
         logger.info("[javatools] Verifying version output contains expected git and API information")
     }


### PR DESCRIPTION
When we start the platform that uses non-self-certifying CA, such as "Let's Encrypt" the following messages get logged:

```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details

```
The reason for that is that `javatools.jar` includes acme4j for ACME/certbot certificate support, which uses SLF4J internally, and the fat jar ends up containing `slf4j-api`, but no SLF4J provider.

This change adds `slf4j-nop` to the `javatools` runtime so the existing effective behavior is preserved while avoiding the startup warning. This keeps ACME logging disabled, which matches the previous runtime behavior after SLF4J fell back to NOP.

Disclaimer: the fix was created by Codex