### PR TITLE
Fix tree-sitter grammar: allow static modifier on property accessor shorthand

### DIFF
--- a/lang/dsl/src/main/resources/templates/grammar.js.template
+++ b/lang/dsl/src/main/resources/templates/grammar.js.template
@@ -521,10 +521,14 @@ module.exports = grammar({
 
         // Property accessor syntax: `Type propName.get() { ... }` or `Type propName.calc() = expr;`
         // Supports any accessor method name (get, set, calc, add, etc.)
+        // Modifiers can appear in either order: "static protected" or "protected static"
         property_getter_declaration: $ => seq(
             optional($.doc_comment),
             repeat($.annotation),
-            optional(seq($.visibility_modifier, repeat($.annotation))),
+            optional(choice(
+                seq($.visibility_modifier, repeat($.annotation), optional(seq('static', repeat($.annotation)))),
+                seq('static', repeat($.annotation), optional(seq($.visibility_modifier, repeat($.annotation)))),
+            )),
             $.type_expression,
             $.identifier,
             '.',


### PR DESCRIPTION
## Problem

The tree-sitter corpus parse validation in CI fails on `manualTests/src/main/x/prop.x`:

```
Tree-sitter parse results: 898 passed, 1 failed
Failed files (first 20):
  - manualTests/src/main/x/prop.x
```

The failing line (112) is:

```
static @Lazy Int lazyStatic.calc() = 42;
```

This line was added by #511 ("Add support for @Lazy static properties"), but the grammar's `property_getter_declaration` rule — which handles the `Type propName.calc() = expr;` accessor shorthand — only accepted an optional visibility modifier, not `static`. The sibling rules `property_declaration` and `method_declaration` both already accept `static` and visibility modifiers in either order.

## Why nobody noticed until now

CI's tree-sitter/LSP validation is path-gated on `lang/**` changes. #511 touched only the compiler and `manualTests/`, so validation never ran on it. The dependabot bump #521 is the first `lang/**`-touching change since, so it was the first run to trip over the pre-existing regression.

## Fix

One edit in `lang/dsl/src/main/resources/templates/grammar.js.template` (the source `grammar.js` is generated from): give `property_getter_declaration` the same either-order `static`/visibility modifier block used by `property_declaration` and `method_declaration`.

## Verification (locally, mirroring the CI lang-validation steps)

- `:lang:tree-sitter:validateTreeSitterGrammar` — grammar compiles, no new GLR conflicts
- `:lang:tree-sitter:testTreeSitterParse` — **899 passed, 0 failed**
- `:lang:dsl:test` and `:lang:lsp-server:test -Plsp.adapter=treesitter` — green (includes the Zig cross-compile of native libraries)

Once merged, re-running #521 against master should pass its lang validation.
