### PR TITLE
Prepare Gradle build scripts for Gradle 10

### DIFF
--- a/build-logic/aggregator/src/main/kotlin/org.xtclang.build.aggregator.gradle.kts
+++ b/build-logic/aggregator/src/main/kotlin/org.xtclang.build.aggregator.gradle.kts
@@ -25,7 +25,7 @@ private class XdkBuildAggregator(val project: Project) : Runnable {
 
         val ignoredIncludedBuilds = gradle.includedBuilds.map { it.name }.filter {
             val attachKey = "includeBuildAttach${it.replaceFirstChar(Char::titlecase)}"
-            val attach = (properties[attachKey]?.toString() ?: "true").toBoolean()
+            val attach = providers.gradleProperty(attachKey).map(String::toBoolean).getOrElse(true)
             if (!attach) {
                 logger.info("[aggregator] Included build '$it' is explicitly configured to be outside the root lifecycle ($attachKey: false).")
             }

--- a/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.docker.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.docker.gradle.kts
@@ -97,7 +97,7 @@ fun createDockerBuildTask(
     createDockerBuildTask("pushAll", listOf("linux/amd64", "linux/arm64"), "push")
     
     // Create the Docker cleanup taskg
-    val cleanImages by tasks.registering(DockerCleanupTask::class) {
+    val cleanImages = tasks.register<DockerCleanupTask>("cleanImages") {
         group = "docker"
         description = "Clean up old Docker package versions (default: keep 10 most recent, protect master images)"
 

--- a/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.java.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.java.gradle.kts
@@ -133,8 +133,8 @@ val junitJupiter = libsCatalog.findLibrary("junit.jupiter")
 
 testing {
     suites {
-        @Suppress("UnstableApiUsage", "unused")
-        val test by getting(JvmTestSuite::class) {
+        @Suppress("UnstableApiUsage")
+        getByName<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 // Resolving catalog entries at configuration time is fine (static coords).

--- a/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.publishing.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.publishing.gradle.kts
@@ -191,7 +191,7 @@ val allowReleaseProvider = xdkPublishingCredentials.allowRelease
 logPublishingConfiguration(logger, publicationVersion, isSnapshot)
 
 // Register validateCredentials task for credential validation
-val validateCredentials by tasks.registering(ValidateCredentialsTask::class) {
+val validateCredentials = tasks.register<ValidateCredentialsTask>("validateCredentials") {
     group = PUBLISH_TASK_GROUP
     description = "Validate all publishing credentials (GitHub, Maven Central, Plugin Portal, Signing) without publishing"
     // Set project info for output (configuration-cache safe)

--- a/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.xdk.properties.gradle.kts
+++ b/build-logic/common-plugins/src/main/kotlin/org.xtclang.build.xdk.properties.gradle.kts
@@ -91,7 +91,7 @@ plugins.withType<JavaBasePlugin> {
  * Only create if it doesn't already exist (aggregator may have created it in root build).
  */
 if ("versions" !in tasks.names) {
-    val versions by tasks.registering {
+    val versions = tasks.register("versions") {
         group = "help"
         description = "Print group:name:version for this project and all subprojects"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ logger.info("[xvm] Root aggregator version: $group:$name:$version")
  * The aggregator plugin creates this task and adds dependencies to all included builds.
  * We configure it here to also print the root aggregator's version.
  */
-val versions by tasks.existing {
+val versions = tasks.named("versions") {
     // Capture values during configuration for configuration cache compatibility
     val projectName = project.name
     val projectGroup = project.group
@@ -43,19 +43,19 @@ val versions by tasks.existing {
  * and similar things.
  */
 
-val distZip by tasks.registering {
+val distZip = tasks.register("distZip") {
     group = DISTRIBUTION_TASK_GROUP
     description = "Build the XDK distribution zip in the xdk/build/distributions directory."
     dependsOn(xdk.task(":$name"))
 }
 
-val installDist by tasks.registering {
+val installDist = tasks.register("installDist") {
     group = DISTRIBUTION_TASK_GROUP
     description = "Install the XDK distribution in the xdk/build/distributions and xdk/build/install directories."
     dependsOn(xdk.task(":$name"))
 }
 
-val installWithNativeLaunchersDist by tasks.registering {
+val installWithNativeLaunchersDist = tasks.register("installWithNativeLaunchersDist") {
     group = DISTRIBUTION_TASK_GROUP
     description = "Install the XDK distribution with native launchers in the xdk/build/install directory."
     dependsOn(xdk.task(":$name"))
@@ -65,7 +65,7 @@ private val xdk = gradle.includedBuild("xdk")
 private val plugin = gradle.includedBuild("plugin")
 private val publishedBuilds = listOf(xdk, plugin)
 
-val publishLocal by tasks.registering {
+val publishLocal = tasks.register("publishLocal") {
     group = PUBLISH_TASK_GROUP
     description = "Publish XDK and plugin artifacts to local Maven repository."
 
@@ -75,7 +75,7 @@ val publishLocal by tasks.registering {
     }
 }
 
-val publishSnapshotBundle by tasks.registering {
+val publishSnapshotBundle = tasks.register("publishSnapshotBundle") {
     group = PUBLISH_TASK_GROUP
     description = "Publish XDK and plugin snapshot artifacts to an isolated file-backed Maven repository."
 
@@ -112,7 +112,7 @@ val publishSnapshotBundle by tasks.registering {
  * Options:
  * - Use -Porg.xtclang.allowRelease=true to allow publishing release versions (required for non-SNAPSHOT versions)
  */
-val publish by tasks.registering {
+val publish = tasks.register("publish") {
     group = PUBLISH_TASK_GROUP
     description = "Publish XDK and plugin artifacts to both local Maven and remote repositories."
 
@@ -161,7 +161,7 @@ val publish by tasks.registering {
 /**
  * Aggregate validateCredentials task that runs validation in all publishable projects.
  */
-val validateCredentials by tasks.registering {
+val validateCredentials = tasks.register("validateCredentials") {
     group = PUBLISH_TASK_GROUP
     description = "Validate all publishing credentials across all projects without publishing"
 

--- a/docker/build.gradle.kts
+++ b/docker/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 // Create consumer configuration for XDK distribution zip
-val xdkDistConsumer by configurations.registering {
+val xdkDistConsumer = configurations.register("xdkDistConsumer") {
     isCanBeResolved = true
     isCanBeConsumed = false
     attributes {

--- a/javatools/build.gradle.kts
+++ b/javatools/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 // TODO: Move these to common-plugins, the XDK composite build does use them in some different places.
-val xdkJavaToolsProvider by configurations.registering {
+val xdkJavaToolsProvider = configurations.register("xdkJavaToolsProvider") {
     description = "Provider configuration of the The XVM Java Tools jar artifact: 'javatools-$version.jar'"
     isCanBeResolved = false
     isCanBeConsumed = true
@@ -52,7 +52,7 @@ val ecstasyResourcesDir = layout.projectDirectory.dir(
  * Uses direct file path references instead of configuration dependencies to avoid
  * circular dependency issues when the plugin tries to use javatools as compileOnly.
  */
-val copyEcstasyResources by tasks.registering(Copy::class) {
+val copyEcstasyResources = tasks.register<Copy>("copyEcstasyResources") {
     description = "Copy ecstasy resources from lib_ecstasy using direct file reference"
     from(ecstasyResourcesDir)
     into(layout.buildDirectory.dir("generated/resources/main"))
@@ -63,7 +63,7 @@ val copyEcstasyResources by tasks.registering(Copy::class) {
  * This allows generated XTC projects to have a working gradle wrapper out of the box.
  */
 val compositeRoot = XdkPropertiesService.compositeRootRelativeFile(projectDir, ".")
-val copyGradleWrapper by tasks.registering(Copy::class) {
+val copyGradleWrapper = tasks.register<Copy>("copyGradleWrapper") {
     description = "Copy gradle wrapper files for embedding in generated projects"
     from(File(compositeRoot, "gradlew"))
     from(File(compositeRoot, "gradlew.bat"))
@@ -122,7 +122,7 @@ abstract class GenerateBuildInfo : DefaultTask() {
     }
 }
 
-val generateBuildInfo by tasks.registering(GenerateBuildInfo::class) {
+val generateBuildInfo = tasks.register<GenerateBuildInfo>("generateBuildInfo") {
     description = "Generate build-info.properties deterministically (config-cache safe)"
     baseProps.set(versionPropsFile)
 
@@ -177,7 +177,7 @@ tasks.processResources {
 }
 
 // Make 'jar' clean: no I/O or repo reads inside actions
-val jar by tasks.existing(Jar::class) {
+val jar = tasks.named<Jar>("jar") {
     dependsOn(tasks.processResources)
 
     // Declare inputs that affect jar content
@@ -224,7 +224,7 @@ val jar by tasks.existing(Jar::class) {
     }
 }
 
-val versionOutputTest by tasks.registering(Test::class) {
+val versionOutputTest = tasks.register<Test>("versionOutputTest") {
     description = "Run tests that verify version output contains git and API information"
     group = VERIFICATION_GROUP
 

--- a/javatools_bridge/build.gradle.kts
+++ b/javatools_bridge/build.gradle.kts
@@ -22,6 +22,6 @@ dependencies {
     xtcModule(libs.xdk.web)
 }
 
-val compileXtc by tasks.existing(XtcCompileTask::class) {
+val compileXtc = tasks.named<XtcCompileTask>("compileXtc") {
     outputFilename("_native.xtc" to "javatools_bridge.xtc")
 }

--- a/javatools_jitbridge/build.gradle.kts
+++ b/javatools_jitbridge/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 // This JAR is NOT for classpath use - it's loaded by runtime via disk probing.
 // The XDK build consumes this via libs.javatools.jitbridge dependency with matching attributes.
 // See: xdk/build.gradle.kts:29-37 (consumer) and gradle/libs.versions.toml:73 (version catalog)
-val xdkJavaToolsJitBridgeProvider by configurations.registering {
+val xdkJavaToolsJitBridgeProvider = configurations.register("xdkJavaToolsJitBridgeProvider") {
     description = "Provides javatools-jitbridge JAR as native binary blob for XDK distribution (NOT classpath)"
     isCanBeResolved = false
     isCanBeConsumed = true

--- a/javatools_launcher/build.gradle.kts
+++ b/javatools_launcher/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 
 val launcherExecutableDir = layout.projectDirectory.dir("src/main/resources/exe")
 
-val processLauncherResources by tasks.registering(Copy::class) {
+val processLauncherResources = tasks.register<Copy>("processLauncherResources") {
     from(files(launcherExecutableDir))
     // TODO: This may cause a warning in IDEA with non-delegated compilation, but it is safe.
     //   "Cannot resolve resource filtering of . IDEA may fail to build project. Consider using delegated build (enabled by default)."
@@ -29,14 +29,14 @@ val processLauncherResources by tasks.registering(Copy::class) {
     into(layout.buildDirectory.file("bin"))
 }
 
-val assemble by tasks.existing {
+val assemble = tasks.named("assemble") {
     dependsOn(processLauncherResources)
     doLast {
         logger.info("[javatools_launcher] Finished assembling launcher resources into Gradle build.")
     }
 }
 
-val xtcLauncherBinaries by configurations.registering {
+val xtcLauncherBinaries = configurations.register("xtcLauncherBinaries") {
     isCanBeResolved = false
     isCanBeConsumed = true
     outgoing.artifact(processLauncherResources)

--- a/javatools_turtle/build.gradle.kts
+++ b/javatools_turtle/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
     alias(libs.plugins.xtc)
 }
 
-val processXtcResources by tasks.existing(Copy::class)
+val processXtcResources = tasks.named<Copy>("processXtcResources")
 
-val xdkTurtleProvider by configurations.registering {
+val xdkTurtleProvider = configurations.register("xdkTurtleProvider") {
     isCanBeResolved = false
     isCanBeConsumed = true
     outgoing.artifact(tasks.processResources) {
@@ -24,6 +24,6 @@ val xdkTurtleProvider by configurations.registering {
     }
 }
 
-val compileXtc by tasks.existing {
+val compileXtc = tasks.named("compileXtc") {
     enabled = false
 }

--- a/javatools_unicode/build.gradle.kts
+++ b/javatools_unicode/build.gradle.kts
@@ -37,12 +37,12 @@ val processedResourcesDir = tasks.processResources.get().outputs.files.singleFil
 /**
  * Type safe "jar" task accessor.
  */
-val jar by tasks.existing(Jar::class)
+val jar = tasks.named<Jar>("jar")
 
 /**
  * Download the ucd zip file from the unicode site, if it does not exist.
  */
-val downloadUcdFlatZip by tasks.registering(Download::class) {
+val downloadUcdFlatZip = tasks.register<Download>("downloadUcdFlatZip") {
     val rebuildUnicode = xdkProperties.booleanValue("org.xtclang.unicode.rebuild", false)
     onlyIf { rebuildUnicode }
 
@@ -121,7 +121,7 @@ abstract class RebuildUnicodeTablesTask : DefaultTask() {
  * its incoming resources, which means that lib_ecstasy will include them in the ecstasy.xtc
  * module. All we need to do is add the configuration as a resource for lib_ecstasy.
  */
-val rebuildUnicodeTables by tasks.registering(RebuildUnicodeTablesTask::class) {
+val rebuildUnicodeTables = tasks.register<RebuildUnicodeTablesTask>("rebuildUnicodeTables") {
     group = BUILD_GROUP
     description = "If the unicode files should be regenerated, generate them from the build tool, and place them under the build resources."
 

--- a/lang/README.md
+++ b/lang/README.md
@@ -322,7 +322,7 @@ crash/memory isolation.
 |---------|---------|---------|
 | **intellij-ide** | 2026.1 | Target IDE version |
 | **intellij-jdk** | 25 | Plugin JDK requirement |
-| **intellij-platform-gradle-plugin** | 2.14.0 | Build plugin for IntelliJ plugins |
+| **intellij-platform-gradle-plugin** | 2.17.0 | Build plugin for IntelliJ plugins |
 
 ### Compatibility Matrix
 

--- a/lang/build.gradle.kts
+++ b/lang/build.gradle.kts
@@ -80,7 +80,7 @@ subprojects {
 // after modifying the language model or generators.
 // =============================================================================
 
-val updateGeneratedExamples by tasks.registering(Copy::class) {
+val updateGeneratedExamples = tasks.register<Copy>("updateGeneratedExamples") {
     group = "generation"
     description = "Update the generated-examples directory with freshly generated files"
 
@@ -129,13 +129,13 @@ taskMappings.forEach { (aggregateTask, overrides) ->
 // IDE run tasks - convenience aliases for subproject tasks
 // =============================================================================
 
-val runIntellijPlugin by tasks.registering {
+val runIntellijPlugin = tasks.register("runIntellijPlugin") {
     group = "run"
     description = "Launch IntelliJ IDEA with the XTC plugin loaded for testing"
     dependsOn(project(":intellij-plugin").tasks.named("runIde"))
 }
 
-val runVsCodeExtension by tasks.registering {
+val runVsCodeExtension = tasks.register("runVsCodeExtension") {
     group = "run"
     description = "Launch VS Code with the XTC extension loaded for testing"
     dependsOn(project(":vscode-extension").tasks.named("runCode"))

--- a/lang/dap-server/build.gradle.kts
+++ b/lang/dap-server/build.gradle.kts
@@ -27,8 +27,8 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 // Ensure ktlint runs during normal development
-val ktlintCheck by tasks.existing
-val compileKotlin by tasks.existing {
+val ktlintCheck = tasks.named("ktlintCheck")
+val compileKotlin = tasks.named("compileKotlin") {
     dependsOn(ktlintCheck)
 }
 

--- a/lang/dap-server/build.gradle.kts
+++ b/lang/dap-server/build.gradle.kts
@@ -28,9 +28,10 @@ tasks.withType<JavaCompile>().configureEach {
 
 // Ensure ktlint runs during normal development
 val ktlintCheck = tasks.named("ktlintCheck")
-val compileKotlin = tasks.named("compileKotlin") {
-    dependsOn(ktlintCheck)
-}
+val compileKotlin =
+    tasks.named("compileKotlin") {
+        dependsOn(ktlintCheck)
+    }
 
 tasks.jar {
     manifest {

--- a/lang/dsl/build.gradle.kts
+++ b/lang/dsl/build.gradle.kts
@@ -27,9 +27,10 @@ tasks.test {
 
 // Ensure ktlint runs during normal development (not just 'check')
 val ktlintCheck = tasks.named("ktlintCheck")
-val compileKotlin = tasks.named("compileKotlin") {
-    dependsOn(ktlintCheck)
-}
+val compileKotlin =
+    tasks.named("compileKotlin") {
+        dependsOn(ktlintCheck)
+    }
 
 // =============================================================================
 // Editor Support Generation
@@ -85,118 +86,127 @@ fun JavaExec.configureGenerator(
     }
 }
 
-val generateTextMate = tasks.register<JavaExec>("generateTextMate") {
-    description = "Generate TextMate grammar from the XTC language model"
-    configureGenerator("textmate", "xtc.tmLanguage.json")
-}
+val generateTextMate =
+    tasks.register<JavaExec>("generateTextMate") {
+        description = "Generate TextMate grammar from the XTC language model"
+        configureGenerator("textmate", "xtc.tmLanguage.json")
+    }
 
-val generateLanguageConfig = tasks.register<JavaExec>("generateLanguageConfig") {
-    description = "Generate VS Code language configuration"
-    configureGenerator("vscode-config", "language-configuration.json")
-}
+val generateLanguageConfig =
+    tasks.register<JavaExec>("generateLanguageConfig") {
+        description = "Generate VS Code language configuration"
+        configureGenerator("vscode-config", "language-configuration.json")
+    }
 
-val generatePackageJson = tasks.register<JavaExec>("generatePackageJson") {
-    description = "Generate package.json for TextMate bundle"
-    configureGenerator("package-json", "package.json")
-}
+val generatePackageJson =
+    tasks.register<JavaExec>("generatePackageJson") {
+        description = "Generate package.json for TextMate bundle"
+        configureGenerator("package-json", "package.json")
+    }
 
-val generateVim = tasks.register<JavaExec>("generateVim") {
-    description = "Generate Vim syntax file"
-    configureGenerator("vim", "xtc.vim")
-}
+val generateVim =
+    tasks.register<JavaExec>("generateVim") {
+        description = "Generate Vim syntax file"
+        configureGenerator("vim", "xtc.vim")
+    }
 
-val generateEmacs = tasks.register<JavaExec>("generateEmacs") {
-    description = "Generate Emacs major mode"
-    configureGenerator("emacs", "xtc-mode.el")
-}
+val generateEmacs =
+    tasks.register<JavaExec>("generateEmacs") {
+        description = "Generate Emacs major mode"
+        configureGenerator("emacs", "xtc-mode.el")
+    }
 
-val generateTreeSitter = tasks.register<JavaExec>("generateTreeSitter") {
-    group = "generation"
-    description = "Generate Tree-sitter grammar and highlights"
-    dependsOn(tasks.compileKotlin, tasks.processResources)
-    classpath = configurations.runtimeClasspath.get() + sourceSets.main.get().output
-    mainClass.set("org.xtclang.tooling.LanguageModelCliKt")
-    val generatorLogLevel =
-        when (gradle.startParameter.logLevel) {
-            org.gradle.api.logging.LogLevel.DEBUG -> "DEBUG"
-            org.gradle.api.logging.LogLevel.INFO -> "INFO"
-            else -> "WARN"
-        }
-    // Pass project version to CLI so generated files have correct version metadata
-    val projectVersion = project.version.toString()
-    systemProperty("project.version", projectVersion)
-    systemProperty("xtc.logLevel", generatorLogLevel)
-    // Declare version as input for proper Gradle caching
-    inputs.property("projectVersion", projectVersion)
-    inputs.property("generatorLogLevel", generatorLogLevel)
-    // Tree-sitter expects a directory, not a file
-    args("tree-sitter", generatedDir.get().asFile.absolutePath)
-    inputs.files(
-        sourceSets.main
-            .get()
-            .kotlin.sourceDirectories,
-    )
-    inputs.files(
-        sourceSets.main
-            .get()
-            .resources.sourceDirectories,
-    )
-    outputs.files(
-        generatedDir.map { it.file("grammar.js") },
-        generatedDir.map { it.file("highlights.scm") },
-    )
-}
+val generateTreeSitter =
+    tasks.register<JavaExec>("generateTreeSitter") {
+        group = "generation"
+        description = "Generate Tree-sitter grammar and highlights"
+        dependsOn(tasks.compileKotlin, tasks.processResources)
+        classpath = configurations.runtimeClasspath.get() + sourceSets.main.get().output
+        mainClass.set("org.xtclang.tooling.LanguageModelCliKt")
+        val generatorLogLevel =
+            when (gradle.startParameter.logLevel) {
+                org.gradle.api.logging.LogLevel.DEBUG -> "DEBUG"
+                org.gradle.api.logging.LogLevel.INFO -> "INFO"
+                else -> "WARN"
+            }
+        // Pass project version to CLI so generated files have correct version metadata
+        val projectVersion = project.version.toString()
+        systemProperty("project.version", projectVersion)
+        systemProperty("xtc.logLevel", generatorLogLevel)
+        // Declare version as input for proper Gradle caching
+        inputs.property("projectVersion", projectVersion)
+        inputs.property("generatorLogLevel", generatorLogLevel)
+        // Tree-sitter expects a directory, not a file
+        args("tree-sitter", generatedDir.get().asFile.absolutePath)
+        inputs.files(
+            sourceSets.main
+                .get()
+                .kotlin.sourceDirectories,
+        )
+        inputs.files(
+            sourceSets.main
+                .get()
+                .resources.sourceDirectories,
+        )
+        outputs.files(
+            generatedDir.map { it.file("grammar.js") },
+            generatedDir.map { it.file("highlights.scm") },
+        )
+    }
 
 // Generate scanner.c from Kotlin ScannerSpec (single source of truth)
-val generateScannerC = tasks.register<JavaExec>("generateScannerC") {
-    group = "generation"
-    description = "Generate scanner.c from Kotlin ScannerSpec"
-    dependsOn(tasks.compileKotlin, tasks.processResources, generateTreeSitter)
-    classpath = configurations.runtimeClasspath.get() + sourceSets.main.get().output
-    mainClass.set("org.xtclang.tooling.scanner.ScannerCGeneratorDslKt")
-    val generatorLogLevel =
-        when (gradle.startParameter.logLevel) {
-            org.gradle.api.logging.LogLevel.DEBUG -> "DEBUG"
-            org.gradle.api.logging.LogLevel.INFO -> "INFO"
-            else -> "WARN"
-        }
-    systemProperty("xtc.logLevel", generatorLogLevel)
-    inputs.property("generatorLogLevel", generatorLogLevel)
-    args(
-        generatedDir
-            .map {
-                it
-                    .dir("src")
-                    .file("scanner.c")
-                    .asFile.absolutePath
-            }.get(),
-    )
-    inputs.files(
-        sourceSets.main
-            .get()
-            .kotlin.sourceDirectories,
-    )
-    outputs.file(generatedDir.map { it.dir("src").file("scanner.c") })
-}
+val generateScannerC =
+    tasks.register<JavaExec>("generateScannerC") {
+        group = "generation"
+        description = "Generate scanner.c from Kotlin ScannerSpec"
+        dependsOn(tasks.compileKotlin, tasks.processResources, generateTreeSitter)
+        classpath = configurations.runtimeClasspath.get() + sourceSets.main.get().output
+        mainClass.set("org.xtclang.tooling.scanner.ScannerCGeneratorDslKt")
+        val generatorLogLevel =
+            when (gradle.startParameter.logLevel) {
+                org.gradle.api.logging.LogLevel.DEBUG -> "DEBUG"
+                org.gradle.api.logging.LogLevel.INFO -> "INFO"
+                else -> "WARN"
+            }
+        systemProperty("xtc.logLevel", generatorLogLevel)
+        inputs.property("generatorLogLevel", generatorLogLevel)
+        args(
+            generatedDir
+                .map {
+                    it
+                        .dir("src")
+                        .file("scanner.c")
+                        .asFile.absolutePath
+                }.get(),
+        )
+        inputs.files(
+            sourceSets.main
+                .get()
+                .kotlin.sourceDirectories,
+        )
+        outputs.file(generatedDir.map { it.dir("src").file("scanner.c") })
+    }
 
-val generateSublime = tasks.register<JavaExec>("generateSublime") {
-    description = "Generate Sublime Text syntax file"
-    configureGenerator("sublime", "xtc.sublime-syntax")
-}
+val generateSublime =
+    tasks.register<JavaExec>("generateSublime") {
+        description = "Generate Sublime Text syntax file"
+        configureGenerator("sublime", "xtc.sublime-syntax")
+    }
 
-val generateEditorSupport = tasks.register("generateEditorSupport") {
-    group = "generation"
-    description = "Generate all editor support files"
-    dependsOn(
-        generateTextMate,
-        generateLanguageConfig,
-        generatePackageJson,
-        generateVim,
-        generateEmacs,
-        generateTreeSitter,
-        generateSublime,
-    )
-}
+val generateEditorSupport =
+    tasks.register("generateEditorSupport") {
+        group = "generation"
+        description = "Generate all editor support files"
+        dependsOn(
+            generateTextMate,
+            generateLanguageConfig,
+            generatePackageJson,
+            generateVim,
+            generateEmacs,
+            generateTreeSitter,
+            generateSublime,
+        )
+    }
 
 // =============================================================================
 // Tree-sitter Native Tasks
@@ -214,24 +224,25 @@ val generateEditorSupport = tasks.register("generateEditorSupport") {
 
 // TODO: Right now we only provide an export point for textMate, since IntelliJ and VS Code plugins use
 //   it until we have integrated semantic tokens in the LSP, which requires rewrite of at least the Lexer.t
-val textMateElements = configurations.register("textMateElements") {
-    isCanBeConsumed = true
-    isCanBeResolved = false
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named("textmate-grammar"))
+val textMateElements =
+    configurations.register("textMateElements") {
+        isCanBeConsumed = true
+        isCanBeResolved = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named("textmate-grammar"))
+        }
+        outgoing {
+            // Expose individual files with their generating tasks as dependencies
+            artifact(generatedDir.map { it.file("xtc.tmLanguage.json") }) {
+                builtBy(generateTextMate)
+            }
+            artifact(generatedDir.map { it.file("language-configuration.json") }) {
+                builtBy(generateLanguageConfig)
+            }
+            // package.json is required for IntelliJ TextMate plugin to recognize the bundle
+            artifact(generatedDir.map { it.file("package.json") }) {
+                builtBy(generatePackageJson)
+            }
+        }
     }
-    outgoing {
-        // Expose individual files with their generating tasks as dependencies
-        artifact(generatedDir.map { it.file("xtc.tmLanguage.json") }) {
-            builtBy(generateTextMate)
-        }
-        artifact(generatedDir.map { it.file("language-configuration.json") }) {
-            builtBy(generateLanguageConfig)
-        }
-        // package.json is required for IntelliJ TextMate plugin to recognize the bundle
-        artifact(generatedDir.map { it.file("package.json") }) {
-            builtBy(generatePackageJson)
-        }
-    }
-}

--- a/lang/dsl/build.gradle.kts
+++ b/lang/dsl/build.gradle.kts
@@ -26,8 +26,8 @@ tasks.test {
 }
 
 // Ensure ktlint runs during normal development (not just 'check')
-val ktlintCheck by tasks.existing
-val compileKotlin by tasks.existing {
+val ktlintCheck = tasks.named("ktlintCheck")
+val compileKotlin = tasks.named("compileKotlin") {
     dependsOn(ktlintCheck)
 }
 
@@ -85,32 +85,32 @@ fun JavaExec.configureGenerator(
     }
 }
 
-val generateTextMate by tasks.registering(JavaExec::class) {
+val generateTextMate = tasks.register<JavaExec>("generateTextMate") {
     description = "Generate TextMate grammar from the XTC language model"
     configureGenerator("textmate", "xtc.tmLanguage.json")
 }
 
-val generateLanguageConfig by tasks.registering(JavaExec::class) {
+val generateLanguageConfig = tasks.register<JavaExec>("generateLanguageConfig") {
     description = "Generate VS Code language configuration"
     configureGenerator("vscode-config", "language-configuration.json")
 }
 
-val generatePackageJson by tasks.registering(JavaExec::class) {
+val generatePackageJson = tasks.register<JavaExec>("generatePackageJson") {
     description = "Generate package.json for TextMate bundle"
     configureGenerator("package-json", "package.json")
 }
 
-val generateVim by tasks.registering(JavaExec::class) {
+val generateVim = tasks.register<JavaExec>("generateVim") {
     description = "Generate Vim syntax file"
     configureGenerator("vim", "xtc.vim")
 }
 
-val generateEmacs by tasks.registering(JavaExec::class) {
+val generateEmacs = tasks.register<JavaExec>("generateEmacs") {
     description = "Generate Emacs major mode"
     configureGenerator("emacs", "xtc-mode.el")
 }
 
-val generateTreeSitter by tasks.registering(JavaExec::class) {
+val generateTreeSitter = tasks.register<JavaExec>("generateTreeSitter") {
     group = "generation"
     description = "Generate Tree-sitter grammar and highlights"
     dependsOn(tasks.compileKotlin, tasks.processResources)
@@ -148,7 +148,7 @@ val generateTreeSitter by tasks.registering(JavaExec::class) {
 }
 
 // Generate scanner.c from Kotlin ScannerSpec (single source of truth)
-val generateScannerC by tasks.registering(JavaExec::class) {
+val generateScannerC = tasks.register<JavaExec>("generateScannerC") {
     group = "generation"
     description = "Generate scanner.c from Kotlin ScannerSpec"
     dependsOn(tasks.compileKotlin, tasks.processResources, generateTreeSitter)
@@ -179,12 +179,12 @@ val generateScannerC by tasks.registering(JavaExec::class) {
     outputs.file(generatedDir.map { it.dir("src").file("scanner.c") })
 }
 
-val generateSublime by tasks.registering(JavaExec::class) {
+val generateSublime = tasks.register<JavaExec>("generateSublime") {
     description = "Generate Sublime Text syntax file"
     configureGenerator("sublime", "xtc.sublime-syntax")
 }
 
-val generateEditorSupport by tasks.registering {
+val generateEditorSupport = tasks.register("generateEditorSupport") {
     group = "generation"
     description = "Generate all editor support files"
     dependsOn(
@@ -214,7 +214,7 @@ val generateEditorSupport by tasks.registering {
 
 // TODO: Right now we only provide an export point for textMate, since IntelliJ and VS Code plugins use
 //   it until we have integrated semantic tokens in the LSP, which requires rewrite of at least the Lexer.t
-val textMateElements by configurations.registering {
+val textMateElements = configurations.register("textMateElements") {
     isCanBeConsumed = true
     isCanBeResolved = false
     attributes {

--- a/lang/intellij-plugin/build.gradle.kts
+++ b/lang/intellij-plugin/build.gradle.kts
@@ -212,7 +212,7 @@ repositories {
 
 val syncedJavaSourceDir: Provider<Directory> = layout.buildDirectory.dir("generated/synced-java")
 
-val syncXtcProjectCreator by tasks.registering(Copy::class) {
+val syncXtcProjectCreator = tasks.register<Copy>("syncXtcProjectCreator") {
     description = "Sync XtcProjectCreator.java from javatools for Java 25 compilation"
     from(rootProject.file("../javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java"))
     into(syncedJavaSourceDir.map { it.dir("org/xvm/tool") })
@@ -223,7 +223,7 @@ val syncXtcProjectCreator by tasks.registering(Copy::class) {
 val syncedResourcesDir: Provider<Directory> = layout.buildDirectory.dir("generated/synced-resources")
 val compositeRoot: File = rootProject.projectDir.parentFile!! // /lang -> /
 
-val syncGradleWrapperResources by tasks.registering(Copy::class) {
+val syncGradleWrapperResources = tasks.register<Copy>("syncGradleWrapperResources") {
     description = "Sync gradle-wrapper resources from repo root (single source of truth)"
     from(File(compositeRoot, "gradlew"))
     from(File(compositeRoot, "gradlew.bat"))
@@ -242,21 +242,21 @@ sourceSets.main {
     kotlin.exclude("org/xtclang/idea/dap/**")
 }
 
-val compileJava by tasks.existing {
+val compileJava = tasks.named("compileJava") {
     dependsOn(syncXtcProjectCreator)
 }
 
 // Ensure ktlint runs during normal development (not just 'check')
-val ktlintCheck by tasks.existing
+val ktlintCheck = tasks.named("ktlintCheck")
 
-val compileKotlin by tasks.existing {
+val compileKotlin = tasks.named("compileKotlin") {
     dependsOn(syncXtcProjectCreator)
     dependsOn(ktlintCheck)
 }
 
 // Copy LSP version properties to plugin resources so the plugin can display version info
 // The properties file comes from lsp-server's generateBuildInfo task
-val copyLspVersionProperties by tasks.registering(Copy::class) {
+val copyLspVersionProperties = tasks.register<Copy>("copyLspVersionProperties") {
     description = "Copy LSP version properties from lsp-server for display in IDE"
     // Use the configuration directly - Gradle will resolve dependencies automatically
     from(configurations.named("lspVersionProperties"))
@@ -267,7 +267,7 @@ sourceSets.main {
     resources.srcDir(copyLspVersionProperties.map { layout.buildDirectory.dir("generated/resources/lsp") })
 }
 
-val processResources by tasks.existing {
+val processResources = tasks.named("processResources") {
     dependsOn(syncGradleWrapperResources)
     dependsOn(copyLspVersionProperties)
 }
@@ -282,7 +282,7 @@ tasks.matching { it.name.startsWith("runKtlint") }.configureEach {
 // =============================================================================
 
 // Configuration to consume TextMate grammar from dsl project
-val textMateGrammar: Configuration by configurations.creating {
+val textMateGrammar = configurations.create("textMateGrammar") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -298,7 +298,7 @@ val textMateGrammar: Configuration by configurations.creating {
 // (avoids lsp4j version conflicts with LSP4IJ) and crash/memory isolation.
 // See doc/plans/PLAN_IDE_INTEGRATION.md for architecture details.
 
-val lspServerJar: Configuration by configurations.creating {
+val lspServerJar = configurations.create("lspServerJar") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -309,7 +309,7 @@ val lspServerJar: Configuration by configurations.creating {
 }
 
 // Configuration to consume LSP version properties for display in IDE
-val lspVersionProperties: Configuration by configurations.creating {
+val lspVersionProperties = configurations.create("lspVersionProperties") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -449,7 +449,7 @@ intellijPlatform {
     }
 }
 
-val publishCheck by tasks.registering(PublishCheckTask::class) {
+val publishCheck = tasks.register<PublishCheckTask>("publishCheck") {
     publishEnabled.set(enablePublishProvider)
     xdkVersion.set(xdkVersionProvider)
     releaseChannel.set(releaseChannelProvider)
@@ -457,16 +457,16 @@ val publishCheck by tasks.registering(PublishCheckTask::class) {
     publishVersion.set(jetbrainsPublishVersionProvider)
 }
 
-val summarizeSearchableOptions by tasks.registering(SummarizeSearchableOptionsTask::class) {
+val summarizeSearchableOptions = tasks.register<SummarizeSearchableOptionsTask>("summarizeSearchableOptions") {
     group = "verification"
     description = "Summarize the generated searchable options manifest for the IntelliJ plugin build."
     mustRunAfter(buildSearchableOptions)
     manifestFile.set(layout.buildDirectory.file("tmp/buildSearchableOptions/content.json"))
 }
 
-val verifyPlugin by tasks.existing
+val verifyPlugin = tasks.named("verifyPlugin")
 
-val publishPlugin by tasks.existing {
+val publishPlugin = tasks.named("publishPlugin") {
     enabled = enablePublish
     dependsOn(publishCheck)
     // Enforce binary-compat verification before publishing, regardless of who
@@ -489,7 +489,7 @@ val searchableOptionsStatus =
     if (buildSearchableOptionsEnabled) "enabled" else "disabled (use -Plsp.buildSearchableOptions=true to enable)"
 logger.info("[ide] Searchable options: $searchableOptionsStatus")
 
-val buildSearchableOptions by tasks.existing {
+val buildSearchableOptions = tasks.named("buildSearchableOptions") {
     enabled = buildSearchableOptionsEnabled
     inputs.property("buildSearchableOptionsEnabled", buildSearchableOptionsEnabled)
     // IntelliJ headless tasks use custom classloading that triggers harmless CDS/class-sharing
@@ -503,7 +503,7 @@ val buildSearchableOptions by tasks.existing {
 // The buildPlugin task creates a distributable ZIP archive that can be installed
 // in any IntelliJ IDE. Log the output path and installation instructions.
 
-val buildPlugin by tasks.existing {
+val buildPlugin = tasks.named("buildPlugin") {
     val distDir = layout.buildDirectory.dir("distributions")
     val rootDir = project.rootDir
     doLastTask {
@@ -534,13 +534,13 @@ val buildPlugin by tasks.existing {
 // The grammar files must be on the filesystem (not inside JAR) for TextMateBundleProvider.
 
 // Get typed reference to IntelliJ Platform tasks
-val prepareSandbox by tasks.existing(Sync::class)
+val prepareSandbox = tasks.named<Sync>("prepareSandbox")
 
 // Derive TextMate destination from prepareSandbox's output (works with any IDE version)
 // prepareSandbox.destinationDir is the plugins/ directory, we need plugins/<plugin-name>/lib/textmate
 val sandboxPluginTextMate: Provider<File> = prepareSandbox.map { it.destinationDir.resolve("intellij-plugin/lib/textmate") }
 
-val copyTextMateToSandbox by tasks.registering(Sync::class) {
+val copyTextMateToSandbox = tasks.register<Sync>("copyTextMateToSandbox") {
     group = "build"
     description = "Copy TextMate grammar into plugin sandbox lib directory"
 
@@ -565,7 +565,7 @@ val copyTextMateToSandbox by tasks.registering(Sync::class) {
 
 val sandboxPluginBin: Provider<File> = prepareSandbox.map { it.destinationDir.resolve("intellij-plugin/bin") }
 
-val copyLspServerToSandbox by tasks.registering(Copy::class) {
+val copyLspServerToSandbox = tasks.register<Copy>("copyLspServerToSandbox") {
     group = "build"
     description = "Copy LSP server fat JAR into plugin sandbox bin directory (off classpath)"
 
@@ -590,7 +590,7 @@ prepareSandbox.configure {
     finalizedBy(copyLspServerToSandbox)
 }
 
-val prepareJarSearchableOptions by tasks.existing {
+val prepareJarSearchableOptions = tasks.named("prepareJarSearchableOptions") {
     // Explicit dependencies ensure copy tasks complete before scanning the sandbox lib directory.
     // These tasks share the sandbox lib output directory, so ordering must be explicit.
     dependsOn(copyTextMateToSandbox)
@@ -615,7 +615,7 @@ val disabledSandboxPlugins =
         "com.intellij.clouds.kubernetes", // Another Kubernetes component
     )
 
-val configureDisabledPlugins by tasks.registering {
+val configureDisabledPlugins = tasks.register("configureDisabledPlugins") {
     group = "intellij platform"
     description = "Disable Ultimate-only plugins in the sandbox IDE"
 
@@ -638,7 +638,7 @@ val configureDisabledPlugins by tasks.registering {
 
 // Enable INFO-level logging for the XTC plugin in the sandbox IDE.
 // IntelliJ defaults to WARN, which hides useful JRE resolution and LSP lifecycle messages.
-val configureSandboxLogging by tasks.registering {
+val configureSandboxLogging = tasks.register("configureSandboxLogging") {
     group = "intellij platform"
     description = "Configure INFO-level logging for XTC plugin in the sandbox IDE"
 
@@ -663,7 +663,7 @@ val configureSandboxLogging by tasks.registering {
     }
 }
 
-val configureSandboxAppearance by tasks.registering {
+val configureSandboxAppearance = tasks.register("configureSandboxAppearance") {
     group = "intellij platform"
     description = "Remove broken user-derived color-scheme overrides from the sandbox IDE config"
 
@@ -710,7 +710,7 @@ val runIdeCapturedLsp4ijVersion =
 val runIdeCapturedPluginVersion = project.version.toString()
 val runIdeCapturedSemanticTokens = ideLspSemanticTokens
 
-val runIdeInfo by tasks.registering(RunIdeEnvironmentReportTask::class) {
+val runIdeInfo = tasks.register<RunIdeEnvironmentReportTask>("runIdeInfo") {
     dependsOn(
         copyTextMateToSandbox,
         copyLspServerToSandbox,
@@ -741,19 +741,19 @@ val runIdeInfo by tasks.registering(RunIdeEnvironmentReportTask::class) {
     lspLogFile.set(layout.file(providers.systemProperty("user.home").map { File(it, ".xtc/logs/lsp-server.log") }))
 }
 
-val startLspLogTail by tasks.registering(StartLogTailTask::class) {
+val startLspLogTail = tasks.register<StartLogTailTask>("startLspLogTail") {
     logFile.set(layout.file(providers.systemProperty("user.home").map { File(it, ".xtc/logs/lsp-server.log") }))
     threadName.set("lsp-log-tailer")
     linePrefix.set("[lsp-server] ")
 }
 
-val stopLspLogTail by tasks.registering(StopLogTailTask::class) {
+val stopLspLogTail = tasks.register<StopLogTailTask>("stopLspLogTail") {
     threadName.set("lsp-log-tailer")
 }
 
 // Ensure TextMate files, LSP server JAR, and mavenLocal artifacts are ready before IDE starts
 // NOTE: finalizedBy doesn't guarantee completion, so we need explicit dependsOn
-val runIde by tasks.existing {
+val runIde = tasks.named("runIde") {
     parentPublishLocal.forEach { dependsOn(it) }
     dependsOn(
         copyTextMateToSandbox,
@@ -794,7 +794,7 @@ val runIde by tasks.existing {
 // or dependency changes are picked up on the next run. The downloaded IDE distribution
 // itself is cached separately and is NOT affected by clean.
 
-val clean by tasks.existing(Delete::class) {
+val clean = tasks.named<Delete>("clean") {
     delete(layout.projectDirectory.dir("../.intellijPlatform/sandbox/intellij-plugin"))
 }
 
@@ -804,7 +804,7 @@ val clean by tasks.existing(Delete::class) {
 // CDS (Class Data Sharing) is a JVM startup optimization; IntelliJ's custom classloader is incompatible with it
 // for non-system classes, so the JVM falls back to normal class loading. This is standard for all IntelliJ plugin
 // test suites and is unrelated to the LSP server JAR (which runs in a separate JVM process at runtime).
-val test by tasks.existing(Test::class) {
+val test = tasks.named<Test>("test") {
     useJUnitPlatform()
     jvmArgs("-Xlog:cds=off")
     testLogging {

--- a/lang/intellij-plugin/build.gradle.kts
+++ b/lang/intellij-plugin/build.gradle.kts
@@ -212,26 +212,28 @@ repositories {
 
 val syncedJavaSourceDir: Provider<Directory> = layout.buildDirectory.dir("generated/synced-java")
 
-val syncXtcProjectCreator = tasks.register<Copy>("syncXtcProjectCreator") {
-    description = "Sync XtcProjectCreator.java from javatools for Java 25 compilation"
-    from(rootProject.file("../javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java"))
-    into(syncedJavaSourceDir.map { it.dir("org/xvm/tool") })
-}
+val syncXtcProjectCreator =
+    tasks.register<Copy>("syncXtcProjectCreator") {
+        description = "Sync XtcProjectCreator.java from javatools for Java 25 compilation"
+        from(rootProject.file("../javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java"))
+        into(syncedJavaSourceDir.map { it.dir("org/xvm/tool") })
+    }
 
 // Sync gradle-wrapper resources needed by XtcProjectCreator
 // Source of truth is the repo root's gradle wrapper (same as what builds XVM)
 val syncedResourcesDir: Provider<Directory> = layout.buildDirectory.dir("generated/synced-resources")
 val compositeRoot: File = rootProject.projectDir.parentFile!! // /lang -> /
 
-val syncGradleWrapperResources = tasks.register<Copy>("syncGradleWrapperResources") {
-    description = "Sync gradle-wrapper resources from repo root (single source of truth)"
-    from(File(compositeRoot, "gradlew"))
-    from(File(compositeRoot, "gradlew.bat"))
-    from(File(compositeRoot, "gradle/wrapper")) {
-        into("gradle/wrapper")
+val syncGradleWrapperResources =
+    tasks.register<Copy>("syncGradleWrapperResources") {
+        description = "Sync gradle-wrapper resources from repo root (single source of truth)"
+        from(File(compositeRoot, "gradlew"))
+        from(File(compositeRoot, "gradlew.bat"))
+        from(File(compositeRoot, "gradle/wrapper")) {
+            into("gradle/wrapper")
+        }
+        into(syncedResourcesDir.map { it.dir("gradle-wrapper") })
     }
-    into(syncedResourcesDir.map { it.dir("gradle-wrapper") })
-}
 
 sourceSets.main {
     java.srcDir(syncedJavaSourceDir)
@@ -242,35 +244,39 @@ sourceSets.main {
     kotlin.exclude("org/xtclang/idea/dap/**")
 }
 
-val compileJava = tasks.named("compileJava") {
-    dependsOn(syncXtcProjectCreator)
-}
+val compileJava =
+    tasks.named("compileJava") {
+        dependsOn(syncXtcProjectCreator)
+    }
 
 // Ensure ktlint runs during normal development (not just 'check')
 val ktlintCheck = tasks.named("ktlintCheck")
 
-val compileKotlin = tasks.named("compileKotlin") {
-    dependsOn(syncXtcProjectCreator)
-    dependsOn(ktlintCheck)
-}
+val compileKotlin =
+    tasks.named("compileKotlin") {
+        dependsOn(syncXtcProjectCreator)
+        dependsOn(ktlintCheck)
+    }
 
 // Copy LSP version properties to plugin resources so the plugin can display version info
 // The properties file comes from lsp-server's generateBuildInfo task
-val copyLspVersionProperties = tasks.register<Copy>("copyLspVersionProperties") {
-    description = "Copy LSP version properties from lsp-server for display in IDE"
-    // Use the configuration directly - Gradle will resolve dependencies automatically
-    from(configurations.named("lspVersionProperties"))
-    into(layout.buildDirectory.dir("generated/resources/lsp"))
-}
+val copyLspVersionProperties =
+    tasks.register<Copy>("copyLspVersionProperties") {
+        description = "Copy LSP version properties from lsp-server for display in IDE"
+        // Use the configuration directly - Gradle will resolve dependencies automatically
+        from(configurations.named("lspVersionProperties"))
+        into(layout.buildDirectory.dir("generated/resources/lsp"))
+    }
 
 sourceSets.main {
     resources.srcDir(copyLspVersionProperties.map { layout.buildDirectory.dir("generated/resources/lsp") })
 }
 
-val processResources = tasks.named("processResources") {
-    dependsOn(syncGradleWrapperResources)
-    dependsOn(copyLspVersionProperties)
-}
+val processResources =
+    tasks.named("processResources") {
+        dependsOn(syncGradleWrapperResources)
+        dependsOn(copyLspVersionProperties)
+    }
 
 // ktlint checks synced Java sources, so it must run after sync
 tasks.matching { it.name.startsWith("runKtlint") }.configureEach {
@@ -282,14 +288,15 @@ tasks.matching { it.name.startsWith("runKtlint") }.configureEach {
 // =============================================================================
 
 // Configuration to consume TextMate grammar from dsl project
-val textMateGrammar = configurations.create("textMateGrammar") {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named("textmate-grammar"))
+val textMateGrammar =
+    configurations.create("textMateGrammar") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named("textmate-grammar"))
+        }
     }
-}
 
 // =============================================================================
 // Consumer configuration for LSP server fat JAR (out-of-process execution)
@@ -298,25 +305,27 @@ val textMateGrammar = configurations.create("textMateGrammar") {
 // (avoids lsp4j version conflicts with LSP4IJ) and crash/memory isolation.
 // See doc/plans/PLAN_IDE_INTEGRATION.md for architecture details.
 
-val lspServerJar = configurations.create("lspServerJar") {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+val lspServerJar =
+    configurations.create("lspServerJar") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+        }
     }
-}
 
 // Configuration to consume LSP version properties for display in IDE
-val lspVersionProperties = configurations.create("lspVersionProperties") {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named("lsp-version-properties"))
+val lspVersionProperties =
+    configurations.create("lspVersionProperties") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named("lsp-version-properties"))
+        }
     }
-}
 
 dependencies {
     // Test dependencies
@@ -449,34 +458,37 @@ intellijPlatform {
     }
 }
 
-val publishCheck = tasks.register<PublishCheckTask>("publishCheck") {
-    publishEnabled.set(enablePublishProvider)
-    xdkVersion.set(xdkVersionProvider)
-    releaseChannel.set(releaseChannelProvider)
-    jetbrainsTokenPresent.set(jetbrainsTokenProvider.map { it.isNotBlank() })
-    publishVersion.set(jetbrainsPublishVersionProvider)
-}
+val publishCheck =
+    tasks.register<PublishCheckTask>("publishCheck") {
+        publishEnabled.set(enablePublishProvider)
+        xdkVersion.set(xdkVersionProvider)
+        releaseChannel.set(releaseChannelProvider)
+        jetbrainsTokenPresent.set(jetbrainsTokenProvider.map { it.isNotBlank() })
+        publishVersion.set(jetbrainsPublishVersionProvider)
+    }
 
-val summarizeSearchableOptions = tasks.register<SummarizeSearchableOptionsTask>("summarizeSearchableOptions") {
-    group = "verification"
-    description = "Summarize the generated searchable options manifest for the IntelliJ plugin build."
-    mustRunAfter(buildSearchableOptions)
-    manifestFile.set(layout.buildDirectory.file("tmp/buildSearchableOptions/content.json"))
-}
+val summarizeSearchableOptions =
+    tasks.register<SummarizeSearchableOptionsTask>("summarizeSearchableOptions") {
+        group = "verification"
+        description = "Summarize the generated searchable options manifest for the IntelliJ plugin build."
+        mustRunAfter(buildSearchableOptions)
+        manifestFile.set(layout.buildDirectory.file("tmp/buildSearchableOptions/content.json"))
+    }
 
 val verifyPlugin = tasks.named("verifyPlugin")
 
-val publishPlugin = tasks.named("publishPlugin") {
-    enabled = enablePublish
-    dependsOn(publishCheck)
-    // Enforce binary-compat verification before publishing, regardless of who
-    // invokes publishPlugin (CI, local, snapshot pipeline). Catches removed/
-    // changed APIs and missing dependencies that would otherwise reach users.
-    dependsOn(verifyPlugin)
-    if (usesGeneratedJetBrainsPublishSuffix) {
-        notCompatibleWithConfigurationCache("JetBrains snapshot publish version uses a generated UTC timestamp suffix for uniqueness.")
+val publishPlugin =
+    tasks.named("publishPlugin") {
+        enabled = enablePublish
+        dependsOn(publishCheck)
+        // Enforce binary-compat verification before publishing, regardless of who
+        // invokes publishPlugin (CI, local, snapshot pipeline). Catches removed/
+        // changed APIs and missing dependencies that would otherwise reach users.
+        dependsOn(verifyPlugin)
+        if (usesGeneratedJetBrainsPublishSuffix) {
+            notCompatibleWithConfigurationCache("JetBrains snapshot publish version uses a generated UTC timestamp suffix for uniqueness.")
+        }
     }
-}
 
 // Searchable options allow IntelliJ's Settings search (Cmd+Shift+A / Ctrl+Shift+A) to index
 // this plugin's settings pages and configuration UI text. When disabled, users cannot find
@@ -489,13 +501,14 @@ val searchableOptionsStatus =
     if (buildSearchableOptionsEnabled) "enabled" else "disabled (use -Plsp.buildSearchableOptions=true to enable)"
 logger.info("[ide] Searchable options: $searchableOptionsStatus")
 
-val buildSearchableOptions = tasks.named("buildSearchableOptions") {
-    enabled = buildSearchableOptionsEnabled
-    inputs.property("buildSearchableOptionsEnabled", buildSearchableOptionsEnabled)
-    // IntelliJ headless tasks use custom classloading that triggers harmless CDS/class-sharing
-    // warnings from the JVM. Suppress them consistently so normal builds stay readable.
-    (this as JavaExec).jvmArgs("-Xlog:cds=off")
-}
+val buildSearchableOptions =
+    tasks.named("buildSearchableOptions") {
+        enabled = buildSearchableOptionsEnabled
+        inputs.property("buildSearchableOptionsEnabled", buildSearchableOptionsEnabled)
+        // IntelliJ headless tasks use custom classloading that triggers harmless CDS/class-sharing
+        // warnings from the JVM. Suppress them consistently so normal builds stay readable.
+        (this as JavaExec).jvmArgs("-Xlog:cds=off")
+    }
 
 // =============================================================================
 // Plugin Distribution ZIP
@@ -503,17 +516,18 @@ val buildSearchableOptions = tasks.named("buildSearchableOptions") {
 // The buildPlugin task creates a distributable ZIP archive that can be installed
 // in any IntelliJ IDE. Log the output path and installation instructions.
 
-val buildPlugin = tasks.named("buildPlugin") {
-    val distDir = layout.buildDirectory.dir("distributions")
-    val rootDir = project.rootDir
-    doLastTask {
-        val dir = distDir.get().asFile
-        val zipFiles = dir.listFiles { f -> f.extension == "zip" }.orEmpty()
-        if (zipFiles.isNotEmpty()) {
-            val zip = zipFiles.first()
-            val relPath = zip.relativeTo(rootDir)
-            logger.info(
-                """
+val buildPlugin =
+    tasks.named("buildPlugin") {
+        val distDir = layout.buildDirectory.dir("distributions")
+        val rootDir = project.rootDir
+        doLastTask {
+            val dir = distDir.get().asFile
+            val zipFiles = dir.listFiles { f -> f.extension == "zip" }.orEmpty()
+            if (zipFiles.isNotEmpty()) {
+                val zip = zipFiles.first()
+                val relPath = zip.relativeTo(rootDir)
+                logger.info(
+                    """
                 |[plugin] Distribution ZIP: $relPath (${zip.length().humanSize()})
                 |[plugin] Absolute path:    ${zip.absolutePath}
                 |[plugin]
@@ -521,11 +535,11 @@ val buildPlugin = tasks.named("buildPlugin") {
                 |[plugin]   1. Open Settings -> Plugins -> gear icon -> Install Plugin from Disk...
                 |[plugin]   2. Select: ${zip.absolutePath}
                 |[plugin]   3. Restart the IDE
-                """.trimMargin(),
-            )
+                    """.trimMargin(),
+                )
+            }
         }
     }
-}
 
 // =============================================================================
 // Copy TextMate Grammar into plugin lib directory
@@ -540,19 +554,20 @@ val prepareSandbox = tasks.named<Sync>("prepareSandbox")
 // prepareSandbox.destinationDir is the plugins/ directory, we need plugins/<plugin-name>/lib/textmate
 val sandboxPluginTextMate: Provider<File> = prepareSandbox.map { it.destinationDir.resolve("intellij-plugin/lib/textmate") }
 
-val copyTextMateToSandbox = tasks.register<Sync>("copyTextMateToSandbox") {
-    group = "build"
-    description = "Copy TextMate grammar into plugin sandbox lib directory"
+val copyTextMateToSandbox =
+    tasks.register<Sync>("copyTextMateToSandbox") {
+        group = "build"
+        description = "Copy TextMate grammar into plugin sandbox lib directory"
 
-    from(textMateGrammar)
-    into(sandboxPluginTextMate)
+        from(textMateGrammar)
+        into(sandboxPluginTextMate)
 
-    // Ensure DSL test compilation completes before copying (Gradle detected potential conflict with build/generated)
-    mustRunAfter(project(":dsl").tasks.named("compileTestJava"))
+        // Ensure DSL test compilation completes before copying (Gradle detected potential conflict with build/generated)
+        mustRunAfter(project(":dsl").tasks.named("compileTestJava"))
 
-    val rootDir = project.rootDir // local capture for CC safety
-    doLastTask { logCopiedFiles("textmate", destinationDir, rootDir) }
-}
+        val rootDir = project.rootDir // local capture for CC safety
+        doLastTask { logCopiedFiles("textmate", destinationDir, rootDir) }
+    }
 
 // =============================================================================
 // Copy LSP Server Fat JAR into plugin bin directory (NOT lib!)
@@ -565,37 +580,39 @@ val copyTextMateToSandbox = tasks.register<Sync>("copyTextMateToSandbox") {
 
 val sandboxPluginBin: Provider<File> = prepareSandbox.map { it.destinationDir.resolve("intellij-plugin/bin") }
 
-val copyLspServerToSandbox = tasks.register<Copy>("copyLspServerToSandbox") {
-    group = "build"
-    description = "Copy LSP server fat JAR into plugin sandbox bin directory (off classpath)"
+val copyLspServerToSandbox =
+    tasks.register<Copy>("copyLspServerToSandbox") {
+        group = "build"
+        description = "Copy LSP server fat JAR into plugin sandbox bin directory (off classpath)"
 
-    from(lspServerJar) {
-        rename { "xtc-lsp-server.jar" }
-    }
-    into(sandboxPluginBin)
+        from(lspServerJar) {
+            rename { "xtc-lsp-server.jar" }
+        }
+        into(sandboxPluginBin)
 
-    // Capture at configuration time for CC safety
-    val binDir = sandboxPluginBin
-    val rootDir = project.rootDir
-    doFirstTask {
-        binDir.get().mkdirs()
+        // Capture at configuration time for CC safety
+        val binDir = sandboxPluginBin
+        val rootDir = project.rootDir
+        doFirstTask {
+            binDir.get().mkdirs()
+        }
+        doLastTask {
+            logCopiedFiles("lsp", binDir.get(), rootDir, "Adapter: tree-sitter (out-of-process, off classpath)")
+        }
     }
-    doLastTask {
-        logCopiedFiles("lsp", binDir.get(), rootDir, "Adapter: tree-sitter (out-of-process, off classpath)")
-    }
-}
 
 prepareSandbox.configure {
     finalizedBy(copyTextMateToSandbox)
     finalizedBy(copyLspServerToSandbox)
 }
 
-val prepareJarSearchableOptions = tasks.named("prepareJarSearchableOptions") {
-    // Explicit dependencies ensure copy tasks complete before scanning the sandbox lib directory.
-    // These tasks share the sandbox lib output directory, so ordering must be explicit.
-    dependsOn(copyTextMateToSandbox)
-    dependsOn(copyLspServerToSandbox)
-}
+val prepareJarSearchableOptions =
+    tasks.named("prepareJarSearchableOptions") {
+        // Explicit dependencies ensure copy tasks complete before scanning the sandbox lib directory.
+        // These tasks share the sandbox lib output directory, so ordering must be explicit.
+        dependsOn(copyTextMateToSandbox)
+        dependsOn(copyLspServerToSandbox)
+    }
 
 // =============================================================================
 // Disable problematic plugins in the sandbox
@@ -615,80 +632,83 @@ val disabledSandboxPlugins =
         "com.intellij.clouds.kubernetes", // Another Kubernetes component
     )
 
-val configureDisabledPlugins = tasks.register("configureDisabledPlugins") {
-    group = "intellij platform"
-    description = "Disable Ultimate-only plugins in the sandbox IDE"
+val configureDisabledPlugins =
+    tasks.register("configureDisabledPlugins") {
+        group = "intellij platform"
+        description = "Disable Ultimate-only plugins in the sandbox IDE"
 
-    // Must run after prepareSandbox creates the directory structure
-    dependsOn(prepareSandbox)
-    mustRunAfter(prepareSandbox)
+        // Must run after prepareSandbox creates the directory structure
+        dependsOn(prepareSandbox)
+        mustRunAfter(prepareSandbox)
 
-    val configDir = sandboxConfigDir // Capture for configuration cache
-    val pluginsList = disabledSandboxPlugins
-    inputs.property("disabledPlugins", pluginsList)
-    outputs.dir(configDir) // Output is the config directory
+        val configDir = sandboxConfigDir // Capture for configuration cache
+        val pluginsList = disabledSandboxPlugins
+        inputs.property("disabledPlugins", pluginsList)
+        outputs.dir(configDir) // Output is the config directory
 
-    doLast {
-        val disabledPluginsFile = configDir.get().resolve("disabled_plugins.txt")
-        disabledPluginsFile.parentFile.mkdirs()
-        disabledPluginsFile.writeText(pluginsList.joinToString("\n") + "\n")
-        logger.info("[sandbox] Disabled ${pluginsList.size} Ultimate-only plugins in sandbox config")
+        doLast {
+            val disabledPluginsFile = configDir.get().resolve("disabled_plugins.txt")
+            disabledPluginsFile.parentFile.mkdirs()
+            disabledPluginsFile.writeText(pluginsList.joinToString("\n") + "\n")
+            logger.info("[sandbox] Disabled ${pluginsList.size} Ultimate-only plugins in sandbox config")
+        }
     }
-}
 
 // Enable INFO-level logging for the XTC plugin in the sandbox IDE.
 // IntelliJ defaults to WARN, which hides useful JRE resolution and LSP lifecycle messages.
-val configureSandboxLogging = tasks.register("configureSandboxLogging") {
-    group = "intellij platform"
-    description = "Configure INFO-level logging for XTC plugin in the sandbox IDE"
+val configureSandboxLogging =
+    tasks.register("configureSandboxLogging") {
+        group = "intellij platform"
+        description = "Configure INFO-level logging for XTC plugin in the sandbox IDE"
 
-    dependsOn(prepareSandbox)
-    mustRunAfter(prepareSandbox)
+        dependsOn(prepareSandbox)
+        mustRunAfter(prepareSandbox)
 
-    val configDir = sandboxConfigDir
-    outputs.dir(configDir)
+        val configDir = sandboxConfigDir
+        outputs.dir(configDir)
 
-    doLast {
-        val optionsDir = configDir.get().resolve("options")
-        optionsDir.mkdirs()
-        val logCategoriesFile = optionsDir.resolve("log-categories.xml")
-        logCategoriesFile.writeText(
-            """
+        doLast {
+            val optionsDir = configDir.get().resolve("options")
+            optionsDir.mkdirs()
+            val logCategoriesFile = optionsDir.resolve("log-categories.xml")
+            logCategoriesFile.writeText(
+                """
             |<application>
             |  <component name="Logs.Categories"><![CDATA[{"org.xtclang":"INFO"}]]></component>
             |</application>
-            """.trimMargin() + "\n",
-        )
-        logger.info("[sandbox] Configured INFO-level logging for org.xtclang")
-    }
-}
-
-val configureSandboxAppearance = tasks.register("configureSandboxAppearance") {
-    group = "intellij platform"
-    description = "Remove broken user-derived color-scheme overrides from the sandbox IDE config"
-
-    dependsOn(prepareSandbox)
-    mustRunAfter(prepareSandbox)
-
-    val configDir = sandboxConfigDir
-    outputs.dir(configDir)
-
-    doLast {
-        val colorsSchemeFile = configDir.get().resolve("options/colors.scheme.xml")
-        if (!colorsSchemeFile.isFile) {
-            return@doLast
+                """.trimMargin() + "\n",
+            )
+            logger.info("[sandbox] Configured INFO-level logging for org.xtclang")
         }
-
-        val text = colorsSchemeFile.readText()
-        if ("_@user_" !in text) {
-            logger.info("[sandbox] Preserving sandbox color scheme override: ${colorsSchemeFile.absolutePath}")
-            return@doLast
-        }
-
-        colorsSchemeFile.delete()
-        logger.info("[sandbox] Removed user-derived sandbox color scheme override: ${colorsSchemeFile.absolutePath}")
     }
-}
+
+val configureSandboxAppearance =
+    tasks.register("configureSandboxAppearance") {
+        group = "intellij platform"
+        description = "Remove broken user-derived color-scheme overrides from the sandbox IDE config"
+
+        dependsOn(prepareSandbox)
+        mustRunAfter(prepareSandbox)
+
+        val configDir = sandboxConfigDir
+        outputs.dir(configDir)
+
+        doLast {
+            val colorsSchemeFile = configDir.get().resolve("options/colors.scheme.xml")
+            if (!colorsSchemeFile.isFile) {
+                return@doLast
+            }
+
+            val text = colorsSchemeFile.readText()
+            if ("_@user_" !in text) {
+                logger.info("[sandbox] Preserving sandbox color scheme override: ${colorsSchemeFile.absolutePath}")
+                return@doLast
+            }
+
+            colorsSchemeFile.delete()
+            logger.info("[sandbox] Removed user-derived sandbox color scheme override: ${colorsSchemeFile.absolutePath}")
+        }
+    }
 
 // Ensure the Ecstasy Gradle plugin and XDK are published to mavenLocal before the sandbox IDE starts.
 // The sandbox IDE resolves the plugin from mavenLocal (not from the composite includeBuild),
@@ -710,80 +730,84 @@ val runIdeCapturedLsp4ijVersion =
 val runIdeCapturedPluginVersion = project.version.toString()
 val runIdeCapturedSemanticTokens = ideLspSemanticTokens
 
-val runIdeInfo = tasks.register<RunIdeEnvironmentReportTask>("runIdeInfo") {
-    dependsOn(
-        copyTextMateToSandbox,
-        copyLspServerToSandbox,
-        configureDisabledPlugins,
-        configureSandboxLogging,
-        configureSandboxAppearance,
-    )
-    ideVersion.set(runIdeCapturedIdeVersion)
-    sinceBuild.set(runIdeCapturedSinceBuild)
-    lsp4ijVersion.set(runIdeCapturedLsp4ijVersion)
-    pluginVersion.set(runIdeCapturedPluginVersion)
-    semanticTokensEnabled.set(runIdeCapturedSemanticTokens)
-    sandboxDir.set(layout.dir(sandboxConfigDir.map { it.parentFile }))
-    val mavenLocalRoot =
-        providers
-            .systemProperty("maven.repo.local")
-            .orElse(providers.systemProperty("user.home").map { "$it/.m2/repository" })
-    this.mavenLocalRoot.set(layout.dir(mavenLocalRoot.map(::File)))
-    pluginNames.set(
-        sandboxConfigDir.map { configDir ->
-            configDir.parentFile
-                .resolve("plugins")
-                .listFiles()
-                ?.map { it.name }
-                ?.sorted() ?: emptyList()
-        },
-    )
-    lspLogFile.set(layout.file(providers.systemProperty("user.home").map { File(it, ".xtc/logs/lsp-server.log") }))
-}
+val runIdeInfo =
+    tasks.register<RunIdeEnvironmentReportTask>("runIdeInfo") {
+        dependsOn(
+            copyTextMateToSandbox,
+            copyLspServerToSandbox,
+            configureDisabledPlugins,
+            configureSandboxLogging,
+            configureSandboxAppearance,
+        )
+        ideVersion.set(runIdeCapturedIdeVersion)
+        sinceBuild.set(runIdeCapturedSinceBuild)
+        lsp4ijVersion.set(runIdeCapturedLsp4ijVersion)
+        pluginVersion.set(runIdeCapturedPluginVersion)
+        semanticTokensEnabled.set(runIdeCapturedSemanticTokens)
+        sandboxDir.set(layout.dir(sandboxConfigDir.map { it.parentFile }))
+        val mavenLocalRoot =
+            providers
+                .systemProperty("maven.repo.local")
+                .orElse(providers.systemProperty("user.home").map { "$it/.m2/repository" })
+        this.mavenLocalRoot.set(layout.dir(mavenLocalRoot.map(::File)))
+        pluginNames.set(
+            sandboxConfigDir.map { configDir ->
+                configDir.parentFile
+                    .resolve("plugins")
+                    .listFiles()
+                    ?.map { it.name }
+                    ?.sorted() ?: emptyList()
+            },
+        )
+        lspLogFile.set(layout.file(providers.systemProperty("user.home").map { File(it, ".xtc/logs/lsp-server.log") }))
+    }
 
-val startLspLogTail = tasks.register<StartLogTailTask>("startLspLogTail") {
-    logFile.set(layout.file(providers.systemProperty("user.home").map { File(it, ".xtc/logs/lsp-server.log") }))
-    threadName.set("lsp-log-tailer")
-    linePrefix.set("[lsp-server] ")
-}
+val startLspLogTail =
+    tasks.register<StartLogTailTask>("startLspLogTail") {
+        logFile.set(layout.file(providers.systemProperty("user.home").map { File(it, ".xtc/logs/lsp-server.log") }))
+        threadName.set("lsp-log-tailer")
+        linePrefix.set("[lsp-server] ")
+    }
 
-val stopLspLogTail = tasks.register<StopLogTailTask>("stopLspLogTail") {
-    threadName.set("lsp-log-tailer")
-}
+val stopLspLogTail =
+    tasks.register<StopLogTailTask>("stopLspLogTail") {
+        threadName.set("lsp-log-tailer")
+    }
 
 // Ensure TextMate files, LSP server JAR, and mavenLocal artifacts are ready before IDE starts
 // NOTE: finalizedBy doesn't guarantee completion, so we need explicit dependsOn
-val runIde = tasks.named("runIde") {
-    parentPublishLocal.forEach { dependsOn(it) }
-    dependsOn(
-        copyTextMateToSandbox,
-        copyLspServerToSandbox,
-        configureDisabledPlugins,
-        configureSandboxLogging,
-        configureSandboxAppearance,
-        runIdeInfo,
-        startLspLogTail,
-    )
+val runIde =
+    tasks.named("runIde") {
+        parentPublishLocal.forEach { dependsOn(it) }
+        dependsOn(
+            copyTextMateToSandbox,
+            copyLspServerToSandbox,
+            configureDisabledPlugins,
+            configureSandboxLogging,
+            configureSandboxAppearance,
+            runIdeInfo,
+            startLspLogTail,
+        )
 
-    // Pass log level to the IDE JVM so the IntelliJ plugin can forward it to the
-    // out-of-process LSP server. Set both system property and env var for robustness.
-    (this as JavaExec).apply {
-        systemProperty("xtc.logLevel", logLevel)
-        environment("XTC_LOG_LEVEL", logLevel)
-        systemProperty("xtc.lsp.semanticTokens", ideLspSemanticTokens)
-        environment("XTC_LSP_SEMANTIC_TOKENS", ideLspSemanticTokens)
-        // IntelliJ's classloader setup disables JVM CDS optimizations and otherwise prints
-        // harmless class-sharing warnings. Suppress those so runIde output stays focused.
-        jvmArgs("-Xlog:cds=off")
-        // Sandbox plugin auto-reload is convenient during plugin development, but in this
-        // project it can leave IntelliJ holding a stale or partially reloaded plugin JAR
-        // while Gradle is still rebuilding and copying artifacts into the sandbox.
-        // Disable it for deterministic startup and classloading.
-        systemProperty("idea.auto.reload.plugins", "false")
+        // Pass log level to the IDE JVM so the IntelliJ plugin can forward it to the
+        // out-of-process LSP server. Set both system property and env var for robustness.
+        (this as JavaExec).apply {
+            systemProperty("xtc.logLevel", logLevel)
+            environment("XTC_LOG_LEVEL", logLevel)
+            systemProperty("xtc.lsp.semanticTokens", ideLspSemanticTokens)
+            environment("XTC_LSP_SEMANTIC_TOKENS", ideLspSemanticTokens)
+            // IntelliJ's classloader setup disables JVM CDS optimizations and otherwise prints
+            // harmless class-sharing warnings. Suppress those so runIde output stays focused.
+            jvmArgs("-Xlog:cds=off")
+            // Sandbox plugin auto-reload is convenient during plugin development, but in this
+            // project it can leave IntelliJ holding a stale or partially reloaded plugin JAR
+            // while Gradle is still rebuilding and copying artifacts into the sandbox.
+            // Disable it for deterministic startup and classloading.
+            systemProperty("idea.auto.reload.plugins", "false")
+        }
+
+        finalizedBy(stopLspLogTail)
     }
-
-    finalizedBy(stopLspLogTail)
-}
 
 // =============================================================================
 // Clean sandbox when running 'clean'
@@ -794,9 +818,10 @@ val runIde = tasks.named("runIde") {
 // or dependency changes are picked up on the next run. The downloaded IDE distribution
 // itself is cached separately and is NOT affected by clean.
 
-val clean = tasks.named<Delete>("clean") {
-    delete(layout.projectDirectory.dir("../.intellijPlatform/sandbox/intellij-plugin"))
-}
+val clean =
+    tasks.named<Delete>("clean") {
+        delete(layout.projectDirectory.dir("../.intellijPlatform/sandbox/intellij-plugin"))
+    }
 
 // The IntelliJ Platform Gradle Plugin sets -Djava.system.class.loader=com.intellij.util.lang.PathClassLoader
 // on the test JVM so that IntelliJ's plugin classloading works during tests. This causes a harmless JVM warning:
@@ -804,10 +829,11 @@ val clean = tasks.named<Delete>("clean") {
 // CDS (Class Data Sharing) is a JVM startup optimization; IntelliJ's custom classloader is incompatible with it
 // for non-system classes, so the JVM falls back to normal class loading. This is standard for all IntelliJ plugin
 // test suites and is unrelated to the LSP server JAR (which runs in a separate JVM process at runtime).
-val test = tasks.named<Test>("test") {
-    useJUnitPlatform()
-    jvmArgs("-Xlog:cds=off")
-    testLogging {
-        events("failed")
+val test =
+    tasks.named<Test>("test") {
+        useJUnitPlatform()
+        jvmArgs("-Xlog:cds=off")
+        testLogging {
+            events("failed")
+        }
     }
-}

--- a/lang/lsp-server/build.gradle.kts
+++ b/lang/lsp-server/build.gradle.kts
@@ -72,32 +72,33 @@ val logLevel: String =
 logger.info("[lsp] LSP Server adapter: $lspAdapter, semanticTokens: $lspSemanticTokens, logLevel: $logLevel")
 
 // Generate build info for version verification and adapter selection
-val generateBuildInfo = tasks.register("generateBuildInfo") {
-    val outputDir = layout.buildDirectory.dir("generated/resources/buildinfo")
-    val buildTime = Instant.now().toString()
-    val projectVersion = project.version.toString() // Capture at configuration time
-    val adapter = lspAdapter // Capture at configuration time
-    val semanticTokens = lspSemanticTokens // Capture at configuration time
+val generateBuildInfo =
+    tasks.register("generateBuildInfo") {
+        val outputDir = layout.buildDirectory.dir("generated/resources/buildinfo")
+        val buildTime = Instant.now().toString()
+        val projectVersion = project.version.toString() // Capture at configuration time
+        val adapter = lspAdapter // Capture at configuration time
+        val semanticTokens = lspSemanticTokens // Capture at configuration time
 
-    // Declare inputs so task re-runs when adapter or feature flags change
-    inputs.property("adapter", adapter)
-    inputs.property("semanticTokens", semanticTokens)
-    inputs.property("version", projectVersion)
-    outputs.dir(outputDir)
+        // Declare inputs so task re-runs when adapter or feature flags change
+        inputs.property("adapter", adapter)
+        inputs.property("semanticTokens", semanticTokens)
+        inputs.property("version", projectVersion)
+        outputs.dir(outputDir)
 
-    doLast {
-        val outFile = outputDir.get().file("lsp-version.properties").asFile
-        outFile.parentFile.mkdirs()
-        outFile.writeText(
-            """
-            lsp.build.time=$buildTime
-            lsp.version=$projectVersion
-            lsp.adapter=$adapter
-            lsp.semanticTokens=$semanticTokens
-            """.trimIndent() + "\n",
-        )
+        doLast {
+            val outFile = outputDir.get().file("lsp-version.properties").asFile
+            outFile.parentFile.mkdirs()
+            outFile.writeText(
+                """
+                lsp.build.time=$buildTime
+                lsp.version=$projectVersion
+                lsp.adapter=$adapter
+                lsp.semanticTokens=$semanticTokens
+                """.trimIndent() + "\n",
+            )
+        }
     }
-}
 
 sourceSets.main {
     resources.srcDir(generateBuildInfo.map { layout.buildDirectory.dir("generated/resources/buildinfo") })
@@ -116,14 +117,15 @@ repositories {
 // Consume the tree-sitter native library for the current platform.
 // This library is built on-demand using Zig cross-compilation.
 
-val treeSitterNativeLib = configurations.create("treeSitterNativeLib") {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named("native-library"))
+val treeSitterNativeLib =
+    configurations.create("treeSitterNativeLib") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named("native-library"))
+        }
     }
-}
 
 dependencies {
     // Native library from tree-sitter project
@@ -161,13 +163,14 @@ dependencies {
 // so they can be bundled in the JAR. The runtime loader will select the appropriate
 // library based on the current platform.
 
-val copyNativeLibToResources = tasks.register<Copy>("copyNativeLibToResources") {
-    group = "build"
-    description = "Copy tree-sitter native libraries for all platforms to resources"
+val copyNativeLibToResources =
+    tasks.register<Copy>("copyNativeLibToResources") {
+        group = "build"
+        description = "Copy tree-sitter native libraries for all platforms to resources"
 
-    from(treeSitterNativeLib)
-    into(layout.buildDirectory.dir("generated/resources/native"))
-}
+        from(treeSitterNativeLib)
+        into(layout.buildDirectory.dir("generated/resources/native"))
+    }
 
 // Add native library resources to source sets
 sourceSets.main {
@@ -175,9 +178,10 @@ sourceSets.main {
 }
 
 // Ensure native library is copied before processResources
-val processResources = tasks.named("processResources") {
-    dependsOn(copyNativeLibToResources)
-}
+val processResources =
+    tasks.named("processResources") {
+        dependsOn(copyNativeLibToResources)
+    }
 
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:deprecation")
@@ -191,9 +195,10 @@ tasks.withType<JavaCompile>().configureEach {
 // We fix this by making compileKotlin depend on ktlintCheck, so any build
 // that compiles code also verifies formatting.
 val ktlintCheck = tasks.named("ktlintCheck")
-val compileKotlin = tasks.named("compileKotlin") {
-    dependsOn(ktlintCheck)
-}
+val compileKotlin =
+    tasks.named("compileKotlin") {
+        dependsOn(ktlintCheck)
+    }
 val classes = tasks.named("classes")
 
 tasks.test {
@@ -232,30 +237,31 @@ tasks.jar {
 // Creates a self-contained JAR with all dependencies that can be launched
 // by any IDE (IntelliJ, VS Code, etc.) as a language server process.
 
-val fatJar = tasks.register<Jar>("fatJar") {
-    archiveClassifier.set("all")
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+val fatJar =
+    tasks.register<Jar>("fatJar") {
+        archiveClassifier.set("all")
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-    // Explicit dependency ensures resources (logback.xml, etc.) are processed before JAR creation
-    dependsOn(classes)
+        // Explicit dependency ensures resources (logback.xml, etc.) are processed before JAR creation
+        dependsOn(classes)
 
-    from(sourceSets.main.get().output)
+        from(sourceSets.main.get().output)
 
-    dependsOn(configurations.runtimeClasspath)
-    from({
-        configurations.runtimeClasspath
-            .get()
-            .filter { it.name.endsWith("jar") }
-            .map { zipTree(it) }
-    })
+        dependsOn(configurations.runtimeClasspath)
+        from({
+            configurations.runtimeClasspath
+                .get()
+                .filter { it.name.endsWith("jar") }
+                .map { zipTree(it) }
+        })
 
-    // Exclude signature files from dependencies (they become invalid in fat JAR)
-    exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
+        // Exclude signature files from dependencies (they become invalid in fat JAR)
+        exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
 
-    manifest {
-        attributes("Main-Class" to "org.xvm.lsp.server.XtcLanguageServerLauncherKt")
+        manifest {
+            attributes("Main-Class" to "org.xvm.lsp.server.XtcLanguageServerLauncherKt")
+        }
     }
-}
 
 // =============================================================================
 // Consumable configuration for IDE plugins
@@ -263,36 +269,39 @@ val fatJar = tasks.register<Jar>("fatJar") {
 // This configuration exposes the fat JAR as an artifact that other projects
 // (like intellij-plugin) can depend on through proper Gradle configuration.
 
-val lspServerElements = configurations.register("lspServerElements") {
-    isCanBeConsumed = true
-    isCanBeResolved = false
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+val lspServerElements =
+    configurations.register("lspServerElements") {
+        isCanBeConsumed = true
+        isCanBeResolved = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+        }
+        outgoing {
+            artifact(fatJar)
+        }
     }
-    outgoing {
-        artifact(fatJar)
-    }
-}
 
 // Configuration to expose version properties to IDE plugins
 // This allows the IntelliJ plugin to display version info without accessing the LSP JAR
-val lspVersionProperties = configurations.register("lspVersionProperties") {
-    isCanBeConsumed = true
-    isCanBeResolved = false
-    attributes {
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named("lsp-version-properties"))
-    }
-    outgoing {
-        artifact(generateBuildInfo.map { layout.buildDirectory.file("generated/resources/buildinfo/lsp-version.properties") }) {
-            builtBy(generateBuildInfo)
+val lspVersionProperties =
+    configurations.register("lspVersionProperties") {
+        isCanBeConsumed = true
+        isCanBeResolved = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named("lsp-version-properties"))
+        }
+        outgoing {
+            artifact(generateBuildInfo.map { layout.buildDirectory.file("generated/resources/buildinfo/lsp-version.properties") }) {
+                builtBy(generateBuildInfo)
+            }
         }
     }
-}
 
 // Ensure fatJar is built when assembling
-val assemble = tasks.named("assemble") {
-    dependsOn(fatJar)
-}
+val assemble =
+    tasks.named("assemble") {
+        dependsOn(fatJar)
+    }

--- a/lang/lsp-server/build.gradle.kts
+++ b/lang/lsp-server/build.gradle.kts
@@ -72,7 +72,7 @@ val logLevel: String =
 logger.info("[lsp] LSP Server adapter: $lspAdapter, semanticTokens: $lspSemanticTokens, logLevel: $logLevel")
 
 // Generate build info for version verification and adapter selection
-val generateBuildInfo by tasks.registering {
+val generateBuildInfo = tasks.register("generateBuildInfo") {
     val outputDir = layout.buildDirectory.dir("generated/resources/buildinfo")
     val buildTime = Instant.now().toString()
     val projectVersion = project.version.toString() // Capture at configuration time
@@ -116,7 +116,7 @@ repositories {
 // Consume the tree-sitter native library for the current platform.
 // This library is built on-demand using Zig cross-compilation.
 
-val treeSitterNativeLib: Configuration by configurations.creating {
+val treeSitterNativeLib = configurations.create("treeSitterNativeLib") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -161,7 +161,7 @@ dependencies {
 // so they can be bundled in the JAR. The runtime loader will select the appropriate
 // library based on the current platform.
 
-val copyNativeLibToResources by tasks.registering(Copy::class) {
+val copyNativeLibToResources = tasks.register<Copy>("copyNativeLibToResources") {
     group = "build"
     description = "Copy tree-sitter native libraries for all platforms to resources"
 
@@ -175,7 +175,7 @@ sourceSets.main {
 }
 
 // Ensure native library is copied before processResources
-val processResources by tasks.existing {
+val processResources = tasks.named("processResources") {
     dependsOn(copyNativeLibToResources)
 }
 
@@ -190,11 +190,11 @@ tasks.withType<JavaCompile>().configureEach {
 // This means running 'runIde', 'jar', or 'assemble' skips ktlint entirely.
 // We fix this by making compileKotlin depend on ktlintCheck, so any build
 // that compiles code also verifies formatting.
-val ktlintCheck by tasks.existing
-val compileKotlin by tasks.existing {
+val ktlintCheck = tasks.named("ktlintCheck")
+val compileKotlin = tasks.named("compileKotlin") {
     dependsOn(ktlintCheck)
 }
-val classes by tasks.existing
+val classes = tasks.named("classes")
 
 tasks.test {
     useJUnitPlatform()
@@ -232,7 +232,7 @@ tasks.jar {
 // Creates a self-contained JAR with all dependencies that can be launched
 // by any IDE (IntelliJ, VS Code, etc.) as a language server process.
 
-val fatJar by tasks.registering(Jar::class) {
+val fatJar = tasks.register<Jar>("fatJar") {
     archiveClassifier.set("all")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
@@ -263,7 +263,7 @@ val fatJar by tasks.registering(Jar::class) {
 // This configuration exposes the fat JAR as an artifact that other projects
 // (like intellij-plugin) can depend on through proper Gradle configuration.
 
-val lspServerElements by configurations.registering {
+val lspServerElements = configurations.register("lspServerElements") {
     isCanBeConsumed = true
     isCanBeResolved = false
     attributes {
@@ -278,7 +278,7 @@ val lspServerElements by configurations.registering {
 
 // Configuration to expose version properties to IDE plugins
 // This allows the IntelliJ plugin to display version info without accessing the LSP JAR
-val lspVersionProperties by configurations.registering {
+val lspVersionProperties = configurations.register("lspVersionProperties") {
     isCanBeConsumed = true
     isCanBeResolved = false
     attributes {
@@ -293,6 +293,6 @@ val lspVersionProperties by configurations.registering {
 }
 
 // Ensure fatJar is built when assembling
-val assemble by tasks.existing {
+val assemble = tasks.named("assemble") {
     dependsOn(fatJar)
 }

--- a/lang/tree-sitter/build.gradle.kts
+++ b/lang/tree-sitter/build.gradle.kts
@@ -97,7 +97,7 @@ val nativeLibFile: Provider<RegularFile> = nativeOutputDir.map { it.file("libtre
 /**
  * Download tree-sitter CLI gzipped binary for the current platform.
  */
-val downloadTreeSitterCliGz by tasks.registering(Download::class) {
+val downloadTreeSitterCliGz = tasks.register<Download>("downloadTreeSitterCliGz") {
     group = "tree-sitter"
     description = "Download tree-sitter CLI gzipped binary"
     enabled = treeSitterPlatformSupported
@@ -124,7 +124,7 @@ val downloadTreeSitterCliGz by tasks.registering(Download::class) {
  * Extract the tree-sitter CLI from the downloaded gzip file.
  * Uses Java's built-in GZIPInputStream for platform independence.
  */
-val extractTreeSitterCli by tasks.registering {
+val extractTreeSitterCli = tasks.register("extractTreeSitterCli") {
     group = "tree-sitter"
     description = "Extract tree-sitter CLI from gzip"
     dependsOn(downloadTreeSitterCliGz)
@@ -167,7 +167,7 @@ val treeSitterSourceDir: Provider<Directory> = layout.buildDirectory.dir("tree-s
 /**
  * Download tree-sitter source code for building the runtime library.
  */
-val downloadTreeSitterSource by tasks.registering(Download::class) {
+val downloadTreeSitterSource = tasks.register<Download>("downloadTreeSitterSource") {
     group = "tree-sitter"
     description = "Download tree-sitter source for runtime library build"
 
@@ -198,7 +198,7 @@ val downloadTreeSitterSource by tasks.registering(Download::class) {
 /**
  * Extract tree-sitter source code.
  */
-val extractTreeSitterSource by tasks.registering {
+val extractTreeSitterSource = tasks.register("extractTreeSitterSource") {
     group = "tree-sitter"
     description = "Extract tree-sitter source"
     dependsOn(downloadTreeSitterSource)
@@ -269,7 +269,7 @@ val zigExeName = if (osName.contains("windows")) "zig.exe" else "zig"
  * Download Zig compiler archive for the current platform.
  * Downloads to persistent cache in ~/.gradle/caches/zig/<version>/
  */
-val downloadZig by tasks.registering(Download::class) {
+val downloadZig = tasks.register<Download>("downloadZig") {
     group = "zig"
     description = "Download Zig compiler for cross-compilation"
     enabled = zigPlatformSupported
@@ -366,7 +366,7 @@ abstract class ExtractZigTask @Inject constructor(
     }
 }
 
-val extractZig by tasks.registering(ExtractZigTask::class) {
+val extractZig = tasks.register<ExtractZigTask>("extractZig") {
     group = "zig"
     description = "Extract Zig compiler from archive (cached in ~/.gradle/caches/zig/)"
     dependsOn(downloadZig)
@@ -386,7 +386,7 @@ val zigExe: String = File(zigDir, "zig-$zigPlatform-$zigVersion/$zigExeName").ab
 /**
  * Copy generated grammar.js and scanner.c from the DSL project.
  */
-val copyGrammarFiles by tasks.registering(Copy::class) {
+val copyGrammarFiles = tasks.register<Copy>("copyGrammarFiles") {
     group = "tree-sitter"
     description = "Copy grammar files from DSL project"
     dependsOn(dslProject.tasks.named("generateTreeSitter"), dslProject.tasks.named("generateScannerC"))
@@ -403,7 +403,7 @@ val copyGrammarFiles by tasks.registering(Copy::class) {
  * Generate tree-sitter.json config file for ABI version 15 support.
  * This eliminates the warning about missing config file.
  */
-val generateTreeSitterConfig by tasks.registering {
+val generateTreeSitterConfig = tasks.register("generateTreeSitterConfig") {
     group = "tree-sitter"
     description = "Generate tree-sitter.json (grammar manifest) and tree-sitter-user-config.json (CLI parser-directories)"
     dependsOn(copyGrammarFiles)
@@ -467,7 +467,7 @@ val generateTreeSitterConfig by tasks.registering {
  * Validate that the generated tree-sitter grammar compiles.
  * This runs `tree-sitter generate` which validates grammar.js and produces parser.c
  */
-val validateTreeSitterGrammar by tasks.registering(Exec::class) {
+val validateTreeSitterGrammar = tasks.register<Exec>("validateTreeSitterGrammar") {
     group = "tree-sitter"
     description = "Validate tree-sitter grammar compiles"
     dependsOn(copyGrammarFiles, extractTreeSitterCli, generateTreeSitterConfig)
@@ -743,7 +743,7 @@ abstract class TreeSitterParseTestTask @Inject constructor(
     }
 }
 
-val testTreeSitterParse by tasks.registering(TreeSitterParseTestTask::class) {
+val testTreeSitterParse = tasks.register<TreeSitterParseTestTask>("testTreeSitterParse") {
     group = "tree-sitter"
     description = "Test tree-sitter parsing on XDK library files. Use -PtestFiles=pattern to filter. Timing shown by default; use -PshowTiming=false to disable."
     dependsOn(validateTreeSitterGrammar)
@@ -975,7 +975,7 @@ crossCompileTargets.forEach { (platform, zigTarget) ->
 /**
  * Build all native libraries (grammar + runtime) for all platforms using Zig.
  */
-val buildAllNativeLibraries by tasks.registering {
+val buildAllNativeLibraries = tasks.register("buildAllNativeLibraries") {
     group = "tree-sitter"
     description = "Build grammar and runtime libraries for all platforms using Zig"
     enabled = zigPlatformSupported
@@ -992,7 +992,7 @@ val buildAllNativeLibraries by tasks.registering {
  * This is useful for CI to warm the cache, or for developers building all platforms locally.
  * Libraries are stored in ~/.gradle/caches/tree-sitter-xtc/<hash>/<platform>/
  */
-val populateNativeLibraryCache by tasks.registering {
+val populateNativeLibraryCache = tasks.register("populateNativeLibraryCache") {
     group = "tree-sitter"
     description = "Build and cache native libraries for all platforms"
     dependsOn(buildAllNativeLibraries)
@@ -1359,7 +1359,7 @@ val nativeLibOutputDir: Provider<Directory> = layout.buildDirectory.dir("native-
  * Build native libraries for ALL platforms on-demand with caching.
  * This is the task that consumers should depend on.
  */
-val buildAllNativeLibrariesOnDemand by tasks.registering(BuildAllNativeLibrariesOnDemandTask::class) {
+val buildAllNativeLibrariesOnDemand = tasks.register<BuildAllNativeLibrariesOnDemandTask>("buildAllNativeLibrariesOnDemand") {
     group = "tree-sitter"
     description = "Build native libraries for all platforms (cached in ~/.gradle/caches/)"
     dependsOn(copyGrammarFiles, extractZig, extractTreeSitterSource, validateTreeSitterGrammar)
@@ -1386,7 +1386,7 @@ val buildAllNativeLibrariesOnDemand by tasks.registering(BuildAllNativeLibraries
  * Expose native libraries for ALL platforms for consumption by other projects.
  * Libraries are built on-demand using Zig cross-compilation and cached.
  */
-val nativeLibraryElements by configurations.registering {
+val nativeLibraryElements = configurations.register("nativeLibraryElements") {
     isCanBeConsumed = true
     isCanBeResolved = false
     attributes {

--- a/lang/vscode-extension/build.gradle.kts
+++ b/lang/vscode-extension/build.gradle.kts
@@ -12,7 +12,7 @@ node {
 }
 
 // Configuration to consume TextMate grammar from root project
-val textMateGrammar by configurations.creating {
+val textMateGrammar = configurations.create("textMateGrammar") {
     isCanBeConsumed = false
     isCanBeResolved = true
     attributes {
@@ -26,7 +26,7 @@ dependencies {
 }
 
 // Copy TextMate grammar files
-val copyTextMateGrammar by tasks.registering(Copy::class) {
+val copyTextMateGrammar = tasks.register<Copy>("copyTextMateGrammar") {
     description = "Copy TextMate grammar from generated output"
     from(textMateGrammar) {
         include("xtc.tmLanguage.json")
@@ -35,7 +35,7 @@ val copyTextMateGrammar by tasks.registering(Copy::class) {
 }
 
 // Copy language configuration
-val copyLanguageConfig by tasks.registering(Copy::class) {
+val copyLanguageConfig = tasks.register<Copy>("copyLanguageConfig") {
     description = "Copy language configuration from generated output"
     from(textMateGrammar) {
         include("language-configuration.json")
@@ -44,7 +44,7 @@ val copyLanguageConfig by tasks.registering(Copy::class) {
 }
 
 // Copy LSP server fat JAR (self-contained with all dependencies: LSP4J, tree-sitter, Logback)
-val copyLspServer by tasks.registering(Copy::class) {
+val copyLspServer = tasks.register<Copy>("copyLspServer") {
     description = "Copy LSP server fat JAR"
     dependsOn(project(":lsp-server").tasks.named("fatJar"))
     from(project(":lsp-server").tasks.named("fatJar"))
@@ -53,7 +53,7 @@ val copyLspServer by tasks.registering(Copy::class) {
 }
 
 // Copy DAP server JAR (bundled for debugging support)
-val copyDapServer by tasks.registering(Copy::class) {
+val copyDapServer = tasks.register<Copy>("copyDapServer") {
     description = "Copy DAP server JAR"
     dependsOn(project(":dap-server").tasks.named("jar"))
     from(project(":dap-server").tasks.named("jar")) {
@@ -64,7 +64,7 @@ val copyDapServer by tasks.registering(Copy::class) {
 }
 
 // Copy LICENSE from repository root
-val copyLicense by tasks.registering(Copy::class) {
+val copyLicense = tasks.register<Copy>("copyLicense") {
     description = "Copy LICENSE from repository root"
     val compositeRoot = XdkPropertiesService.compositeRootDirectory(projectDir)
     from(File(compositeRoot, "LICENSE.md"))
@@ -75,7 +75,7 @@ val copyLicense by tasks.registering(Copy::class) {
 // (xtc-file.png, 32x32) from doc/logo/x.jpg in the repository root. We derive
 // PNGs rather than checking them in so the single JPEG source of truth in
 // doc/logo/ stays canonical; the `sharp` devDependency handles the conversion.
-val generateIcons by tasks.registering(NodeTask::class) {
+val generateIcons = tasks.register<NodeTask>("generateIcons") {
     description = "Generate VS Code marketplace and file icons from doc/logo/x.jpg"
     dependsOn(tasks.named("npmInstall"))
     val compositeRoot = XdkPropertiesService.compositeRootDirectory(projectDir)
@@ -91,12 +91,12 @@ val generateIcons by tasks.registering(NodeTask::class) {
 }
 
 // Configure the plugin-provided npmInstall task (runs `npm install` using the pinned Node)
-val npmInstall by tasks.existing {
+val npmInstall = tasks.named("npmInstall") {
     mustRunAfter(copyLanguageConfig, copyTextMateGrammar, copyLicense)
 }
 
 // Compile TypeScript
-val npmCompile by tasks.registering(NpmTask::class) {
+val npmCompile = tasks.register<NpmTask>("npmCompile") {
     description = "Compile TypeScript"
     dependsOn(npmInstall)
     args.set(listOf("run", "compile"))
@@ -125,7 +125,7 @@ val npmCompile by tasks.registering(NpmTask::class) {
 // else in the repo.
 val vscodeVersionSuffix: Provider<String> = providers.gradleProperty("vscode.version.suffix")
 
-val stampVscodeVersion by tasks.registering {
+val stampVscodeVersion = tasks.register("stampVscodeVersion") {
     description = "Apply -Pvscode.version.suffix to lang/vscode-extension/package.json (no-op when unset)"
     val pkgJsonFile = layout.projectDirectory.file("package.json").asFile
     val backupFile = layout.projectDirectory.file("package.json.version-backup").asFile
@@ -152,7 +152,7 @@ val stampVscodeVersion by tasks.registering {
     }
 }
 
-val restoreVscodeVersion by tasks.registering {
+val restoreVscodeVersion = tasks.register("restoreVscodeVersion") {
     description = "Restore lang/vscode-extension/package.json from the backup written by stampVscodeVersion"
     val pkgJsonFile = layout.projectDirectory.file("package.json").asFile
     val backupFile = layout.projectDirectory.file("package.json.version-backup").asFile
@@ -166,7 +166,7 @@ val restoreVscodeVersion by tasks.registering {
 }
 
 // Package the extension
-val packageExtension by tasks.registering(NpmTask::class) {
+val packageExtension = tasks.register<NpmTask>("packageExtension") {
     description = "Package VS Code extension"
     dependsOn(npmCompile, copyTextMateGrammar, copyLanguageConfig, copyLspServer, copyDapServer, copyLicense, generateIcons, stampVscodeVersion)
     finalizedBy(restoreVscodeVersion)
@@ -189,7 +189,7 @@ val packageExtension by tasks.registering(NpmTask::class) {
 // Not wired into `check` by default because on headless Linux runners this
 // needs `xvfb-run` (or a similar virtual display). The intent is that local
 // developers run it explicitly, and CI opt-in via xvfb if/when desired.
-val testVscodeExtension by tasks.registering(NpmTask::class) {
+val testVscodeExtension = tasks.register<NpmTask>("testVscodeExtension") {
     group = "verification"
     description = "Run headless integration tests for the VS Code extension"
     dependsOn(npmCompile, copyTextMateGrammar, copyLanguageConfig, copyLspServer, copyDapServer, copyLicense, generateIcons)
@@ -201,17 +201,17 @@ val testVscodeExtension by tasks.registering(NpmTask::class) {
 }
 
 // Main build task - configure the existing task from base plugin
-val build by tasks.existing {
+val build = tasks.named("build") {
     dependsOn(packageExtension)
 }
 
 // Assemble prepares all resources without packaging
-val assemble by tasks.existing {
+val assemble = tasks.named("assemble") {
     dependsOn(copyTextMateGrammar, copyLanguageConfig, copyLspServer, copyDapServer, copyLicense, npmCompile, generateIcons)
 }
 
 // Launch VS Code with extension loaded for testing
-val runCode by tasks.registering(Exec::class) {
+val runCode = tasks.register<Exec>("runCode") {
     group = "run"
     description = "Launch VS Code with the extension loaded for testing"
     dependsOn(assemble)
@@ -254,7 +254,7 @@ val runCode by tasks.registering(Exec::class) {
     }
 }
 
-val clean by tasks.existing(Delete::class) {
+val clean = tasks.named<Delete>("clean") {
     delete(layout.projectDirectory.dir("out"))
     delete(layout.projectDirectory.dir("node_modules"))
     delete(layout.projectDirectory.dir("server"))

--- a/lib_ecstasy/build.gradle.kts
+++ b/lib_ecstasy/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     alias(libs.plugins.xtc)
 }
 
-val xdkTurtleConsumer by configurations.registering {
+val xdkTurtleConsumer = configurations.register("xdkTurtleConsumer") {
     isCanBeResolved = true
     isCanBeConsumed = false
     attributes {
@@ -23,7 +23,7 @@ val xdkTurtleConsumer by configurations.registering {
     }
 }
 
-val xdkUnicodeConsumer by configurations.registering {
+val xdkUnicodeConsumer = configurations.register("xdkUnicodeConsumer") {
     isCanBeResolved = true
     isCanBeConsumed = false
     attributes {
@@ -32,7 +32,7 @@ val xdkUnicodeConsumer by configurations.registering {
     }
 }
 
-val xdkEcstasyResourcesProvider by configurations.registering {
+val xdkEcstasyResourcesProvider = configurations.register("xdkEcstasyResourcesProvider") {
     description = "Provider configuration for ecstasy resources (implicit.x and unicode data)"
     isCanBeResolved = false
     isCanBeConsumed = true
@@ -52,7 +52,7 @@ dependencies {
     xdkTurtleConsumer(libs.javatools.turtle) // A dependency declaration like this works equally well if we are working with an included build/project or with an artifact. This is exactly what we want.
 }
 
-val compileXtc by tasks.existing(XtcCompileTask::class) {
+val compileXtc = tasks.named<XtcCompileTask>("compileXtc") {
     outputFilename("mack.xtc" to "javatools_turtle.xtc")
 }
 

--- a/manualTests/build.gradle.kts
+++ b/manualTests/build.gradle.kts
@@ -394,7 +394,7 @@ xtcTest {
 // jvmArgs("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
 // See plugin/README.md for more information on debugging.
 //
-val runTwoTestsInSequence by tasks.registering(XtcRunTask::class) {
+val runTwoTestsInSequence = tasks.register<XtcRunTask>("runTwoTestsInSequence") {
     group = "application"
     verbose = true // override a default from xtcRun
     module {
@@ -430,7 +430,7 @@ val executionModeTasks = ExecutionMode.entries.associateWith { mode ->
     }
 }
 
-val runTestAllExecutionModes by tasks.registering {
+val runTestAllExecutionModes = tasks.register("runTestAllExecutionModes") {
     group = "application"
     description = "Run EchoTest in all execution modes to verify that they work."
     dependsOn(executionModeTasks.values)
@@ -440,7 +440,7 @@ val runTestAllExecutionModes by tasks.registering {
 }
 
 // This allows running a single test, e.g.: ./gradlew manualTests:runOne -PtestName="TestArray"
-val runOne by tasks.registering(XtcRunTask::class) {
+val runOne = tasks.register<XtcRunTask>("runOne") {
     group = "application"
     description = """
         Runs one test as given by the property 'testName' (has a hardcoded default test name)
@@ -485,7 +485,7 @@ val testModuleNames = listOf(
 /**
  * Run all tests in parallel using the Runner module, which spawns all test modules concurrently.
  */
-val runParallel by tasks.registering(XtcRunTask::class) {
+val runParallel = tasks.register<XtcRunTask>("runParallel") {
     group = "application"
     description = "Run all known tests in parallel through the parallel test runner."
     // TODO: Re-enable TestIO here after the intermittent TypeSystem.implicitTypes initialization
@@ -509,7 +509,7 @@ val runParallel by tasks.registering(XtcRunTask::class) {
  * Run all tests sequentially, one after another. Each test module runs to completion before
  * the next one starts. This is useful for debugging or when parallel execution causes issues.
  */
-val runSequential by tasks.registering(XtcRunTask::class) {
+val runSequential = tasks.register<XtcRunTask>("runSequential") {
     group = "application"
     description = "Run all known tests sequentially, one after another."
     // TODO: TestAnnotations is currently failing - fix the test and remove this exclusion
@@ -519,25 +519,25 @@ val runSequential by tasks.registering(XtcRunTask::class) {
     testModuleNames.filter { it !in excludedModules }.forEach { moduleName(it) }
 }
 
-val runAllTestTasks by tasks.registering {
+val runAllTestTasks = tasks.register("runAllTestTasks") {
     group = "application"
     description = "Run all test tasks."
     dependsOn(runOne, runTwoTestsInSequence, runTestAllExecutionModes, runSequential)
 }
 
-val runAllTestTasksParallel by tasks.registering {
+val runAllTestTasksParallel = tasks.register("runAllTestTasksParallel") {
     group = "application"
     description = "Run all test tasks."
     dependsOn(runOne, runTwoTestsInSequence, runTestAllExecutionModes, runParallel)
 }
 
-val runCiTestTasks by tasks.registering {
+val runCiTestTasks = tasks.register("runCiTestTasks") {
     group = "application"
     description = "Run the CI aggregate manual-test tasks without re-running the explicit smoke tasks."
     dependsOn(runTestAllExecutionModes, runSequential)
 }
 
-val runCiTestTasksParallel by tasks.registering {
+val runCiTestTasksParallel = tasks.register("runCiTestTasksParallel") {
     group = "application"
     description = "Run the CI aggregate manual-test tasks in parallel mode without re-running the explicit smoke tasks."
     dependsOn(runTestAllExecutionModes, runParallel)
@@ -549,7 +549,7 @@ val runCiTestTasksParallel by tasks.registering {
  * This demonstrates creating a custom test task that overrides the default xtcTest configuration.
  * Test tasks inherit from XtcRunTask, so all run configuration options are available.
  */
-val runXunitTests by tasks.registering(XtcTestTask::class) {
+val runXunitTests = tasks.register<XtcTestTask>("runXunitTests") {
     group = "verification"
     description = "Run xunit tests using the xunit framework."
 
@@ -565,11 +565,11 @@ val runXunitTests by tasks.registering(XtcTestTask::class) {
 }
 
 fun resolveTestNameProperty(defaultTestName: String = "EchoTest"): String {
-    return if (hasProperty("testName")) (properties["testName"] as String) else defaultTestName
+    return providers.gradleProperty("testName").getOrElse(defaultTestName)
 }
 
 fun resolveTestArgumentsProperty(defaultTestArguments: String = ""): List<String> {
-    val argsString = if (hasProperty("testArgs")) (properties["testArgs"] as String) else defaultTestArguments
+    val argsString = providers.gradleProperty("testArgs").getOrElse(defaultTestArguments)
     return if (argsString.isEmpty()) emptyList() else argsString.split(",").map { it.trim() }
 }
 
@@ -604,7 +604,7 @@ val testModuleProvider: Provider<List<String>> = provider {
     sourceSets.main.get().output.asFileTree.filter { isValidXtcModule(it) }.map { it.absolutePath }.toList()
 }
 
-val printTestModules by tasks.registering {
+val printTestModules = tasks.register("printTestModules") {
     group = "help"
     description = "Print the output of provideTestModules."
     doLastTask {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -17,7 +17,7 @@ private val defaultJvmArgs: Provider<List<String>> = extensions.getByName<Provid
 private val jdkVersionProvider = xdkProperties.int("org.xtclang.java.jdk")
 
 // Generate resource file with build-time configuration
-val generatePluginResources by tasks.registering {
+val generatePluginResources = tasks.register("generatePluginResources") {
     val outputDir = layout.buildDirectory.dir("generated/resources")
     val buildInfoFile = outputDir.map { it.file("org/xtclang/build/internal/plugin-build-info.properties") }
     val xdkVersionProvider = provider { version.toString() }
@@ -112,7 +112,7 @@ gradlePlugin {
     vcsUrl = vcsUrlValue
 
     plugins {
-        val xtc by registering {
+        register("xtc") {
             id = pluginIdValue
             implementationClass = pluginImplementationClassValue
             displayName = pluginDisplayNameValue

--- a/xdk/build.gradle.kts
+++ b/xdk/build.gradle.kts
@@ -34,12 +34,12 @@ plugins {
     distribution
 }
 
-val xtcLauncherBinaries by configurations.registering {
+val xtcLauncherBinaries = configurations.register("xtcLauncherBinaries") {
     isCanBeResolved = true
     isCanBeConsumed = false
 }
 
-val xdkJavaToolsJitBridge by configurations.registering {
+val xdkJavaToolsJitBridge = configurations.register("xdkJavaToolsJitBridge") {
     description = "Consumes javatools-jitbridge JAR as native binary blob for distribution (NOT classpath)"
     isCanBeResolved = true
     isCanBeConsumed = false
@@ -53,7 +53,7 @@ val xdkJavaToolsJitBridge by configurations.registering {
 /**
  * Local configuration to provide an xdk-distribution, which contains versioned zip and tar.gz XDKs.
  */
-val xdkProvider by configurations.registering {
+val xdkProvider = configurations.register("xdkProvider") {
     isCanBeConsumed = true
     isCanBeResolved = false
     // TODO these are added twice to the archive configuration. We probably don't want that.
@@ -185,7 +185,7 @@ abstract class ModifyScriptsTask : DefaultTask() {
     }
 }
 
-val modifyScripts by tasks.registering(ModifyScriptsTask::class) {
+val modifyScripts = tasks.register<ModifyScriptsTask>("modifyScripts") {
     dependsOn(tasks.startScripts)
 
     artifactVersionProperty.set(artifactVersion)
@@ -198,7 +198,7 @@ val modifyScripts by tasks.registering(ModifyScriptsTask::class) {
     })
 }
 
-val prepareDistributionScripts by tasks.registering(Copy::class) {
+val prepareDistributionScripts = tasks.register<Copy>("prepareDistributionScripts") {
     dependsOn(modifyScripts)
     from(tasks.startScripts.map { it.outputDir!! }) {
         include("xtc*", "xcc*", "xec*")
@@ -373,7 +373,7 @@ tasks.distZip {
 // Let the Distribution plugin handle dependencies properly through the standard lifecycle
 // Distribution tasks should automatically depend on processResources and other build outputs
 
-val cleanXdk by tasks.registering(Delete::class) {
+val cleanXdk = tasks.register<Delete>("cleanXdk") {
     subprojects.forEach {
         delete(it.layout.buildDirectory)
     }
@@ -381,7 +381,7 @@ val cleanXdk by tasks.registering(Delete::class) {
     delete(File(XdkPropertiesService.compositeRootDirectory(projectDir), "build"))
 }
 
-val clean by tasks.existing {
+val clean = tasks.named("clean") {
     dependsOn(cleanXdk)
     doLast {
         logger.info("[xdk] WARNING: Note that running 'clean' is often unnecessary with a properly configured build cache.")


### PR DESCRIPTION
## Summary
- upgrade the branch to Gradle 9.6.1 so the Gradle 10 Kotlin DSL deprecations are visible under the active wrapper
- replace deprecated Kotlin DSL delegated task/configuration accessors with named/register/create APIs
- migrate the direct Project.properties map reads for includeBuildAttach* and manualTests testName/testArgs to providers.gradleProperty
- keep intentional dynamic extra-property paths unchanged for Palantir versionDetails and signing-plugin compatibility

## Verification
- ./gradlew --version reports Gradle 9.6.1
- ./gradlew --no-configuration-cache --console=plain --warning-mode=all help passes with CI-like includeBuildLang/includeBuildAttachLang env set
- env-cleared default manualTests:help passes, confirming manualTests remains included by default
- env-cleared default lang:help fails with project 'lang' not found, confirming lang remains excluded by default
- env-cleared default build --dry-run emits no :lang: or :manualTests: tasks, confirming default attach flags remain false
- -PincludeBuildManualTests=false manualTests:help fails with project 'manualTests' not found
- -PincludeBuildManualTests=true -PincludeBuildAttachManualTests=true build --dry-run schedules :manualTests:* lifecycle tasks
- -PincludeBuildLang=true -PincludeBuildAttachLang=false lang:help passes
- -PincludeBuildLang=true -PincludeBuildAttachLang=false build --dry-run schedules no :lang:* lifecycle tasks
- -PincludeBuildLang=true -PincludeBuildAttachLang=true build --dry-run schedules :lang:* lifecycle tasks
- -PincludeBuildLang=true -PincludeBuildAttachLang=true assemble passes locally, including lang core compile/assemble paths
- -PincludeBuildLang=true -PincludeBuildAttachLang=true :lang:intellij-plugin:buildPlugin :lang:vscode-extension:build passes locally
- -Porg.xtclang.java.enablePreview=true -Porg.xtclang.java.enableNativeAccess=true :plugin:generatePluginResources --rerun-tasks shows expected JVM args from xdkProperties
- -PincludeBuildLang=true -PincludeBuildAttachLang=false :lang:lsp-server:generateBuildInfo --rerun-tasks produces lsp.adapter=treesitter and lsp.semanticTokens=true from root gradle.properties
- manualTests:runOne -PtestName=TestMisc -PtestArgs=alpha,beta --dry-run configures successfully
- :javatools:compileJava :javatools:test --tests org.xvm.tool.XtcVersionSanityTest passes
- git diff --check passes
- grep confirms no remaining delegated registering/existing/getting/creating declarations and no stale 9.5.1 references