### PR TITLE
Add support for @Lazy static properties

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/PropertyStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/PropertyStructure.java
@@ -236,6 +236,13 @@ public class PropertyStructure
     }
 
     /**
+     * @return true iff the property has the Lazy annotation
+     */
+    public boolean isLazy() {
+        return containsRefAnnotation(getConstantPool().clzLazy());
+    }
+
+    /**
      * @return true iff the property has a Future annotation
      */
     public boolean isFuture() {

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyBody.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyBody.java
@@ -66,17 +66,22 @@ public class PropertyBody
                 || impl == Implementation.SansCode
                 || impl == Implementation.Explicit;
         assert (impl == Implementation.Delegating) ^ (constDelegate == null);
-        if (constInitVal != null && constInitFunc != null) {
-            // this can happen when the initial value is a constant function (lambda)
-            // or any other constant that refers to the initializer (see
-            // PropertyDeclarationStatement,validateContent);
-            // in that case we simply disregard the initializer
-            constInitFunc = null;
-        } else if (fConstant && constInitVal == null && constInitFunc == null && !struct.isInjected()) {
-            // this can only happen when we're building the TypeInfo for a partially compiled class,
-            // so we will need to invalidate the TypeInfo afterward;
-            // mark the implementation as "Implicit" just to assert it gets replaced later
-            impl = Implementation.Implicit;
+        if (fConstant) {
+            if (constInitVal != null && constInitFunc != null) {
+                // this can happen when the initial value is a constant function (lambda)
+                // or any other constant that refers to the initializer (see
+                // PropertyDeclarationStatement,validateContent);
+                // in that case we simply disregard the initializer
+                constInitFunc = null;
+            } else if (struct.isLazy()) {
+                // a static lazy property must have an explicit implementation
+                impl = Implementation.Explicit;
+            } else if (constInitVal == null && constInitFunc == null && !struct.isInjected()) {
+                // this can only happen when we're building the TypeInfo for a partially compiled class,
+                // so we will need to invalidate the TypeInfo afterward;
+                // mark the implementation as "Implicit" just to assert it gets replaced later
+                impl = Implementation.Implicit;
+            }
         }
         assert effectGet != null && effectSet != null;
 

--- a/javatools/src/main/java/org/xvm/asm/constants/PropertyInfo.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/PropertyInfo.java
@@ -784,6 +784,10 @@ public class PropertyInfo
      * @return true iff the property is a Var (or false if the property is only a Ref)
      */
     public boolean isVar() {
+        if (isLazy()) {
+            return true;
+        }
+
         if (m_fSuppressVar || isConstant() || isFormalType() || isInjected()) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -5270,7 +5270,7 @@ public abstract class TypeConstant
         // functions and constants cannot have properties; methods cannot have constants
         IdentityConstant constParent = prop.getIdentityConstant().getParentConstant();
         boolean          fConstant   = prop.isStatic();
-        boolean          fLazyConst  = fConstant && prop.containsRefAnnotation(pool.clzLazy());
+        boolean          fLazyConst  = fConstant && prop.isLazy();
         switch (constParent.getFormat()) {
         case Property:
             if (!fConstant && prop.getParent().isStatic()) {

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -5270,6 +5270,7 @@ public abstract class TypeConstant
         // functions and constants cannot have properties; methods cannot have constants
         IdentityConstant constParent = prop.getIdentityConstant().getParentConstant();
         boolean          fConstant   = prop.isStatic();
+        boolean          fLazyConst  = fConstant && prop.containsRefAnnotation(pool.clzLazy());
         switch (constParent.getFormat()) {
         case Property:
             if (!fConstant && prop.getParent().isStatic()) {
@@ -5324,7 +5325,7 @@ public abstract class TypeConstant
                         continue;
                     }
 
-                    if (fConstant) {
+                    if (fConstant && !fLazyConst) {
                         // the only method allowed under a static property is the initializer
                         log(errs, Severity.ERROR, VE_CONST_CODE_ILLEGAL,
                                 getValueString(),
@@ -5396,7 +5397,7 @@ public abstract class TypeConstant
             impl = Implementation.Native;
 
             // static properties of a type are language-level constant values, e.g. "Int KB = 1024;"
-            if (!fHasInject && !prop.hasInitialValue() &&
+            if (!fLazyConst && !fHasInject && !prop.hasInitialValue() &&
                     (prop.getInitialValue() == null) == (methodInit == null)) {
                 if (methodInit == null) {
                     // it is an error for a static property to not have an initial value
@@ -5426,7 +5427,7 @@ public abstract class TypeConstant
                         sName);
             }
 
-            if (fHasRefAnno) {
+            if (fHasRefAnno && !fLazyConst) {
                 // it is an error for a constant to be annotated in a manner that affects the Ref
                 log(errs, Severity.ERROR, VE_CONST_ANNOTATION_ILLEGAL,
                         getValueString(),

--- a/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
+++ b/javatools/src/main/java/org/xvm/compiler/ast/NameExpression.java
@@ -2500,7 +2500,7 @@ public class NameExpression
 
             PropertyStructure prop = (PropertyStructure) idProp.getComponent();
             if (prop.isConstant() && !fSuppressDeref) {
-                assert !m_fAssignable;
+                assert !m_fAssignable || prop.isLazy();
                 m_plan = prop.hasInitialValue() ? Plan.PropertyDeref : Plan.Singleton;
                 return typeProp;
             }

--- a/javatools/src/main/java/org/xvm/runtime/ClassComposition.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassComposition.java
@@ -670,7 +670,8 @@ public class ClassComposition
                     cRegular++;
                 }
             } else {
-                assert clzRef == null;
+                // lazy constants are handled by the runtime
+                assert clzRef == null || (infoProp.isLazy() && infoProp.isConstant());
             }
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -31,6 +31,7 @@ import org.xvm.asm.constants.PropertyConstant;
 import org.xvm.asm.constants.PropertyInfo;
 import org.xvm.asm.constants.RegisterConstant;
 import org.xvm.asm.constants.SignatureConstant;
+import org.xvm.asm.constants.SingletonConstant;
 import org.xvm.asm.constants.StringConstant;
 import org.xvm.asm.constants.TerminalTypeConstant;
 import org.xvm.asm.constants.TypeConstant;
@@ -1476,6 +1477,15 @@ public abstract class ClassTemplate
         if (infoProp == null) {
             return frame.raiseException(
                 xException.unknownProperty(frame, idProp.getName(), hThis.getType()));
+        }
+
+        if (infoProp.isConstant() && infoProp.isLazy()) {
+            SingletonConstant constLazy =
+                    idProp.getConstantPool().ensureSingletonConstConstant(idProp);
+            // we need to avoid to kick the computation logic; they only asked for a ref
+            ObjectHandle hLazy = constLazy.getHandle();
+            assert hLazy != null; // it must be there - assigned or not
+            return frame.assignDeferredValue(iReturn, hLazy);
         }
 
         TypeComposition clzRef = clzThis.ensurePropertyComposition(infoProp);

--- a/javatools/src/main/java/org/xvm/runtime/ConstHeap.java
+++ b/javatools/src/main/java/org/xvm/runtime/ConstHeap.java
@@ -17,6 +17,7 @@ import org.xvm.runtime.ObjectHandle.DeferredCallHandle;
 import org.xvm.runtime.ObjectHandle.DeferredPropertyHandle;
 import org.xvm.runtime.ObjectHandle.DeferredSingletonHandle;
 import org.xvm.runtime.ObjectHandle.InitializingHandle;
+import org.xvm.runtime.template.annotations.xLazy;
 
 
 /**
@@ -52,6 +53,29 @@ public class ConstHeap {
         if (constValue instanceof SingletonConstant constSingle) {
             hValue = constSingle.getHandle();
             if (hValue != null) {
+                if (hValue instanceof xLazy.LazyHandle hLazy && !hLazy.isAssigned()) {
+                    // compute the lazy value now
+                    switch (hLazy.getVarSupport().getReferent(frame, hLazy, Op.A_STACK)) {
+                    case Op.R_NEXT:
+                        hValue = frame.popStack();
+                        break;
+
+                    case Op.R_CALL: {
+                        Frame frameNext = frame.m_frameNext;
+                        frameNext.addContinuation(frameCaller -> {
+                            saveConstHandle(constValue, frameCaller.peekStack());
+                            return Op.R_NEXT;
+                        });
+                        return new DeferredCallHandle(frameNext);
+                    }
+
+                    case Op.R_EXCEPTION:
+                        return new DeferredCallHandle(frame.clearException());
+
+                    default:
+                        throw new IllegalStateException();
+                    }
+                }
                 return saveConstHandle(constValue, hValue);
             }
 

--- a/javatools/src/main/java/org/xvm/runtime/Utils.java
+++ b/javatools/src/main/java/org/xvm/runtime/Utils.java
@@ -47,6 +47,7 @@ import org.xvm.runtime.template.annotations.xFuture.FutureHandle;
 import org.xvm.runtime.template.annotations.xFuture.FutureTupleHandle;
 import org.xvm.runtime.template.annotations.xInject;
 import org.xvm.runtime.template.annotations.xInject.InjectedHandle;
+import org.xvm.runtime.template.annotations.xLazy;
 
 import org.xvm.runtime.template.collections.xArray;
 import org.xvm.runtime.template.collections.xArray.ArrayHandle;
@@ -939,6 +940,13 @@ public abstract class Utils {
             default:
                 throw new IllegalStateException();
             }
+        }
+
+        if (prop.isLazy()) {
+            // create an unassigned LazyHandle
+            TypeComposition clzRef   = idProp.getRefType(null).ensureClass(frame);
+            xLazy           template = (xLazy) frame.ensureTemplate(frame.poolContext().clzLazy());
+            return template.introduceRef(frame, clzRef, idProp.getName(), Op.A_STACK);
         }
 
         Constant constVal = prop.getInitialValue();

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xLazy.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xLazy.java
@@ -123,8 +123,9 @@ public class xLazy
          * @return true iff this handle represents a lazy property on an immutable object
          */
         public boolean isPropertyOnImmutable() {
+            // absence of the OUTER indicates a static Lazy property
             ObjectHandle hOuter = getField(null, GenericHandle.OUTER);
-            return hOuter != null && !hOuter.isMutable();
+            return hOuter == null || !hOuter.isMutable();
         }
 
         /**

--- a/manualTests/src/main/x/prop.x
+++ b/manualTests/src/main/x/prop.x
@@ -99,10 +99,17 @@ module TestProps {
     }
 
     void testLazyProperty() {
-        assert lazy == 42;
+        assert !&lazyInstance.assigned;
+        assert lazyInstance == 42;
+        assert &lazyInstance.assigned;
+
+        assert !&lazyStatic.assigned;
+        assert lazyStatic == 42;
+        assert &lazyStatic.assigned;
     }
 
-    @Lazy Int lazy.calc() = 42;
+    @Lazy Int lazyInstance.calc() = 42;
+    static @Lazy Int lazyStatic.calc() = 42;
 
     static void testModuleProperty() {
         this:module.console.print("\n** testModuleProperty()");


### PR DESCRIPTION
This issue arose from [the question from Michael on Discord](https://discord.com/channels/837372142576205885/1406009322307190834/1532566968752931007)

As it is, we don't allow `@Lazy` static properties. 

This change adds the necessary support in the compiler and the interpreter.