### PR TITLE
Add authenticated AES encryption and key wrapping

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
@@ -148,7 +148,9 @@ public class xRTAlgorithms
             }
 
             case 1:   // SymmetricalCipher
-            case 2: { // AsymmetricalCipher
+            case 2:   // AsymmetricalCipher
+            case 6:   // AuthenticatedCipher
+            case 7: { // KeyWrappingCipher
                 Cipher cipher = Cipher.getInstance(sName);
 
                 nBlockSize = cipher.getBlockSize();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAuthenticatedDecryptor.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAuthenticatedDecryptor.java
@@ -1,0 +1,162 @@
+package org.xvm.runtime.template._native.crypto;
+
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.SecureRandom;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.Cipher;
+
+import javax.crypto.spec.GCMParameterSpec;
+
+import org.xvm.asm.ClassStructure;
+import org.xvm.asm.MethodStructure;
+
+import org.xvm.runtime.Container;
+import org.xvm.runtime.Frame;
+import org.xvm.runtime.ObjectHandle;
+
+import org.xvm.runtime.template.xBoolean;
+import org.xvm.runtime.template.xException;
+import org.xvm.runtime.template.xService;
+import org.xvm.runtime.template.text.xString.StringHandle;
+
+import org.xvm.runtime.template.collections.xArray;
+import org.xvm.runtime.template.collections.xArray.ArrayHandle;
+import org.xvm.runtime.template.collections.xArray.Mutability;
+import org.xvm.runtime.template.collections.xByteArray;
+
+import org.xvm.runtime.template._native.crypto.xRTAlgorithms.KeyForm;
+
+
+/**
+ * Native implementation of the RTAuthenticatedDecryptor service.
+ */
+public class xRTAuthenticatedDecryptor
+        extends xService {
+    public static xRTAuthenticatedDecryptor INSTANCE;
+
+    public xRTAuthenticatedDecryptor(Container container, ClassStructure structure,
+                                     boolean fInstance) {
+        super(container, structure, false);
+
+        if (fInstance) {
+            INSTANCE = this;
+        }
+    }
+
+    @Override
+    public void initNative() {
+        markNativeMethod("seal",
+                new String[] {STRING[0], OBJECT[0], BYTES[0], BYTES[0]}, null);
+        markNativeMethod("open",
+                new String[] {STRING[0], OBJECT[0], BYTES[0], BYTES[0], BYTES[0]}, null);
+
+        invalidateTypeInfo();
+    }
+
+    @Override
+    public int invokeNativeNN(Frame frame, MethodStructure method, ObjectHandle hTarget,
+                              ObjectHandle[] ahArg, int[] aiReturn) {
+        switch (method.getName()) {
+        case "seal":
+            return invokeSeal(frame, ((StringHandle) ahArg[0]).getStringValue(), ahArg[1],
+                    (ArrayHandle) ahArg[2], (ArrayHandle) ahArg[3], aiReturn);
+
+        case "open":
+            return invokeOpen(frame, ((StringHandle) ahArg[0]).getStringValue(), ahArg[1],
+                    (ArrayHandle) ahArg[2], (ArrayHandle) ahArg[3],
+                    (ArrayHandle) ahArg[4], aiReturn);
+        }
+
+        return super.invokeNativeNN(frame, method, hTarget, ahArg, aiReturn);
+    }
+
+    /**
+     * Native implementation of:
+     * {@code (Byte[] nonce, Byte[] ciphertext) seal(String algorithm, Object secret,
+     * Byte[] data, Byte[] associatedData)}.
+     */
+    private int invokeSeal(Frame frame, String sAlgorithm, ObjectHandle hKey,
+                           ArrayHandle haData, ArrayHandle haAssociatedData, int[] aiReturn) {
+        byte[] abData           = xByteArray.getBytes(haData);
+        byte[] abAssociatedData = xByteArray.getBytes(haAssociatedData);
+        byte[] abNonce          = new byte[NONCE_SIZE];
+        s_random.nextBytes(abNonce);
+
+        try {
+            String sKeyAlgorithm = validateAlgorithm(sAlgorithm);
+            Key    key           = xRTAlgorithms.extractKey(frame, hKey, sKeyAlgorithm,
+                    KeyForm.PrivateOrSecret);
+
+            Cipher cipher = Cipher.getInstance(sAlgorithm);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_SIZE_BITS, abNonce));
+            cipher.updateAAD(abAssociatedData);
+
+            byte[] abCiphertext = cipher.doFinal(abData);
+            return frame.assignValues(aiReturn,
+                    xArray.makeByteArrayHandle(abNonce, Mutability.Constant),
+                    xArray.makeByteArrayHandle(abCiphertext, Mutability.Constant));
+        } catch (GeneralSecurityException e) {
+            return frame.raiseException(xException.makeObscure(frame, e.getMessage()));
+        }
+    }
+
+    /**
+     * Native implementation of:
+     * {@code conditional Byte[] open(String algorithm, Object secret, Byte[] nonce,
+     * Byte[] ciphertext, Byte[] associatedData)}.
+     */
+    private int invokeOpen(Frame frame, String sAlgorithm, ObjectHandle hKey,
+                           ArrayHandle haNonce, ArrayHandle haCiphertext,
+                           ArrayHandle haAssociatedData, int[] aiReturn) {
+        byte[] abNonce          = xByteArray.getBytes(haNonce);
+        byte[] abCiphertext     = xByteArray.getBytes(haCiphertext);
+        byte[] abAssociatedData = xByteArray.getBytes(haAssociatedData);
+
+        if (abNonce.length != NONCE_SIZE || abCiphertext.length < TAG_SIZE_BYTES) {
+            return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+        }
+
+        try {
+            String sKeyAlgorithm = validateAlgorithm(sAlgorithm);
+            Key    key           = xRTAlgorithms.extractKey(frame, hKey, sKeyAlgorithm,
+                    KeyForm.PrivateOrSecret);
+
+            Cipher cipher = Cipher.getInstance(sAlgorithm);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_SIZE_BITS, abNonce));
+            cipher.updateAAD(abAssociatedData);
+
+            byte[] abData = cipher.doFinal(abCiphertext);
+            return frame.assignValues(aiReturn, xBoolean.TRUE,
+                    xArray.makeByteArrayHandle(abData, Mutability.Constant));
+        } catch (AEADBadTagException e) {
+            return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+        } catch (GeneralSecurityException e) {
+            return frame.raiseException(xException.makeObscure(frame, e.getMessage()));
+        }
+    }
+
+    /**
+     * Validate the selected authenticated-encryption transformation and obtain its key algorithm.
+     */
+    private static String validateAlgorithm(String sAlgorithm)
+            throws GeneralSecurityException {
+        if (!AES_GCM_ALGORITHM.equals(sAlgorithm)) {
+            throw new GeneralSecurityException(
+                    "Unsupported authenticated-encryption algorithm: " + sAlgorithm);
+        }
+        return "AES";
+    }
+
+
+    // ----- constants -----------------------------------------------------------------------------
+
+    private static final String AES_GCM_ALGORITHM = "AES/GCM/NoPadding";
+    private static final int    NONCE_SIZE        = 12;
+    private static final int    TAG_SIZE_BITS     = 128;
+    private static final int    TAG_SIZE_BYTES    = TAG_SIZE_BITS / 8;
+
+    private static final SecureRandom s_random = new SecureRandom();
+}

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyUnwrapper.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyUnwrapper.java
@@ -1,0 +1,171 @@
+package org.xvm.runtime.template._native.crypto;
+
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+
+import javax.crypto.Cipher;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.xvm.asm.ClassStructure;
+import org.xvm.asm.MethodStructure;
+
+import org.xvm.runtime.Container;
+import org.xvm.runtime.Frame;
+import org.xvm.runtime.ObjectHandle;
+
+import org.xvm.runtime.template.xBoolean;
+import org.xvm.runtime.template.xException;
+import org.xvm.runtime.template.xService;
+
+import org.xvm.runtime.template.collections.xArray;
+import org.xvm.runtime.template.collections.xArray.ArrayHandle;
+import org.xvm.runtime.template.collections.xArray.Mutability;
+import org.xvm.runtime.template.collections.xByteArray;
+
+import org.xvm.runtime.template.numbers.xInt64;
+
+import org.xvm.runtime.template.text.xString.StringHandle;
+
+import org.xvm.runtime.template._native.crypto.xRTAlgorithms.KeyForm;
+import org.xvm.runtime.template._native.crypto.xRTAlgorithms.SecretHandle;
+
+
+/**
+ * Native implementation of the RTKeyUnwrapper service.
+ */
+public class xRTKeyUnwrapper
+        extends xService {
+    public static xRTKeyUnwrapper INSTANCE;
+
+    public xRTKeyUnwrapper(Container container, ClassStructure structure, boolean fInstance) {
+        super(container, structure, false);
+
+        if (fInstance) {
+            INSTANCE = this;
+        }
+    }
+
+    @Override
+    public void initNative() {
+        markNativeMethod("wrap",
+                new String[] {STRING[0], OBJECT[0], STRING[0], OBJECT[0]}, BYTES);
+        markNativeMethod("unwrap",
+                new String[] {STRING[0], OBJECT[0], BYTES[0], STRING[0]}, null);
+
+        invalidateTypeInfo();
+    }
+
+    @Override
+    public int invokeNativeN(Frame frame, MethodStructure method, ObjectHandle hTarget,
+                             ObjectHandle[] ahArg, int iReturn) {
+        if ("wrap".equals(method.getName())) {
+            return invokeWrap(frame,
+                    ((StringHandle) ahArg[0]).getStringValue(),
+                    ahArg[1],
+                    ((StringHandle) ahArg[2]).getStringValue(),
+                    ahArg[3],
+                    iReturn);
+        }
+
+        return super.invokeNativeN(frame, method, hTarget, ahArg, iReturn);
+    }
+
+    @Override
+    public int invokeNativeNN(Frame frame, MethodStructure method, ObjectHandle hTarget,
+                              ObjectHandle[] ahArg, int[] aiReturn) {
+        if ("unwrap".equals(method.getName())) {
+            return invokeUnwrap(frame,
+                    ((StringHandle) ahArg[0]).getStringValue(),
+                    ahArg[1],
+                    (ArrayHandle) ahArg[2],
+                    ((StringHandle) ahArg[3]).getStringValue(),
+                    aiReturn);
+        }
+
+        return super.invokeNativeNN(frame, method, hTarget, ahArg, aiReturn);
+    }
+
+    /**
+     * Native implementation of:
+     * {@code Byte[] wrap(String algorithm, Object wrappingSecret, String keyAlgorithm,
+     * Object keySecret)}.
+     */
+    private int invokeWrap(Frame frame, String sAlgorithm, ObjectHandle hWrappingKey,
+                           String sKeyAlgorithm, ObjectHandle hKey, int iReturn) {
+        try {
+            validateAlgorithm(sAlgorithm);
+
+            Key keyWrapping = xRTAlgorithms.extractKey(
+                    frame, hWrappingKey, "AES", KeyForm.PrivateOrSecret);
+            Key key = extractSecretKey(hKey, sKeyAlgorithm);
+
+            Cipher cipher = Cipher.getInstance(sAlgorithm);
+            cipher.init(Cipher.WRAP_MODE, keyWrapping);
+
+            byte[] abWrapped = cipher.wrap(key);
+            return frame.assignValue(iReturn,
+                    xArray.makeByteArrayHandle(abWrapped, Mutability.Constant));
+        } catch (GeneralSecurityException e) {
+            return frame.raiseException(xException.illegalArgument(frame, e.getMessage()));
+        }
+    }
+
+    /**
+     * Native implementation of:
+     * {@code conditional (Int keySize, Object keySecret) unwrap(String algorithm,
+     * Object wrappingSecret, Byte[] wrapped, String keyAlgorithm)}.
+     */
+    private int invokeUnwrap(Frame frame, String sAlgorithm, ObjectHandle hWrappingKey,
+                             ArrayHandle haWrapped, String sKeyAlgorithm, int[] aiReturn) {
+        try {
+            validateAlgorithm(sAlgorithm);
+
+            Key keyWrapping = xRTAlgorithms.extractKey(
+                    frame, hWrappingKey, "AES", KeyForm.PrivateOrSecret);
+
+            Cipher cipher = Cipher.getInstance(sAlgorithm);
+            cipher.init(Cipher.UNWRAP_MODE, keyWrapping);
+
+            Key key = cipher.unwrap(
+                    xByteArray.getBytes(haWrapped), sKeyAlgorithm, Cipher.SECRET_KEY);
+            byte[] abKey = key.getEncoded();
+            if (abKey == null) {
+                return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+            }
+
+            return frame.assignValues(aiReturn, xBoolean.TRUE,
+                    xInt64.makeHandle(abKey.length), new SecretHandle(key));
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+        }
+    }
+
+    /**
+     * Extract an opaque key, or represent visible bytes directly as a secret key. Key wrapping only
+     * requires an encoded secret and must not depend on a SecretKeyFactory for the target algorithm.
+     */
+    private static Key extractSecretKey(ObjectHandle hKey, String sAlgorithm) {
+        return hKey instanceof SecretHandle hSecret
+                ? hSecret.f_key
+                : new SecretKeySpec(xByteArray.getBytes((ArrayHandle) hKey), sAlgorithm);
+    }
+
+    /**
+     * Verify that the bridge requested one of the registered key-wrapping transformations.
+     */
+    private static void validateAlgorithm(String sAlgorithm)
+            throws GeneralSecurityException {
+        if (!AES_KW_ALGORITHM.equals(sAlgorithm) && !AES_KWP_ALGORITHM.equals(sAlgorithm)) {
+            throw new GeneralSecurityException(
+                    "Unsupported key-wrapping algorithm: " + sAlgorithm);
+        }
+    }
+
+
+    // ----- constants -----------------------------------------------------------------------------
+
+    private static final String AES_KW_ALGORITHM  = "AES/KW/NoPadding";
+    private static final String AES_KWP_ALGORITHM = "AES/KWP/NoPadding";
+}

--- a/javatools_bridge/src/main/x/_native/crypto/RTAlgorithms.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTAlgorithms.x
@@ -9,7 +9,8 @@ import libcrypto.KeyForm;
 service RTAlgorithms {
     typedef Int|Int[] as KeySize;
 
-    enum AlgorithmMethod {Hasher, SymmetricCipher, AsymmetricCipher, MAC, Signature, KeyGen}
+    enum AlgorithmMethod {Hasher, SymmetricCipher, AsymmetricCipher, MAC, Signature, KeyGen,
+                          AuthenticatedCipher, KeyWrappingCipher}
 
     /**
      * Create the Algorithms object based on the supported algorithm information.
@@ -18,7 +19,8 @@ service RTAlgorithms {
      */
     Algorithms createAlgorithms() {
         Algorithm[] algorithms = new Array<Algorithm>
-            (hashers.size + encryptions.size + macs.size + signers.size + keyGenerators.size);
+            (hashers.size + encryptions.size + authenticatedEncryptions.size + keyWrappings.size
+                + macs.size + signers.size + keyGenerators.size);
 
         for ((String name, String hasherName, Int hashSize) : hashers) {
             (_, Object implementation) = getAlgorithmInfo(hasherName, Hasher);
@@ -32,6 +34,20 @@ service RTAlgorithms {
 
             KeyForm   keyForm = method == SymmetricCipher ? Secret : Pair;
             Algorithm alg     = new RTEncryptionAlgorithm(name, blockSize, keySize, keyForm, implementation);
+            algorithms.add(&alg.maskAs(Algorithm));
+        }
+
+        for ((String name, KeySize keySize) : authenticatedEncryptions) {
+            (Int blockSize, _) = getAlgorithmInfo(name, AuthenticatedCipher);
+
+            Algorithm alg = new RTAuthenticatedEncryptionAlgorithm(name, blockSize, keySize);
+            algorithms.add(&alg.maskAs(Algorithm));
+        }
+
+        for ((String name, KeySize keySize) : keyWrappings) {
+            (Int blockSize, _) = getAlgorithmInfo(name, KeyWrappingCipher);
+
+            Algorithm alg = new RTKeyWrappingAlgorithm(name, blockSize, keySize);
             algorithms.add(&alg.maskAs(Algorithm));
         }
 
@@ -115,6 +131,21 @@ service RTAlgorithms {
         // such as shared secret key
         (AsymmetricCipher, "RSA"                 , RSA_SIZES),
         (AsymmetricCipher, "RSA/ECB/PKCS1Padding", RSA_SIZES),
+    ];
+
+    /**
+     * Supported authenticated-encryption algorithms (name, key sizes).
+     */
+    static Tuple<String, KeySize>[] authenticatedEncryptions = [
+        ("AES/GCM/NoPadding", AES_SIZES),
+    ];
+
+    /**
+     * Supported key-wrapping algorithms (name, key-encryption-key sizes).
+     */
+    static Tuple<String, KeySize>[] keyWrappings = [
+        ("AES/KW/NoPadding" , AES_SIZES),
+        ("AES/KWP/NoPadding", AES_SIZES),
     ];
 
     /**

--- a/javatools_bridge/src/main/x/_native/crypto/RTAuthenticatedDecryptor.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTAuthenticatedDecryptor.x
@@ -1,0 +1,83 @@
+import libcrypto.AuthenticatedCiphertext;
+import libcrypto.AuthenticatedDecryptor;
+import libcrypto.CryptoKey;
+
+/**
+ * The native [AuthenticatedDecryptor] implementation.
+ */
+service RTAuthenticatedDecryptor(String algorithm)
+        implements AuthenticatedDecryptor {
+
+    construct(String algorithm, CryptoKey privateKey) {
+        this.algorithm  = algorithm;
+        this.privateKey = privateKey;
+    }
+
+    @Override
+    CryptoKey? publicKey.get() = Null;
+
+    @Override
+    CryptoKey? privateKey;
+
+    /**
+     * The number of messages sealed by this engine. NIST SP 800-38D limits randomly generated
+     * 96-bit IVs to at most 2^32 invocations under one key.
+     */
+    private Int sealCount;
+
+    @Override
+    AuthenticatedCiphertext seal(Byte[] data, Byte[] associatedData = []) {
+        if (sealCount >= MaxSeals) {
+            throw new IllegalState("AES-GCM key usage limit reached; rekey before sealing more data");
+        }
+        ++sealCount;
+
+        if (Object secret := RTKeyStore.extractSecret(privateKey ?: assert)) {
+            (Byte[] nonce, Byte[] ciphertext) = seal(algorithm, secret, data, associatedData);
+            return new AuthenticatedCiphertext(algorithm, nonce, ciphertext);
+        }
+
+        throw new IllegalState($"Unsupported key {privateKey}");
+    }
+
+    @Override
+    conditional Byte[] open(
+            AuthenticatedCiphertext encrypted, Byte[] associatedData = []) {
+        if (encrypted.algorithm != algorithm) {
+            return False;
+        }
+
+        if (Object secret := RTKeyStore.extractSecret(privateKey ?: assert)) {
+            return open(algorithm, secret, encrypted.nonce, encrypted.ciphertext, associatedData);
+        }
+
+        throw new IllegalState($"Unsupported key {privateKey}");
+    }
+
+    @Override
+    void close(Exception? cause = Null) {}
+
+    @Override
+    String toString() {
+        return $"{algorithm.quoted()} authenticated decryptor";
+    }
+
+
+    // ----- native helpers ------------------------------------------------------------------------
+
+    protected (Byte[] nonce, Byte[] ciphertext)
+            seal(String algorithm, Object secret, Byte[] data, Byte[] associatedData) {
+        TODO("Native");
+    }
+
+    protected conditional Byte[]
+            open(String algorithm, Object secret, Byte[] nonce, Byte[] ciphertext,
+                 Byte[] associatedData) {
+        TODO("Native");
+    }
+
+
+    // ----- constants -----------------------------------------------------------------------------
+
+    static Int MaxSeals = 0x1_0000_0000;
+}

--- a/javatools_bridge/src/main/x/_native/crypto/RTAuthenticatedEncryptionAlgorithm.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTAuthenticatedEncryptionAlgorithm.x
@@ -1,0 +1,66 @@
+import libcrypto.Algorithm;
+import libcrypto.Algorithm.Category;
+import libcrypto.Algorithms;
+import libcrypto.AuthenticatedDecryptor;
+import libcrypto.CryptoKey;
+import libcrypto.KeyForm;
+
+/**
+ * The native [AuthenticatedEncryption] [Algorithm] implementation.
+ */
+service RTAuthenticatedEncryptionAlgorithm(String name)
+        implements Algorithm {
+
+    construct(String name, Int blockSize, Int|Int[] keySize) {
+        this.name       = name;
+        this.blockSize_ = blockSize;
+        this.keySize    = keySize;
+    }
+
+    /**
+     * The block size reported by the native provider.
+     */
+    private Int blockSize_;
+
+    /**
+     * The supported key size(s) for this algorithm.
+     */
+    private Int|Int[] keySize;
+
+
+    // ----- Algorithm API -------------------------------------------------------------------------
+
+    @Override
+    Category category.get() {
+        return AuthenticatedEncryption;
+    }
+
+    @Override
+    Int blockSize.get() {
+        return blockSize_;
+    }
+
+    @Override
+    conditional Int|Int[] keyRequired() {
+        return True, keySize;
+    }
+
+    @Override
+    AuthenticatedDecryptor allocate(CryptoKey? key) {
+        if (key == Null) {
+            throw new IllegalArgument("Key is required");
+        }
+
+        assert key.form == Secret as $"Invalid key form for {this}";
+        assert key.algorithm == "AES" as $"Invalid key algorithm for {this}";
+        assert Algorithms.validSize(keySize, key.size) as $"Invalid key size for {this}";
+
+        AuthenticatedDecryptor decryptor = new RTAuthenticatedDecryptor(name, key);
+        return &decryptor.maskAs(AuthenticatedDecryptor);
+    }
+
+    @Override
+    String toString() {
+        return $"{name.quoted()} authenticated-encryption algorithm with {keySize} bytes key";
+    }
+}

--- a/javatools_bridge/src/main/x/_native/crypto/RTKeyUnwrapper.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTKeyUnwrapper.x
@@ -1,0 +1,79 @@
+import libcrypto.CryptoKey;
+import libcrypto.KeyUnwrapper;
+import libcrypto.PrivateKey;
+import libcrypto.WrappedKey;
+
+/**
+ * The native [KeyUnwrapper] implementation.
+ */
+service RTKeyUnwrapper(String algorithm)
+        implements KeyUnwrapper {
+
+    construct(String algorithm, CryptoKey wrappingKey) {
+        this.algorithm   = algorithm;
+        this.wrappingKey = wrappingKey;
+    }
+
+    @Override
+    CryptoKey wrappingKey;
+
+    @Override
+    WrappedKey wrap(CryptoKey key) {
+        if (key.form != Secret) {
+            throw new IllegalArgument("Only secret keys can be wrapped");
+        }
+        if (key.algorithm.empty || key.size <= 0) {
+            throw new IllegalArgument("The key algorithm and size are required");
+        }
+        if (algorithm == "AES/KW/NoPadding" && (key.size < 16 || key.size % 8 != 0)) {
+            throw new IllegalArgument(
+                "AES-KW requires a key size of at least 16 bytes and a multiple of 8 bytes");
+        }
+
+        if (Object wrappingSecret := RTKeyStore.extractSecret(wrappingKey),
+                Object keySecret := RTKeyStore.extractSecret(key)) {
+            Byte[] bytes = wrap(algorithm, wrappingSecret, key.algorithm, keySecret);
+            return new WrappedKey(algorithm, bytes);
+        }
+
+        throw new IllegalState("Unsupported key");
+    }
+
+    @Override
+    conditional CryptoKey unwrap(
+            WrappedKey wrapped, String keyName, String keyAlgorithm) {
+        if (wrapped.algorithm != algorithm || keyAlgorithm.empty) {
+            return False;
+        }
+
+        if (Object wrappingSecret := RTKeyStore.extractSecret(wrappingKey),
+                (Int keySize, Object keySecret) :=
+                    unwrap(algorithm, wrappingSecret, wrapped.bytes, keyAlgorithm)) {
+            CryptoKey key = new RTPrivateKey(keyName, keyAlgorithm, keySize, keySecret);
+            return True, &key.maskAs(PrivateKey);
+        }
+
+        return False;
+    }
+
+    @Override
+    void close(Exception? cause = Null) {}
+
+    @Override
+    String toString() {
+        return $"{algorithm.quoted()} key unwrapper";
+    }
+
+
+    // ----- native helpers ------------------------------------------------------------------------
+
+    protected Byte[] wrap(
+        String algorithm, Object wrappingSecret, String keyAlgorithm, Object keySecret) {
+        TODO("Native");
+    }
+
+    protected conditional (Int keySize, Object keySecret) unwrap(
+        String algorithm, Object wrappingSecret, Byte[] wrapped, String keyAlgorithm) {
+        TODO("Native");
+    }
+}

--- a/javatools_bridge/src/main/x/_native/crypto/RTKeyWrappingAlgorithm.x
+++ b/javatools_bridge/src/main/x/_native/crypto/RTKeyWrappingAlgorithm.x
@@ -1,0 +1,66 @@
+import libcrypto.Algorithm;
+import libcrypto.Algorithm.Category;
+import libcrypto.Algorithms;
+import libcrypto.CryptoKey;
+import libcrypto.KeyUnwrapper;
+import libcrypto.KeyForm;
+
+/**
+ * The native [KeyWrapping] [Algorithm] implementation.
+ */
+service RTKeyWrappingAlgorithm(String name)
+        implements Algorithm {
+
+    construct(String name, Int blockSize, Int|Int[] keySize) {
+        this.name       = name;
+        this.blockSize_ = blockSize;
+        this.keySize    = keySize;
+    }
+
+    /**
+     * The block size reported by the native provider.
+     */
+    private Int blockSize_;
+
+    /**
+     * The supported key-encryption-key size(s).
+     */
+    private Int|Int[] keySize;
+
+
+    // ----- Algorithm API -------------------------------------------------------------------------
+
+    @Override
+    Category category.get() {
+        return KeyWrapping;
+    }
+
+    @Override
+    Int blockSize.get() {
+        return blockSize_;
+    }
+
+    @Override
+    conditional Int|Int[] keyRequired() {
+        return True, keySize;
+    }
+
+    @Override
+    KeyUnwrapper allocate(CryptoKey? key) {
+        if (key == Null) {
+            throw new IllegalArgument("Key is required");
+        }
+
+        assert key.form == Secret as $"Invalid key form for {this}";
+        assert key.algorithm == "AES" as $"Invalid key algorithm for {this}";
+        assert Algorithms.validSize(keySize, key.size) as $"Invalid key size for {this}";
+
+        KeyUnwrapper unwrapper = new RTKeyUnwrapper(name, key);
+        return &unwrapper.maskAs(KeyUnwrapper);
+    }
+
+    @Override
+    String toString() {
+        return $"{name.quoted()} key-wrapping algorithm with {keySize} bytes key";
+    }
+}

--- a/lib_crypto/README.md
+++ b/lib_crypto/README.md
@@ -37,3 +37,60 @@ Like the `Encryptor`/`Decryptor`, there is also a `Verifier`/`Signer`. The `Decr
 extends the `Encryptor`, just like the `Signer` extends the `Verifier`. The `Verifier`
 and the `Encryptor` only need a public key when a public/private key pair algorithm is
 used.
+
+## Authenticated encryption
+
+Application data should use an authenticated-encryption algorithm whenever both confidentiality and
+integrity are required. AES-GCM is available through the `AuthenticatedEncryptor` and
+`AuthenticatedDecryptor` capabilities:
+
+    @Inject Algorithms algorithms;
+
+    assert AuthenticatedDecryptor decryptor :=
+        algorithms.authenticatedDecryptorFor("AES/GCM/NoPadding", aesKey);
+
+    Byte[] associatedData = "tenant-id:field-name".utf8();
+    AuthenticatedCiphertext encrypted = decryptor.seal(secretBytes, associatedData);
+
+    assert Byte[] decrypted := decryptor.open(encrypted, associatedData);
+    assert decrypted == secretBytes;
+
+`seal()` generates a fresh 96-bit nonce for every operation. `AuthenticatedCiphertext` carries that
+nonce and the ciphertext with its appended 128-bit authentication tag. The associated data is
+authenticated but not encrypted and must be supplied unchanged to `open()`.
+
+NIST SP 800-38D limits randomly generated 96-bit nonces to 2^32 invocations under one key. The
+runtime enforces that ceiling per encryptor instance; applications must rotate the key before
+reaching 2^32 total seals across all instances that use it.
+
+`open()` returns `False` if authentication fails and never returns unauthenticated plaintext. This
+includes a wrong key or associated data, and any modification to the nonce, ciphertext, or tag.
+
+The provider-dependent `"AES"` transformation commonly selects ECB mode and is not suitable for
+application data. CBC also requires explicit IV handling and separate authentication. Use
+`"AES/GCM/NoPadding"` for self-contained, authenticated messages.
+
+## Key wrapping
+
+AES-KW and AES-KWP protect secret keys using an AES key-encryption key. They are available through
+the `KeyWrapper` and `KeyUnwrapper` capabilities:
+
+    @Inject Algorithms algorithms;
+
+    assert KeyUnwrapper unwrapper :=
+        algorithms.keyUnwrapperFor("AES/KW/NoPadding", keyEncryptionKey);
+
+    WrappedKey wrapped = unwrapper.wrap(applicationKey);
+
+    assert CryptoKey recovered :=
+        unwrapper.unwrap(wrapped, "application-key", "AES");
+
+Use `"AES/KW/NoPadding"` for RFC 3394 interoperability when the wrapped key is at least 16 bytes
+and its size is a multiple of eight bytes. Use `"AES/KWP/NoPadding"` for RFC 5649 interoperability
+when key material has another non-zero size. Both transformations accept 16-, 24-, and 32-byte AES
+key-encryption keys and are supplied by the standard JDK provider.
+
+Wrapping is deterministic and is only intended for cryptographic keys; use AES-GCM for application
+data. `unwrap()` returns `False` for malformed input, a wrong key-encryption key, or an integrity
+failure. A recovered key is opaque. Its name and algorithm must come from trusted, out-of-band
+configuration and are deliberately not stored as unauthenticated `WrappedKey` metadata.

--- a/lib_crypto/build.gradle.kts
+++ b/lib_crypto/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
 dependencies {
     xdkJavaTools(libs.javatools)
     xtcModule(libs.xdk.ecstasy)
+    xtcModuleTest(libs.javatools.bridge)
+    xtcModuleTest(libs.xdk.xunit.engine)
 }

--- a/lib_crypto/src/main/x/crypto/Algorithm.x
+++ b/lib_crypto/src/main/x/crypto/Algorithm.x
@@ -55,11 +55,25 @@ interface Algorithm {
      * * * an [Decryptor] uses either a `Secret` key or a public/private key `Pair` to decrypt
      *     the information in the input.
      *
+     * * `AuthenticatedEncryption` algorithms protect both the confidentiality and integrity of
+     *   input data.
+     *
+     * * * an [AuthenticatedEncryptor] seals data and produces an [AuthenticatedCiphertext] with
+     *     a generated nonce and authentication tag.
+     *
+     * * * an [AuthenticatedDecryptor] authenticates a sealed message before returning plaintext.
+     *
      * * `KeyGeneration` algorithms create `Secret` keys that could be used for symmetrical
      *    encryption and decryption.
      *
+     * * `KeyWrapping` algorithms protect secret keys using another secret key.
+     *
+     * * * a [KeyWrapper] protects encoded key material and its integrity.
+     *
+     * * * a [KeyUnwrapper] verifies and recovers a wrapped secret key.
+     *
      */
-    enum Category {Signing, Encryption, KeyGeneration}
+    enum Category {Signing, Encryption, KeyGeneration, AuthenticatedEncryption, KeyWrapping}
 
     /**
      * The category of the cryptographic algorithm.
@@ -94,8 +108,11 @@ interface Algorithm {
      *
      * @return True if the key is valid and an engine was successfully allocated
      * @return (conditional) the configured crypto engine, which is an `Encryptor`, a `Decryptor`,
-     *         a `Verifier`, a `Signer`, or a `KeyGenerator` as indicated by a combination of the
-     *         [category] and [keyRequired] of the `Algorithm`, and the contents of the passed key
+     *         an `AuthenticatedEncryptor`, an `AuthenticatedDecryptor`, a `Verifier`, a `Signer`,
+     *         a `KeyGenerator`, a `KeyWrapper`, or a `KeyUnwrapper` as indicated by a combination
+     *         of the [category] and [keyRequired] of the `Algorithm`, and the contents of the passed
+     *         key
      */
-    Encryptor|Decryptor|Verifier|Signer|KeyGenerator allocate(CryptoKey? key);
+    Encryptor|Decryptor|AuthenticatedEncryptor|AuthenticatedDecryptor|Verifier|Signer|KeyGenerator|
+            KeyWrapper|KeyUnwrapper allocate(CryptoKey? key);
 }

--- a/lib_crypto/src/main/x/crypto/Algorithms.x
+++ b/lib_crypto/src/main/x/crypto/Algorithms.x
@@ -120,6 +120,84 @@ const Algorithms {
     }
 
     /**
+     * Obtain an [AuthenticatedEncryptor] for the authenticated-encryption algorithm of the
+     * specified name.
+     *
+     * @param specifier  the algorithm name, or the [Algorithm] object itself
+     * @param key        the key used to encrypt and authenticate
+     *
+     * @return `True` iff the `Algorithms` is configured with the specified algorithm, and the key
+     *         is acceptable
+     * @return (conditional) the [AuthenticatedEncryptor] for the specified algorithm
+     */
+    conditional AuthenticatedEncryptor authenticatedEncryptorFor(
+            Specifier specifier, CryptoKey key) {
+        if (Algorithm algorithm := findAlgorithm(specifier, AuthenticatedEncryption, key, False),
+                validSecretKeyFor(algorithm, key)) {
+            return True, algorithm.allocate(key).as(AuthenticatedEncryptor);
+        }
+
+        return False;
+    }
+
+    /**
+     * Obtain an [AuthenticatedDecryptor] for the authenticated-encryption algorithm of the
+     * specified name.
+     *
+     * @param specifier  the algorithm name, or the [Algorithm] object itself
+     * @param key        the private or symmetric key used to authenticate and decrypt
+     *
+     * @return `True` iff the `Algorithms` is configured with the specified algorithm, and the key
+     *         is acceptable
+     * @return (conditional) the [AuthenticatedDecryptor] for the specified algorithm
+     */
+    conditional AuthenticatedDecryptor authenticatedDecryptorFor(
+            Specifier specifier, CryptoKey key) {
+        if (Algorithm algorithm := findAlgorithm(specifier, AuthenticatedEncryption, key, True),
+                validSecretKeyFor(algorithm, key)) {
+            return True, algorithm.allocate(key).as(AuthenticatedDecryptor);
+        }
+
+        return False;
+    }
+
+    /**
+     * Obtain a [KeyWrapper] for the specified key-wrapping algorithm.
+     *
+     * @param specifier  the algorithm name, or the [Algorithm] object itself
+     * @param key        the secret key-encryption key used to wrap keys
+     *
+     * @return `True` iff the algorithm is configured and accepts the key-encryption key
+     * @return (conditional) the [KeyWrapper] for the specified algorithm
+     */
+    conditional KeyWrapper keyWrapperFor(Specifier specifier, CryptoKey key) {
+        if (Algorithm algorithm := findAlgorithm(specifier, KeyWrapping, key, False),
+                validSecretKeyFor(algorithm, key)) {
+            return True, algorithm.allocate(key).as(KeyWrapper);
+        }
+
+        return False;
+    }
+
+    /**
+     * Obtain a [KeyUnwrapper] for the specified key-wrapping algorithm.
+     *
+     * @param specifier  the algorithm name, or the [Algorithm] object itself
+     * @param key        the secret key-encryption key used to unwrap keys
+     *
+     * @return `True` iff the algorithm is configured and accepts the key-encryption key
+     * @return (conditional) the [KeyUnwrapper] for the specified algorithm
+     */
+    conditional KeyUnwrapper keyUnwrapperFor(Specifier specifier, CryptoKey key) {
+        if (Algorithm algorithm := findAlgorithm(specifier, KeyWrapping, key, True),
+                validSecretKeyFor(algorithm, key)) {
+            return True, algorithm.allocate(key).as(KeyUnwrapper);
+        }
+
+        return False;
+    }
+
+    /**
      * Obtain a [KeyGenerator] for the key generation algorithm of the specified name.
      *
      * @param specifier  the algorithm name, or the [Algorithm] object itself
@@ -175,7 +253,9 @@ const Algorithms {
 
         if (Algorithm algorithm := byName.get(name), algorithm.category == category) {
             if (Int|Int[] keySize := algorithm.keyRequired()) {
-                return key != Null && validSize(keySize, key.size)
+                return key != Null
+                        && (!privateRequired || key.form != Public)
+                        && validSize(keySize, key.size)
                         ? (True, algorithm)
                         : False;
             } else {
@@ -185,5 +265,13 @@ const Algorithms {
             }
         }
         return False;
+    }
+
+    /**
+     * Verify the additional key constraints shared by authenticated-encryption algorithms.
+     */
+    private Boolean validSecretKeyFor(Algorithm algorithm, CryptoKey key) {
+        String keyAlgorithm = algorithm.name.split('/')[0];
+        return key.form == Secret && key.algorithm == keyAlgorithm;
     }
 }

--- a/lib_crypto/src/main/x/crypto/AuthenticatedCiphertext.x
+++ b/lib_crypto/src/main/x/crypto/AuthenticatedCiphertext.x
@@ -1,0 +1,24 @@
+/**
+ * The self-contained result of authenticated encryption.
+ *
+ * The [ciphertext] contains both the encrypted data and its authentication tag, using the layout
+ * defined by the named [algorithm]. The [nonce] is public information, but it must not be reused
+ * with the same key; instances are produced by [AuthenticatedEncryptor.seal], which generates the
+ * nonce on behalf of the caller.
+ */
+const AuthenticatedCiphertext(String algorithm, Byte[] nonce, Byte[] ciphertext) {
+    /**
+     * The name of the authenticated-encryption algorithm.
+     */
+    String algorithm;
+
+    /**
+     * The nonce generated for this encryption operation.
+     */
+    Byte[] nonce;
+
+    /**
+     * The encrypted data followed by its authentication tag.
+     */
+    Byte[] ciphertext;
+}

--- a/lib_crypto/src/main/x/crypto/AuthenticatedDecryptor.x
+++ b/lib_crypto/src/main/x/crypto/AuthenticatedDecryptor.x
@@ -1,0 +1,25 @@
+/**
+ * Represents the ability to open a message produced by an [AuthenticatedEncryptor].
+ */
+interface AuthenticatedDecryptor
+        extends AuthenticatedEncryptor {
+    /**
+     * The private key used by the algorithm. A `Null` indicates that the decryptor is not permitted
+     * to expose the private key.
+     */
+    @RO CryptoKey? privateKey;
+
+    /**
+     * Authenticate and decrypt a sealed message.
+     *
+     * No plaintext is returned unless the ciphertext, nonce, authentication tag, and associated
+     * data have all been successfully authenticated.
+     *
+     * @param encrypted       the sealed message to authenticate and decrypt
+     * @param associatedData  the same additional data supplied when the message was sealed
+     *
+     * @return `True` iff authentication succeeds
+     * @return (conditional) the decrypted data
+     */
+    conditional Byte[] open(AuthenticatedCiphertext encrypted, Byte[] associatedData = []);
+}

--- a/lib_crypto/src/main/x/crypto/AuthenticatedEncryptor.x
+++ b/lib_crypto/src/main/x/crypto/AuthenticatedEncryptor.x
@@ -1,0 +1,31 @@
+/**
+ * Represents the ability to seal a message using authenticated encryption.
+ *
+ * Authenticated encryption protects both the confidentiality and integrity of the message.
+ * Additional associated data is authenticated but is not encrypted. The encryptor owns nonce
+ * generation; callers cannot accidentally reuse a nonce directly. A key must be replaced before
+ * it has been used to seal 2^32 messages in total, including use by other encryptor instances.
+ */
+interface AuthenticatedEncryptor
+        extends Closeable {
+    /**
+     * The algorithm name implemented by this `AuthenticatedEncryptor`.
+     */
+    @RO String algorithm;
+
+    /**
+     * The public key used by the algorithm, if it has one. A `Null` indicates that the encryptor
+     * uses a symmetric private key.
+     */
+    @RO CryptoKey? publicKey;
+
+    /**
+     * Encrypt and authenticate the provided data.
+     *
+     * @param data            the data to encrypt
+     * @param associatedData  additional data to authenticate without encrypting
+     *
+     * @return the encrypted data, authentication tag, and generated nonce
+     */
+    AuthenticatedCiphertext seal(Byte[] data, Byte[] associatedData = []);
+}

--- a/lib_crypto/src/main/x/crypto/KeyUnwrapper.x
+++ b/lib_crypto/src/main/x/crypto/KeyUnwrapper.x
@@ -1,0 +1,21 @@
+/**
+ * Represents the ability to recover a secret key protected by a [KeyWrapper].
+ */
+interface KeyUnwrapper
+        extends KeyWrapper {
+    /**
+     * Verify and recover a wrapped secret key.
+     *
+     * The name and algorithm are supplied by the caller so that key semantics are established by
+     * trusted, out-of-band information rather than unauthenticated envelope metadata.
+     *
+     * @param wrapped       the wrapped key material
+     * @param keyName       the name to assign to the recovered key
+     * @param keyAlgorithm  the algorithm for which the recovered key will be used
+     *
+     * @return `True` iff the wrapped key passes its integrity check and can be recovered
+     * @return (conditional) an opaque secret key
+     */
+    conditional CryptoKey unwrap(
+        WrappedKey wrapped, String keyName, String keyAlgorithm);
+}

--- a/lib_crypto/src/main/x/crypto/KeyWrapper.x
+++ b/lib_crypto/src/main/x/crypto/KeyWrapper.x
@@ -1,0 +1,26 @@
+/**
+ * Represents the ability to protect secret key material using a key-encryption key.
+ */
+interface KeyWrapper
+        extends Closeable {
+    /**
+     * The key-wrapping algorithm.
+     */
+    @RO String algorithm;
+
+    /**
+     * The secret key-encryption key used to wrap keys.
+     */
+    @RO CryptoKey wrappingKey;
+
+    /**
+     * Protect a secret key.
+     *
+     * @param key  the secret key to wrap
+     *
+     * @return the wrapped key material
+     *
+     * @throws IllegalArgument  if the key form or encoded size is not supported by the algorithm
+     */
+    WrappedKey wrap(CryptoKey key);
+}

--- a/lib_crypto/src/main/x/crypto/WrappedKey.x
+++ b/lib_crypto/src/main/x/crypto/WrappedKey.x
@@ -1,0 +1,17 @@
+/**
+ * Key material protected by a [KeyWrapper].
+ *
+ * The algorithm and intended use of the wrapped key are supplied independently when the key is
+ * unwrapped; they are not encoded as unauthenticated metadata in this envelope.
+ */
+const WrappedKey(String algorithm, Byte[] bytes) {
+    /**
+     * The key-wrapping algorithm used to produce the wrapped bytes.
+     */
+    String algorithm;
+
+    /**
+     * The wrapped key bytes, including the integrity check defined by the algorithm.
+     */
+    Byte[] bytes;
+}

--- a/lib_crypto/src/test/x/CryptoTest.x
+++ b/lib_crypto/src/test/x/CryptoTest.x
@@ -1,0 +1,357 @@
+/**
+ * Unit tests for the crypto module.
+ */
+module CryptoTest {
+    package crypto import crypto.xtclang.org;
+    package xunit import xunit.xtclang.org;
+
+    import crypto.Algorithm;
+    import crypto.Algorithms;
+    import crypto.AuthenticatedCiphertext;
+    import crypto.AuthenticatedDecryptor;
+    import crypto.AuthenticatedEncryptor;
+    import crypto.CryptoKey;
+    import crypto.KeyGenerator;
+    import crypto.KeyUnwrapper;
+    import crypto.KeyWrapper;
+    import crypto.PrivateKey;
+    import crypto.PublicKey;
+    import crypto.WrappedKey;
+    import xunit.assertions.assertThrows;
+
+    /**
+     * Tests for AES-GCM authenticated encryption.
+     */
+    class AesGcmTest {
+        @Inject Algorithms algorithms;
+
+        @Test
+        void shouldRoundTripSupportedKeySizes() {
+            for (Int keySize : [16, 24, 32]) {
+                AuthenticatedDecryptor decryptor = decryptorFor(newKey(keySize));
+                Byte[] data = new Byte[73](i -> (i * 3).toByte()).freeze(inPlace=True);
+                Byte[] aad  = "tenant:field".utf8();
+
+                AuthenticatedCiphertext encrypted = decryptor.seal(data, aad);
+
+                assert encrypted.algorithm == "AES/GCM/NoPadding";
+                assert encrypted.nonce.size == 12;
+                assert encrypted.ciphertext.size == data.size + 16;
+                assert Byte[] opened := decryptor.open(encrypted, aad);
+                assert opened == data;
+            }
+        }
+
+        @Test
+        void shouldRoundTripEmptyDataAndAssociatedData() {
+            PrivateKey key = newKey(32);
+            assert AuthenticatedEncryptor encryptor :=
+                algorithms.authenticatedEncryptorFor("AES/GCM/NoPadding", key);
+            AuthenticatedDecryptor decryptor = decryptorFor(key);
+
+            AuthenticatedCiphertext encrypted = encryptor.seal([]);
+
+            assert encrypted.ciphertext.size == 16;
+            assert Byte[] opened := decryptor.open(encrypted);
+            assert opened.empty;
+        }
+
+        @Test
+        void shouldGenerateAUniqueNonce() {
+            AuthenticatedDecryptor decryptor = decryptorFor(newKey(32));
+            Byte[] data = "same plaintext".utf8();
+
+            AuthenticatedCiphertext first  = decryptor.seal(data);
+            AuthenticatedCiphertext second = decryptor.seal(data);
+
+            assert first.nonce != second.nonce;
+            assert first.ciphertext != second.ciphertext;
+        }
+
+        @Test
+        void shouldOpenNistKnownAnswerVector() {
+            PrivateKey key = new PrivateKey(
+                "nist-aes-128",
+                "AES",
+                16,
+                #00000000000000000000000000000000
+            );
+            AuthenticatedDecryptor decryptor = decryptorFor(key);
+            AuthenticatedCiphertext encrypted = new AuthenticatedCiphertext(
+                "AES/GCM/NoPadding",
+                #000000000000000000000000,
+                #58E2FCCEFA7E3061367F1D57A4E7455A
+            );
+
+            assert Byte[] opened := decryptor.open(encrypted);
+            assert opened.empty;
+        }
+
+        @Test
+        void shouldRejectModifiedCiphertextAndTag() {
+            AuthenticatedDecryptor decryptor = decryptorFor(newKey(32));
+            AuthenticatedCiphertext encrypted = decryptor.seal("secret".utf8());
+            Byte[] changed = copy(encrypted.ciphertext);
+            changed[0] ^= 1;
+
+            assert !decryptor.open(new AuthenticatedCiphertext(
+                encrypted.algorithm, encrypted.nonce, changed));
+
+            changed = copy(encrypted.ciphertext);
+            changed[changed.size - 1] ^= 1;
+
+            assert !decryptor.open(new AuthenticatedCiphertext(
+                encrypted.algorithm, encrypted.nonce, changed));
+        }
+
+        @Test
+        void shouldRejectModifiedNonceAndAssociatedData() {
+            AuthenticatedDecryptor decryptor = decryptorFor(newKey(32));
+            Byte[] aad = "partner:credential".utf8();
+            AuthenticatedCiphertext encrypted = decryptor.seal("secret".utf8(), aad);
+            Byte[] changedNonce = copy(encrypted.nonce);
+            changedNonce[0] ^= 1;
+
+            assert !decryptor.open(new AuthenticatedCiphertext(
+                encrypted.algorithm, changedNonce, encrypted.ciphertext), aad);
+            assert !decryptor.open(encrypted, "other context".utf8());
+        }
+
+        @Test
+        void shouldRejectWrongKeyAndMalformedEnvelope() {
+            AuthenticatedCiphertext encrypted = decryptorFor(newKey(32)).seal("secret".utf8());
+            AuthenticatedDecryptor wrongKey = decryptorFor(newKey(32, 1));
+
+            assert !wrongKey.open(encrypted);
+            assert !wrongKey.open(new AuthenticatedCiphertext(
+                "other", encrypted.nonce, encrypted.ciphertext));
+            assert !wrongKey.open(new AuthenticatedCiphertext(
+                encrypted.algorithm, #0001, encrypted.ciphertext));
+            assert !wrongKey.open(new AuthenticatedCiphertext(
+                encrypted.algorithm, encrypted.nonce, #0001));
+        }
+
+        @Test
+        void shouldAcceptOpaqueGeneratedKey() {
+            assert KeyGenerator generator := algorithms.keyGeneratorFor("AES");
+            CryptoKey key = generator.generateSecretKey("aes-gcm-test");
+            AuthenticatedDecryptor decryptor = decryptorFor(key);
+
+            AuthenticatedCiphertext encrypted = decryptor.seal("opaque".utf8());
+
+            assert Byte[] opened := decryptor.open(encrypted);
+            assert opened.unpackUtf8() == "opaque";
+        }
+
+        @Test
+        void shouldAcceptByteArraySlices() {
+            AuthenticatedDecryptor decryptor = decryptorFor(newKey(32));
+            Byte[] dataBacking = #00010203040506;
+            Byte[] aadBacking  = #101112131415;
+            Byte[] data = dataBacking[1..<6];
+            Byte[] aad  = aadBacking[1..<5];
+
+            AuthenticatedCiphertext encrypted = decryptor.seal(data, aad);
+
+            assert Byte[] opened := decryptor.open(encrypted, aad);
+            assert opened == data;
+        }
+
+        @Test
+        void shouldReportMetadataAndRejectInvalidKeys() {
+            Algorithm algorithm = algorithms.byCategory[
+                    Algorithm.Category.AuthenticatedEncryption.ordinal]
+                    .get("AES/GCM/NoPadding") ?: assert;
+
+            assert algorithm.blockSize == 16;
+            assert !algorithms.authenticatedDecryptorFor(
+                algorithm, new PrivateKey("wrong-size", "AES", 15, #000102030405060708090A0B0C0D0E));
+            assert !algorithms.authenticatedDecryptorFor(
+                algorithm, new PrivateKey("wrong-algorithm", "HmacSHA256", 16,
+                    #000102030405060708090A0B0C0D0E0F));
+            assert !algorithms.authenticatedDecryptorFor(
+                algorithm, new PublicKey("public", "AES", 16,
+                    #000102030405060708090A0B0C0D0E0F));
+        }
+
+        private AuthenticatedDecryptor decryptorFor(CryptoKey key) {
+            return algorithms.authenticatedDecryptorFor("AES/GCM/NoPadding", key)
+                    ?: assert as "AES-GCM unavailable";
+        }
+
+        private PrivateKey newKey(Int size, Int offset = 0) {
+            return new PrivateKey(
+                "aes-gcm-test",
+                "AES",
+                size,
+                new Byte[size](i -> (i + offset).toByte())
+            );
+        }
+
+        private Byte[] copy(Byte[] bytes) {
+            return new Byte[bytes.size](i -> bytes[i]);
+        }
+    }
+
+    /**
+     * Tests for AES key wrapping.
+     */
+    class AesKeyWrappingTest {
+        @Inject Algorithms algorithms;
+
+        @Test
+        void shouldMatchRfc3394KnownAnswerVector() {
+            PrivateKey wrappingKey = new PrivateKey(
+                "rfc3394-kek", "AES", 16, #000102030405060708090A0B0C0D0E0F);
+            PrivateKey key = new PrivateKey(
+                "rfc3394-key", "AES", 16, #00112233445566778899AABBCCDDEEFF);
+            KeyUnwrapper unwrapper = unwrapperFor("AES/KW/NoPadding", wrappingKey);
+
+            WrappedKey wrapped = unwrapper.wrap(key);
+
+            assert wrapped.bytes == #1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5;
+            assert CryptoKey recovered := unwrapper.unwrap(wrapped, "recovered", "AES");
+            assert !recovered.isVisible();
+            assert unwrapper.wrap(recovered) == wrapped;
+        }
+
+        @Test
+        void shouldMatchRfc5649KnownAnswerVector() {
+            PrivateKey wrappingKey = new PrivateKey(
+                "rfc5649-kek", "AES", 24, #5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8);
+            PrivateKey key = new PrivateKey(
+                "rfc5649-key", "HmacSHA1", 20, #C37B7E6492584340BED12207808941155068F738);
+            KeyUnwrapper unwrapper = unwrapperFor("AES/KWP/NoPadding", wrappingKey);
+
+            WrappedKey wrapped = unwrapper.wrap(key);
+
+            assert wrapped.bytes ==
+                #138BDEAA9B8FA7FC61F97742E72248EE5AE6AE5360D1AE6A5F54F373FA543B6A;
+            assert CryptoKey recovered := unwrapper.unwrap(wrapped, "recovered", "HmacSHA1");
+            assert unwrapper.wrap(recovered) == wrapped;
+        }
+
+        @Test
+        void shouldRoundTripWithAllWrappingKeySizes() {
+            for (Int keySize : [16, 24, 32]) {
+                PrivateKey wrappingKey = newKey("kek", "AES", keySize);
+
+                KeyUnwrapper kw = unwrapperFor("AES/KW/NoPadding", wrappingKey);
+                WrappedKey wrappedAes = kw.wrap(newKey("aes", "AES", 16, 3));
+                assert CryptoKey aes := kw.unwrap(wrappedAes, "aes-restored", "AES");
+                assert kw.wrap(aes) == wrappedAes;
+
+                KeyUnwrapper kwp = unwrapperFor("AES/KWP/NoPadding", wrappingKey);
+                WrappedKey wrappedHmac = kwp.wrap(newKey("hmac", "HmacSHA256", 13, 7));
+                assert CryptoKey hmac := kwp.unwrap(
+                    wrappedHmac, "hmac-restored", "HmacSHA256");
+                assert kwp.wrap(hmac) == wrappedHmac;
+            }
+        }
+
+        @Test
+        void shouldSupportOpaqueWrappingAndTargetKeys() {
+            assert KeyGenerator aesGenerator := algorithms.keyGeneratorFor("AES");
+            assert KeyGenerator hmacGenerator := algorithms.keyGeneratorFor("HmacSHA256");
+            CryptoKey opaqueWrappingKey = aesGenerator.generateSecretKey("opaque-kek");
+            CryptoKey opaqueTargetKey   = hmacGenerator.generateSecretKey("opaque-target");
+            KeyUnwrapper unwrapper = unwrapperFor(
+                "AES/KWP/NoPadding", opaqueWrappingKey);
+
+            WrappedKey wrapped = unwrapper.wrap(opaqueTargetKey);
+
+            assert CryptoKey recovered := unwrapper.unwrap(
+                wrapped, "recovered-target", "HmacSHA256");
+            assert !recovered.isVisible();
+            assert unwrapper.wrap(recovered) == wrapped;
+        }
+
+        @Test
+        void shouldProvideSeparateWrapperCapability() {
+            PrivateKey wrappingKey = newKey("kek", "AES", 16);
+            assert KeyWrapper wrapper :=
+                algorithms.keyWrapperFor("AES/KW/NoPadding", wrappingKey);
+
+            WrappedKey wrapped = wrapper.wrap(newKey("target", "AES", 16));
+
+            assert wrapped.algorithm == "AES/KW/NoPadding";
+            assert wrapped.bytes.size == 24;
+        }
+
+        @Test
+        void shouldWrapVisibleKeyWithoutSecretKeyFactory() {
+            KeyUnwrapper unwrapper = unwrapperFor(
+                "AES/KW/NoPadding", newKey("kek", "AES", 16));
+            PrivateKey key = newKey("target", "ChaCha20", 32);
+
+            WrappedKey wrapped = unwrapper.wrap(key);
+
+            assert CryptoKey recovered := unwrapper.unwrap(wrapped, "recovered", "ChaCha20");
+            assert unwrapper.wrap(recovered) == wrapped;
+        }
+
+        @Test
+        void shouldRejectTamperingWrongKeysAndMalformedEnvelopes() {
+            KeyUnwrapper unwrapper = unwrapperFor(
+                "AES/KW/NoPadding", newKey("kek", "AES", 16));
+            WrappedKey wrapped = unwrapper.wrap(newKey("target", "AES", 16));
+            Byte[] changed = copy(wrapped.bytes);
+            changed[0] ^= 1;
+
+            assert !unwrapper.unwrap(
+                new WrappedKey(wrapped.algorithm, changed), "target", "AES");
+
+            KeyUnwrapper wrongKey = unwrapperFor(
+                "AES/KW/NoPadding", newKey("other-kek", "AES", 16, 1));
+            assert !wrongKey.unwrap(wrapped, "target", "AES");
+            assert !unwrapper.unwrap(
+                new WrappedKey("AES/KWP/NoPadding", wrapped.bytes), "target", "AES");
+            assert !unwrapper.unwrap(
+                new WrappedKey(wrapped.algorithm, #0001), "target", "AES");
+            assert !unwrapper.unwrap(wrapped, "target", "");
+        }
+
+        @Test
+        void shouldRejectUnsupportedKeysAndKwPayloadSizes() {
+            assert !algorithms.keyUnwrapperFor(
+                "AES/KW/NoPadding", newKey("wrong-size", "AES", 15));
+            assert !algorithms.keyUnwrapperFor(
+                "AES/KW/NoPadding", newKey("wrong-algorithm", "HmacSHA256", 16));
+            assert !algorithms.keyUnwrapperFor(
+                "AES/KW/NoPadding", new PublicKey(
+                    "public", "AES", 16, #000102030405060708090A0B0C0D0E0F));
+
+            KeyUnwrapper unwrapper = unwrapperFor(
+                "AES/KW/NoPadding", newKey("kek", "AES", 16));
+            assertThrows(IllegalArgument,
+                () -> unwrapper.wrap(newKey("unaligned", "HmacSHA256", 13)));
+            assertThrows(IllegalArgument,
+                () -> unwrapper.wrap(new PublicKey(
+                    "public", "AES", 16, #000102030405060708090A0B0C0D0E0F)));
+
+            KeyUnwrapper padded = unwrapperFor(
+                "AES/KWP/NoPadding", newKey("kek", "AES", 16));
+            assertThrows(IllegalArgument,
+                () -> padded.wrap(newKey("empty", "HmacSHA256", 0)));
+        }
+
+        private KeyUnwrapper unwrapperFor(String algorithm, CryptoKey key) {
+            return algorithms.keyUnwrapperFor(algorithm, key)
+                    ?: assert as $"{algorithm} unavailable";
+        }
+
+        private PrivateKey newKey(
+                String name, String algorithm, Int size, Int offset = 0) {
+            return new PrivateKey(
+                name,
+                algorithm,
+                size,
+                new Byte[size](i -> (i + offset).toByte())
+            );
+        }
+
+        private Byte[] copy(Byte[] bytes) {
+            return new Byte[bytes.size](i -> bytes[i]);
+        }
+    }
+}

--- a/manualTests/src/main/x/AesGcmTest.x
+++ b/manualTests/src/main/x/AesGcmTest.x
@@ -1,0 +1,32 @@
+/**
+ * End-to-end smoke test for AES-GCM authenticated encryption.
+ */
+module AesGcmTest {
+    package crypto import crypto.xtclang.org;
+
+    import crypto.Algorithms;
+    import crypto.AuthenticatedCiphertext;
+    import crypto.AuthenticatedDecryptor;
+    import crypto.PrivateKey;
+
+    void run() {
+        @Inject Algorithms algorithms;
+
+        PrivateKey key = new PrivateKey(
+            "aes-gcm-smoke",
+            "AES",
+            32,
+            new Byte[32](i -> i.toByte())
+        );
+        AuthenticatedDecryptor decryptor =
+            algorithms.authenticatedDecryptorFor("AES/GCM/NoPadding", key)
+                ?: assert as "AES-GCM unavailable";
+
+        Byte[] data = "authenticated encryption".utf8();
+        Byte[] aad  = "manual-test".utf8();
+        AuthenticatedCiphertext encrypted = decryptor.seal(data, aad);
+
+        assert Byte[] opened := decryptor.open(encrypted, aad);
+        assert opened == data;
+    }
+}

--- a/manualTests/src/main/x/AesKeyWrappingTest.x
+++ b/manualTests/src/main/x/AesKeyWrappingTest.x
@@ -1,0 +1,37 @@
+/**
+ * End-to-end smoke test for AES key wrapping.
+ */
+module AesKeyWrappingTest {
+    package crypto import crypto.xtclang.org;
+
+    import crypto.Algorithms;
+    import crypto.CryptoKey;
+    import crypto.KeyUnwrapper;
+    import crypto.PrivateKey;
+    import crypto.WrappedKey;
+
+    void run() {
+        @Inject Algorithms algorithms;
+
+        PrivateKey wrappingKey = new PrivateKey(
+            "wrapping-key",
+            "AES",
+            32,
+            new Byte[32](i -> i.toByte())
+        );
+        PrivateKey key = new PrivateKey(
+            "application-key",
+            "AES",
+            16,
+            new Byte[16](i -> (i + 32).toByte())
+        );
+        KeyUnwrapper unwrapper =
+            algorithms.keyUnwrapperFor("AES/KW/NoPadding", wrappingKey)
+                ?: assert as "AES-KW unavailable";
+
+        WrappedKey wrapped = unwrapper.wrap(key);
+
+        assert CryptoKey recovered := unwrapper.unwrap(wrapped, "recovered-key", "AES");
+        assert unwrapper.wrap(recovered) == wrapped;
+    }
+}


### PR DESCRIPTION
## Summary
- add an authenticated-encryption API backed by AES-GCM with generated nonces, AAD, and fail-closed authentication
- add AES-KW and AES-KWP key-wrapping APIs for visible and opaque secret keys
- document safe AES usage and cover the implementations with NIST/RFC vectors, tamper tests, and smoke modules

## Test plan
- [x] `./gradlew :xdk:lib-crypto:testXtc`
- [x] installed-XDK `AesGcmTest` smoke module
- [x] installed-XDK `AesKeyWrappingTest` smoke module
- [x] `./gradlew check`
- [x] `git diff --check`