### PR TITLE
Claim .x files in IntelliJ plugin

### DIFF
--- a/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/XtcFileType.kt
+++ b/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/XtcFileType.kt
@@ -1,0 +1,22 @@
+package org.xtclang.idea
+
+import com.intellij.openapi.fileTypes.LanguageFileType
+import javax.swing.Icon
+
+/**
+ * Native IntelliJ file type for Ecstasy source files.
+ *
+ * TextMate still provides syntax highlighting through [XtcTextMateBundleProvider],
+ * and LSP4IJ still routes language features by file-name pattern. This file type
+ * exists so IntelliJ knows that the installed Ecstasy plugin owns `*.x` files and
+ * does not offer unrelated Marketplace plugins for the extension.
+ */
+object XtcFileType : LanguageFileType(XtcIntelliJLanguage) {
+    override fun getName(): String = "Ecstasy"
+
+    override fun getDescription(): String = "Ecstasy source file"
+
+    override fun getDefaultExtension(): String = "x"
+
+    override fun getIcon(): Icon? = XtcIconProvider.XTC_ICON
+}

--- a/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/XtcIconProvider.kt
+++ b/lang/intellij-plugin/src/main/kotlin/org/xtclang/idea/XtcIconProvider.kt
@@ -8,11 +8,6 @@ import javax.swing.Icon
 
 /**
  * Provides custom icons for XTC files (.x extension).
- *
- * We use IconProvider instead of FileType registration because:
- * 1. TextMate plugin handles the file type and provides syntax highlighting
- * 2. Registering our own FileType would override TextMate's highlighting
- * 3. IconProvider lets us add custom icons without interfering with TextMate
  */
 class XtcIconProvider : IconProvider() {
     override fun getIcon(

--- a/lang/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/lang/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,13 @@
                            displayType="BALLOON"
                            isLogByDefault="true"/>
 
+        <!-- Claim *.x as an Ecstasy source file so IntelliJ does not suggest unrelated Marketplace plugins. -->
+        <fileType name="Ecstasy"
+                  implementationClass="org.xtclang.idea.XtcFileType"
+                  fieldName="INSTANCE"
+                  language="Ecstasy"
+                  extensions="x"/>
+
         <!-- Project Generator for New Project wizard (IntelliJ IDEA) -->
         <newProjectWizard.generator
             implementation="org.xtclang.idea.project.XtcNewProjectWizard"/>
@@ -49,7 +56,7 @@
         <runConfigurationProducer
             implementation="org.xtclang.idea.run.XtcRunConfigurationProducer"/>
 
-        <!-- IconProvider for .x files - provides icon without overriding TextMate highlighting -->
+        <!-- IconProvider for .x PSI files in contexts that do not ask the file type directly. -->
         <iconProvider implementation="org.xtclang.idea.XtcIconProvider"/>
 
         <!-- Live templates: code snippets triggered by abbreviation + Tab (e.g. cls, fori, sout) -->

--- a/lang/intellij-plugin/src/test/kotlin/org/xtclang/idea/manifest/PluginManifestTest.kt
+++ b/lang/intellij-plugin/src/test/kotlin/org/xtclang/idea/manifest/PluginManifestTest.kt
@@ -78,6 +78,7 @@ class PluginManifestTest {
         val required =
             setOf(
                 "notificationGroup", // notification group "XTC Language Server" used by XtcLspServerSupportProvider
+                "fileType", // registers *.x as Ecstasy so IntelliJ does not suggest unrelated plugins
                 "newProjectWizard.generator", // wizard entry created by XtcNewProjectWizard
                 "configurationType", // run-config type created by XtcRunConfigurationType
                 "runConfigurationProducer", // auto-create run configs from .x context
@@ -131,5 +132,26 @@ class PluginManifestTest {
         assertThat(mapping!!.getAttribute("patterns"))
             .withFailMessage("LSP fileNamePatternMapping patterns must include *.x")
             .contains("*.x")
+    }
+
+    @Test
+    @DisplayName("registers .x as the Ecstasy file type")
+    fun fileTypeWiring() {
+        val fileTypes = pluginXml.getElementsByTagName("fileType")
+        val fileType =
+            (0 until fileTypes.length)
+                .map { fileTypes.item(it) as Element }
+                .firstOrNull { it.getAttribute("implementationClass") == "org.xtclang.idea.XtcFileType" }
+        assertThat(fileType)
+            .withFailMessage(
+                "plugin.xml must register org.xtclang.idea.XtcFileType. Without this, IntelliJ treats .x as " +
+                    "unclaimed and offers unrelated Marketplace plugins that also support the extension.",
+            ).isNotNull
+        assertThat(fileType!!.getAttribute("name")).isEqualTo("Ecstasy")
+        assertThat(fileType.getAttribute("language")).isEqualTo("Ecstasy")
+        assertThat(fileType.getAttribute("fieldName")).isEqualTo("INSTANCE")
+        assertThat(fileType.getAttribute("extensions").split(';'))
+            .withFailMessage("Ecstasy file type must claim the x extension.")
+            .contains("x")
     }
 }


### PR DESCRIPTION
## Why
IntelliJ was showing the Marketplace banner for plugins supporting *.x files, including unrelated Haskell plugins, because our plugin only mapped *.x through LSP4IJ/TextMate and did not register a native IntelliJ file type owner.

## What
- Add an Ecstasy LanguageFileType for .x files.
- Register it in plugin.xml with language Ecstasy and extension x.
- Keep the existing TextMate bundle and LSP4IJ pattern mapping in place.
- Add manifest coverage so this ownership does not regress.

## Verification
- env -u ORG_GRADLE_PROJECT_includeBuildLang -u ORG_GRADLE_PROJECT_includeBuildAttachLang -u ORG_GRADLE_PROJECT_includeBuildManualTests -u ORG_GRADLE_PROJECT_includeBuildAttachManualTests ./gradlew --console=plain -PincludeBuildLang=true -PincludeBuildAttachLang=true :lang:intellij-plugin:test --tests org.xtclang.idea.manifest.PluginManifestTest
- env -u ORG_GRADLE_PROJECT_includeBuildLang -u ORG_GRADLE_PROJECT_includeBuildAttachLang -u ORG_GRADLE_PROJECT_includeBuildManualTests -u ORG_GRADLE_PROJECT_includeBuildAttachManualTests ./gradlew --console=plain -PincludeBuildLang=true -PincludeBuildAttachLang=true :lang:intellij-plugin:buildPlugin