### PR TITLE
Avoid mutating pooled property signatures

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/SignatureConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/SignatureConstant.java
@@ -285,10 +285,18 @@ public class SignatureConstant
         }
 
         if (fDiff) {
-            SignatureConstant that = pool.ensureSignatureConstant(
+            // Property signatures are transient (never serialized). Do not register one into the
+            // ConstantPool and then flip m_fProperty on a pooled method signature — SignatureConstant
+            // is used as a ConcurrentHashMap key, so mutating m_fProperty after registration corrupts
+            // the pool.
+            if (m_fProperty) {
+                SignatureConstant that = new SignatureConstant(
+                        pool, getName(), aconstParamResolved, aconstReturnResolved);
+                that.m_fProperty = true;
+                return that;
+            }
+            return pool.ensureSignatureConstant(
                     getName(), aconstParamResolved, aconstReturnResolved);
-            that.m_fProperty = this.m_fProperty;
-            return that;
         }
 
         return this;

--- a/javatools/src/main/java/org/xvm/asm/constants/SignatureConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/SignatureConstant.java
@@ -285,15 +285,12 @@ public class SignatureConstant
         }
 
         if (fDiff) {
-            // Property signatures are transient (never serialized). Do not register one into the
-            // ConstantPool and then flip m_fProperty on a pooled method signature — SignatureConstant
-            // is used as a ConcurrentHashMap key, so mutating m_fProperty after registration corrupts
-            // the pool.
+            // don't register the constant until its state is changed
             if (m_fProperty) {
                 SignatureConstant that = new SignatureConstant(
                         pool, getName(), aconstParamResolved, aconstReturnResolved);
                 that.m_fProperty = true;
-                return that;
+                return pool.register(that);
             }
             return pool.ensureSignatureConstant(
                     getName(), aconstParamResolved, aconstReturnResolved);

--- a/javatools/src/test/java/org/xvm/asm/constants/SignatureConstantTest.java
+++ b/javatools/src/test/java/org/xvm/asm/constants/SignatureConstantTest.java
@@ -1,0 +1,49 @@
+package org.xvm.asm.constants;
+
+
+import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.ClassStructure;
+import org.xvm.asm.Component;
+import org.xvm.asm.ConstantPool;
+import org.xvm.asm.FileStructure;
+import org.xvm.asm.ModuleStructure;
+import org.xvm.asm.PropertyStructure;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Tests for {@link SignatureConstant}.
+ */
+public class SignatureConstantTest {
+    @Test
+    public void resolvingGenericPropertySignatureDoesNotPolluteConstantPool() {
+        FileStructure  file   = new FileStructure("test");
+        ConstantPool   pool   = file.getConstantPool();
+        ModuleStructure module = file.getModule();
+
+        ClassStructure actual = module.createClass(
+                Component.Access.PUBLIC, Component.Format.CLASS, "Actual", null);
+        ClassStructure box = module.createClass(
+                Component.Access.PUBLIC, Component.Format.CLASS, "Box", null);
+
+        PropertyStructure typeParameter = box.addTypeParam("T", actual.getCanonicalType());
+        TypeConstant formalType = typeParameter.getIdentityConstant().getFormalType();
+        PropertyStructure value = box.createProperty(
+                false, Component.Access.PUBLIC, Component.Access.PUBLIC, formalType, "value");
+
+        SignatureConstant propertySignature = value.getIdentityConstant().getSignature();
+        SignatureConstant resolved = propertySignature.resolveGenericTypes(
+                pool, ignored -> actual.getCanonicalType());
+
+        assertTrue(resolved.isProperty());
+        assertNull(pool.getConstant(resolved));
+
+        SignatureConstant methodSignature = pool.ensureSignatureConstant(
+                "value", ConstantPool.NO_TYPES, new TypeConstant[] {actual.getCanonicalType()});
+        assertFalse(methodSignature.isProperty());
+    }
+}

--- a/javatools/src/test/java/org/xvm/asm/constants/SignatureConstantTest.java
+++ b/javatools/src/test/java/org/xvm/asm/constants/SignatureConstantTest.java
@@ -11,7 +11,8 @@ import org.xvm.asm.ModuleStructure;
 import org.xvm.asm.PropertyStructure;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -20,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class SignatureConstantTest {
     @Test
-    public void resolvingGenericPropertySignatureDoesNotPolluteConstantPool() {
+    public void resolvingGenericPropertySignaturePreservesCanonicalInstances() {
         FileStructure  file   = new FileStructure("test");
         ConstantPool   pool   = file.getConstantPool();
         ModuleStructure module = file.getModule();
@@ -38,12 +39,16 @@ public class SignatureConstantTest {
         SignatureConstant propertySignature = value.getIdentityConstant().getSignature();
         SignatureConstant resolved = propertySignature.resolveGenericTypes(
                 pool, ignored -> actual.getCanonicalType());
+        SignatureConstant resolvedAgain = propertySignature.resolveGenericTypes(
+                pool, ignored -> actual.getCanonicalType());
 
         assertTrue(resolved.isProperty());
-        assertNull(pool.getConstant(resolved));
+        assertSame(resolved, pool.getConstant(resolved));
+        assertSame(resolved, resolvedAgain);
 
         SignatureConstant methodSignature = pool.ensureSignatureConstant(
                 "value", ConstantPool.NO_TYPES, new TypeConstant[] {actual.getCanonicalType()});
         assertFalse(methodSignature.isProperty());
+        assertNotSame(resolved, methodSignature);
     }
 }


### PR DESCRIPTION
## Summary
- set the property-signature flag before registering a resolved signature
- retain canonical constant-pool identity for property signatures and ordinary method signatures
- add focused coverage for canonical reuse and method/property separation

## Why
`SignatureConstant` comparison includes the transient property-signature flag. `resolveGenericTypes()` previously obtained a pooled method signature and then set `m_fProperty`, changing the semantic identity of a key after insertion into the constant pool's `ConcurrentHashMap`.

A subsequent lookup for the equivalent method signature could no longer match that mutated key. We observed the resulting null lookup as an NPE while preparing a JsonDB multi-map transaction.

The fix creates the resolved signature, sets `m_fProperty`, and only then registers it. This avoids mutating a registered key while preserving the constant pool's one-canonical-instance behavior and state such as `m_sJitName`.

## Reproducer
`SignatureConstantTest.resolvingGenericPropertySignaturePreservesCanonicalInstances()` creates and resolves a generic property signature twice. It verifies that both resolutions return the same pooled property signature and that the equivalent method signature remains a distinct non-property instance.

## Test plan
- [x] `./gradlew :javatools:test --tests org.xvm.asm.constants.SignatureConstantTest`
- [x] `./gradlew :javatools:test`