### PR TITLE
Avoid XDK recompiles when rebuild is disabled

### DIFF
--- a/plugin/src/main/java/org/xtclang/plugin/XtcProjectDelegate.java
+++ b/plugin/src/main/java/org/xtclang/plugin/XtcProjectDelegate.java
@@ -460,6 +460,7 @@ public class XtcProjectDelegate {
         compileTask.configure(task -> {
             task.setDescription("Compile an XTC source set, similar to the JavaCompile task for Java.");
             task.dependsOn(XDK_EXTRACT_TASK_NAME);
+            task.dependsOn(configs.getByName(XDK_CONFIG_NAME_JAVATOOLS_INCOMING));
             task.setSource(sourceSet.getExtensions().getByName(XTC_LANGUAGE_NAME)); // Register this task as an XTC language compiler. Not a Java compiler.
 
             // Test source set should depend on main source set compilation

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcCompileTask.java
@@ -237,10 +237,34 @@ public abstract class XtcCompileTask extends XtcSourceTask implements XtcCompile
         return strict;
     }
 
-    @Input
+    @Internal
     @Override
     public Property<@NotNull Boolean> getRebuild() {
         return rebuild;
+    }
+
+    @Override
+    @Optional
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public FileCollection getInputXtcJavaToolsConfig() {
+        return shouldTrackLauncherRuntimeInputs()
+            ? super.getInputXtcJavaToolsConfig()
+            : objects.fileCollection();
+    }
+
+    @Override
+    @Optional
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public FileCollection getInputLauncherRuntimeCandidates() {
+        return shouldTrackLauncherRuntimeInputs()
+            ? super.getInputLauncherRuntimeCandidates()
+            : objects.fileCollection();
+    }
+
+    private boolean shouldTrackLauncherRuntimeInputs() {
+        return getRebuild().get();
     }
 
     @Input

--- a/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
+++ b/plugin/src/main/java/org/xtclang/plugin/tasks/XtcLauncherTask.java
@@ -11,7 +11,6 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -42,6 +41,7 @@ import org.gradle.work.DisableCachingByDefault;
 
 import static org.xtclang.plugin.XtcPluginConstants.PROPERTY_VERBOSE_LOGGING_OVERRIDE;
 import static org.xtclang.plugin.XtcPluginConstants.XDK_CONFIG_NAME_JAVATOOLS_INCOMING;
+import static org.xtclang.plugin.XtcPluginConstants.XTC_MODULE_FILE_EXTENSION;
 import static org.xtclang.plugin.XtcPluginUtils.argumentArrayToList;
 import static org.xtclang.plugin.internal.GradlePhaseAssertions.validateConfigurationTimeCapture;
 
@@ -205,13 +205,13 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    FileCollection getInputXtcJavaToolsConfig() {
+    public FileCollection getInputXtcJavaToolsConfig() {
         return javaToolsConfig.get();
     }
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    FileCollection getInputLauncherRuntimeCandidates() {
+    public FileCollection getInputLauncherRuntimeCandidates() {
         return objects.fileCollection()
             .from(javaToolsConfig.get())
             .from(xdkFileTree.get().matching(pattern -> pattern.include("**/*.jar")));
@@ -386,10 +386,10 @@ public abstract class XtcLauncherTask<E extends XtcLauncherTaskExtension> extend
         ).resolveFullModulePath();
     }
 
-    @InputDirectory
+    @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    public Provider<@NotNull Directory> getInputXdkContents() {
-        return xdkContentsDir;
+    public FileTree getInputXdkContents() {
+        return xdkFileTree.get().matching(pattern -> pattern.include("**/*." + XTC_MODULE_FILE_EXTENSION));
     }
 
     @Optional

--- a/plugin/src/test/java/org/xtclang/plugin/SimpleXtcPluginTest.java
+++ b/plugin/src/test/java/org/xtclang/plugin/SimpleXtcPluginTest.java
@@ -4,12 +4,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE;
+import static org.gradle.api.attributes.Category.LIBRARY;
+import static org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE;
+import static org.xtclang.plugin.XtcPluginConstants.XDK_CONFIG_NAME_ARTIFACT_JAVATOOLS_JAR;
+import static org.xtclang.plugin.XtcPluginConstants.XDK_CONFIG_NAME_JAVATOOLS_INCOMING;
 import static org.xtclang.plugin.XtcPluginConstants.XDK_VERSION_TASK_NAME;
 import static org.xtclang.plugin.XtcPluginConstants.XTC_TEST_TASK_NAME;
 
+import java.io.File;
+import java.util.List;
+
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.testfixtures.ProjectBuilder;
 
@@ -83,5 +96,56 @@ public class SimpleXtcPluginTest {
         assertTrue(testDependencies.contains("compileXtc"), "testXtc should depend on compileXtc");
         assertTrue(testDependencies.contains("compileTestXtc"), "testXtc should depend on compileTestXtc");
         assertNotNull(compileXtc);
+    }
+
+    @Test
+    public void verifyRebuildFalseStopsTrackingLauncherRuntimeAsCompileInput() {
+        final Project project = newProject("verifyRebuildFalseStopsTrackingLauncherRuntimeAsCompileInput");
+        final PluginManager pluginManager = project.getPluginManager();
+        pluginManager.apply(org.gradle.api.plugins.JavaBasePlugin.class);
+        pluginManager.apply(XtcPlugin.XtcProjectPlugin.class);
+
+        final TaskProvider<Task> javaToolsJar = project.getTasks().register("produceJavaTools");
+        final File javaToolsFile = project.getLayout().getBuildDirectory().file("libs/javatools.jar").get().getAsFile();
+        final ConfigurableFileCollection javaToolsFiles = project.files(javaToolsFile).builtBy(javaToolsJar);
+        project.getDependencies().getArtifactTypes().getByName("jar").getAttributes().attribute(
+            CATEGORY_ATTRIBUTE,
+            project.getObjects().named(Category.class, LIBRARY)
+        );
+        project.getDependencies().getArtifactTypes().getByName("jar").getAttributes().attribute(
+            LIBRARY_ELEMENTS_ATTRIBUTE,
+            project.getObjects().named(LibraryElements.class, XDK_CONFIG_NAME_ARTIFACT_JAVATOOLS_JAR)
+        );
+        project.getDependencies().add(XDK_CONFIG_NAME_JAVATOOLS_INCOMING, javaToolsFiles);
+
+        final XtcCompileTask compileXtc = (XtcCompileTask) project.getTasks().getByName("compileXtc");
+
+        assertTrue(
+            compileXtc.getInputXtcJavaToolsConfig().getFiles().contains(javaToolsFile),
+            "compileXtc should track javatools as an input while rebuild is enabled"
+        );
+        assertTrue(
+            compileXtc.getInputLauncherRuntimeCandidates().getFiles().contains(javaToolsFile),
+            "compileXtc should track launcher runtime candidates while rebuild is enabled"
+        );
+
+        compileXtc.getRebuild().set(false);
+
+        assertTrue(
+            compileXtc.getInputXtcJavaToolsConfig().isEmpty(),
+            "compileXtc should ignore javatools as an input while rebuild is disabled"
+        );
+        assertTrue(
+            compileXtc.getInputLauncherRuntimeCandidates().isEmpty(),
+            "compileXtc should ignore launcher runtime candidates while rebuild is disabled"
+        );
+
+        final List<String> compileDependencies = compileXtc.getTaskDependencies().getDependencies(compileXtc).stream()
+            .map(Task::getName)
+            .toList();
+        assertTrue(
+            compileDependencies.contains("produceJavaTools"),
+            "compileXtc should still depend on the javatools producer while rebuild is disabled"
+        );
     }
 }


### PR DESCRIPTION
When I change some classes in the javatools Java library and I know for sure it doesn't impact the .x file compilation I run this command:

    ./gradlew installDist --no-scan -PxtcDefaultRebuild=false

However I noticed that sometimes it still re-compiles some or all of xdk libraries.

I asked Codex to fix that - this is what it came up with.

Here's the explanation of what it found:

> The issue was that -PxtcDefaultRebuild=false only changed the flag passed to the XTC compiler. Gradle was still treating javatools.jar and launcher runtime jars as inputs to every compileXtc task, so a Java-only javatools change could make Gradle mark the XDK library compile tasks out-of-date before the compiler ever saw rebuild=false.
> This change makes the Gradle task model match the intent of rebuild=false. When rebuild is disabled, XTC compile tasks no longer fingerprint the launcher runtime jars as inputs, but they still depend on the xdkJavaTools configuration so the Java tools are built before compilation if compilation is actually needed. Extracted XDK contents are also narrowed to track .xtc module files instead of all files in that directory.