### PR TITLE
Make the Dispatcher more robust

### DIFF
--- a/javatools_bridge/src/main/x/_native/web/RequestInfoImpl.x
+++ b/javatools_bridge/src/main/x/_native/web/RequestInfoImpl.x
@@ -45,7 +45,10 @@ service RequestInfoImpl(RTServer       server,
     private Notify[] observers = [];
 
     @Override
-    @Lazy Uri uri.calc() = new Uri(uriString);
+    @Lazy Uri uri.calc() {
+        return Uri.fromString(uriString, noAuthority=True) ?:
+            assert as $"Invalid request path: {uriString.quoted()}";
+    }
 
     @Override
     @Lazy SocketAddress receivedAtAddress.calc() {
@@ -424,8 +427,10 @@ service RequestInfoImpl(RTServer       server,
     void respond(Int status, String[] headerNames, String[] headerValues, Byte[] body) {
         notifyObservers(status);
 
-        server.setHeaders(context, status, headerNames, headerValues, body.empty ? -1 : body.size);
-        server.setBodyBytes(context, body, final=True);
+        try {
+            server.setHeaders(context, status, headerNames, headerValues, body.empty ? -1 : body.size);
+            server.setBodyBytes(context, body, final=True);
+        } catch (Exception ignore) {}
     }
 
     @Override

--- a/lib_net/src/main/x/net/Uri.x
+++ b/lib_net/src/main/x/net/Uri.x
@@ -993,12 +993,14 @@ const Uri
     /**
      * Create a `Uri` from the passed `String`, iff the `String` contains a valid URI.
      *
-     * @param text  the text containing a URI
+     * @param text         the text containing a URI
+     * @param noAuthority  (optional) `True` indicates that the URI will not contain the authority
+     *                     section, so parsing will begin with the path section
      *
      * @return True if the text was successfully parsed into a Uri
      * @return (conditional) the Uri
      */
-    static conditional Uri fromString(String text) {
+    static conditional Uri fromString(String text, Boolean noAuthority = False) {
         if ((String?    scheme,
              String?    authority,
              String?    user,
@@ -1008,7 +1010,7 @@ const Uri
              String?    path,
              String?    query,
              String?    opaque,
-             String?    fragment) := parse(text)) {
+             String?    fragment) := parse(text, noAuthority=noAuthority)) {
             return True, new Uri(text, scheme, authority, user, host, ip, port, path, query, opaque, fragment);
         }
 
@@ -1018,8 +1020,10 @@ const Uri
     /**
      * Parse URI information from a String, without relying on an exception to report failure.
      *
-     * @param text    the String containing the URI
-     * @param report  (optional) the function to report a failure to, as a non-localized string
+     * @param text         the String containing the URI
+     * @param report       (optional) the function to report a failure to, as a non-localized string
+     * @param noAuthority  (optional) True indicates that the URI will not contain the authority
+     *                     section, so parsing will begin with the path section
      *
      * @return True iff the parsing succeeded and the URI is lexically valid
      * @return (conditional) the scheme name, or Null if none
@@ -1042,7 +1046,8 @@ const Uri
                         String?    path,
                         String?    query,
                         String?    opaque,
-                        String?    fragment) parse(String text, function void (String)? report = Null) {
+                        String?    fragment)
+            parse(String text, function void (String)? report = Null, Boolean noAuthority = False) {
         String?    scheme    = Null;
         String?    user      = Null;
         String?    authority = Null;
@@ -1059,8 +1064,12 @@ const Uri
 
         // an empty URI is not legal
         if (length == 0) {
-            report?($"Invalid URI {text.quoted()}: Empty URI");
-            return False;
+            if (noAuthority) {
+                return True, Null, Null, Null, Null, Null, Null, "", Null, Null, Null;
+            } else {
+                report?($"Invalid URI {text.quoted()}: Empty URI");
+                return False;
+            }
         }
 
         // a Uri is either an absoluteURI or a relativeURI:
@@ -1083,7 +1092,15 @@ const Uri
         //   rel_path = rel_segment [ abs_path ]
         //   rel_segment = 1*( unreserved | escaped | ";" | "@" | "&" | "=" | "+" | "$" | "," )
         String? error = Null;
-        if ((scheme, offset, error) := parseScheme(text, offset, error)) {
+        if (noAuthority) {
+            if (text[offset] == '/') {
+                (path, offset, error) := parseAbsPath(text, offset, error);
+                (query, offset, error) := parseQuery(text, offset, error);
+                (fragment, offset, error) := parseFragment(text, offset, error);
+            } else {
+                error = $"HTTP request path must begin with '/': {text.quoted()}";
+            }
+        } else if ((scheme, offset, error) := parseScheme(text, offset, error)) {
             if ((authority, user, host, ip, port, path, offset, error) := parseNetPath(text, offset)) {
                 (query, offset, error) := parseQuery(text, offset, error);
                 (fragment, offset, error) := parseFragment(text, offset, error);

--- a/lib_xenia/src/main/x/xenia/Dispatcher.x
+++ b/lib_xenia/src/main/x/xenia/Dispatcher.x
@@ -56,8 +56,16 @@ service Dispatcher {
      * Dispatch the "raw" request.
      */
     void dispatch(RequestInfo requestInfo) {
+        Uri fullUri;
+        try {
+            fullUri = requestInfo.uri;
+        } catch (Exception e) {
+            requestInfo.respond(HttpStatus.BadRequest.code, [], [], []);
+            return;
+        }
+
         Boolean tls       = requestInfo.tls;
-        String  uriString = requestInfo.uriString;
+        String  uriString = fullUri.path ?: "";
 
         // select the service to delegate request processing to; the service infos are sorted
         // with the most specific path first (so the first path match wins)
@@ -80,13 +88,10 @@ service Dispatcher {
             } else if (pathSize == 1) { // root path ("/") matches everything
                 serviceInfo = info;
                 break;
-            } else if (uriSize > pathSize && uriString.startsWith(path)) {
-                Char ch = uriString[pathSize];
-                if (ch == '/' || ch == '?' || ch == '#') {
-                    serviceInfo = info;
-                    uriString   = uriString.substring(pathSize);
-                    break;
-                }
+            } else if (uriSize > pathSize && uriString.startsWith(path) && uriString[pathSize] == '/') {
+                serviceInfo = info;
+                uriString   = uriString.substring(pathSize);
+                break;
             }
         }
 
@@ -97,32 +102,11 @@ service Dispatcher {
             handlePlainTextSecrets(tls, requestInfo, request);
             response = catalog.webApp.handleUnhandledError^(request, NotFound);
         } else {
-            // split what's left of the URI into a path, a query, and a fragment
-            String? query    = Null;
-            String? fragment = Null;
-            if (!uriString.empty) {
-                if (Int fragmentOffset := uriString.indexOf('#')) {
-                    fragment  = uriString.substring(fragmentOffset+1);
-                    uriString = uriString[0 ..< fragmentOffset];
-                }
-                if (Int queryOffset := uriString.indexOf('?')) {
-                    query     = uriString.substring(queryOffset+1);
-                    uriString = uriString[0 ..< queryOffset];
-                }
-            }
-
             EndpointInfo  endpoint;
             UriParameters uriParams = [];
             Int           wsid      = serviceInfo.id;
             FindEndpoint: {
-                Uri uri;
-                try {
-                    uri = new Uri(path=uriString, query=query, fragment=fragment);
-                } catch (Exception e) {
-                    handlePlainTextSecrets(tls, requestInfo);
-                    response = new SimpleResponse(BadRequest);
-                    break ProcessRequest;
-                }
+                Uri uri = new Uri(path=uriString, query=fullUri.query, fragment=fullUri.fragment);
 
                 // find a matching endpoint
                 String methodName = requestInfo.method.name;


### PR DESCRIPTION
We noticed the platform logs contained the following exceptions caused by malformed (malicious) requests:

    HttpHandler: unhandled exception for "//autoload_classmap/function.php": IllegalArgument: Invalid character in the name: '_'
	at Uri.construct(String).->(String) (Uri.x:28)
	at Uri.parse(String, function void(String)?) (Uri.x:1117)
	at Uri.construct(String) (Uri.x:28)
	at web.RequestInfoImpl.uri.calc() (RequestInfoImpl.x:48)
	at annotations.Lazy.get() (Lazy.x:39)
	at web.RequestInfoImpl.httpsUrl.get() (RequestInfoImpl.x:378)
	at ^web.RequestInfoImpl (HttpServer.RequestInfo.httpsUrl)
	    =========
	at Dispatcher.dispatch(xenia:HttpServer.RequestInfo) (Dispatcher.x:165)

This change hardens the dispatcher logic by:
 - validating incoming request targets before dispatching to any user endpoint;
 - returning `BadRequest` for malformed or malicious request URIs **before** application code can observe URI parsing failures;
- removing redundant defensive parsing and exception handling from the dispatch path