### PR TITLE
Fix Ecstasy language plugin issues from #459 (grammar + LSP navigation/rename)

### DIFF
--- a/lang/dsl/src/main/resources/templates/grammar.js.template
+++ b/lang/dsl/src/main/resources/templates/grammar.js.template
@@ -106,6 +106,11 @@ module.exports = grammar({
         [$._expression, $.qualified_type_name],
         [$._expression, $.type_name, $.qualified_type_name],
         [$.non_null_type, $.conditional_type],
+        // `protected Foo` as an access-qualified type vs `protected` as a
+        // declaration modifier followed by a type — GLR forks, and
+        // access_qualified_type's prec.dynamic(-1) drops the type reading
+        // whenever the declaration reading also succeeds.
+        [$.type_expression, $.access_qualified_type],
 
         // Declaration keyword conflicts
         [$.module_declaration, $.keyword_type],
@@ -623,6 +628,7 @@ module.exports = grammar({
             $.function_type,
             $.tuple_type,
             $.immutable_type,
+            $.access_qualified_type,
             $.parenthesized_type,
             $.keyword_type,
             $.qualified_keyword_type,
@@ -637,6 +643,15 @@ module.exports = grammar({
         qualified_keyword_type: $ => prec(3, seq(choice('struct', 'service', 'class', 'const', 'enum'), $.type_name)),
         // immutable can be standalone or with a type. prec.right makes it greedy.
         immutable_type: $ => prec.right(seq('immutable', optional($._non_bi_type))),
+        // Access-qualified type: `protected TxManager<TestSchema>` — per BNF
+        // ExtendedPrefixTypeExpression, the access modifier is a type prefix in
+        // the same slot as `immutable` (TypeAccessModifier). Used in cast
+        // contexts like `.as(protected Foo<K, V>)` / `.revealAs((protected Foo))`.
+        // prec.dynamic(-1): when GLR keeps both the `visibility_modifier type name`
+        // declaration reading and this type-prefix reading alive (e.g. `protected
+        // Int x;`), prefer the declaration; in cast/argument contexts there is no
+        // competing reading so this rule still wins.
+        access_qualified_type: $ => prec.dynamic(-1, prec.right(seq($.visibility_modifier, $._non_bi_type))),
         // Parenthesized type may carry annotations on the inner type, e.g.
         // `(@AutoFreezable Freezable)? o = Null` -- the annotation applies
         // to `Freezable`, the parens scope it under the `?` nullable wrap.

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/adapter/treesitter/TreeSitterAdapter.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/adapter/treesitter/TreeSitterAdapter.kt
@@ -843,15 +843,31 @@ class TreeSitterAdapter : AbstractAdapter() {
         op: String,
     ): Pair<XtcTree, String>? {
         val tree = parsedTrees[uri] ?: return null
-        val node =
-            tree.nodeAt(line, column) ?: return null.also {
-                logger.info("{}: no node at {}:{}:{}", op, uri.substringAfterLast('/'), line, column)
-            }
         val id =
-            findIdentifierNode(node) ?: return null.also {
-                logger.info("{}: not an identifier at {}:{}:{} ({})", op, uri.substringAfterLast('/'), line, column, node.type)
+            identifierNodeAt(tree, line, column) ?: return null.also {
+                logger.info("{}: no identifier at {}:{}:{}", op, uri.substringAfterLast('/'), line, column)
             }
         return tree to id.text
+    }
+
+    /**
+     * Finds the identifier node at the given position, tolerating a caret that sits at the
+     * exclusive end of the word. When the user selects a whole identifier and invokes
+     * go-to-declaration (issue #459), the editor reports the caret at selection end -- one
+     * past the last character -- where [XtcTree.nodeAt] returns the *following* node.
+     * Retry one column to the left so the lookup still lands on the identifier.
+     */
+    private fun identifierNodeAt(
+        tree: XtcTree,
+        line: Int,
+        column: Int,
+    ): XtcNode? {
+        val direct = tree.nodeAt(line, column)?.let { findIdentifierNode(it) }
+        if (direct != null) return direct
+        if (column > 0) {
+            return tree.nodeAt(line, column - 1)?.let { findIdentifierNode(it) }
+        }
+        return null
     }
 
     // ========================================================================
@@ -1072,8 +1088,7 @@ class TreeSitterAdapter : AbstractAdapter() {
         column: Int,
     ): PrepareRenameResult? {
         val tree = parsedTrees[uri] ?: return null
-        val node = tree.nodeAt(line, column) ?: return null
-        val id = findIdentifierNode(node) ?: return null
+        val id = identifierNodeAt(tree, line, column) ?: return null
 
         logger.info("prepareRename '{}' at {}:{}", id.text, line, column)
         return PrepareRenameResult(
@@ -1083,8 +1098,11 @@ class TreeSitterAdapter : AbstractAdapter() {
     }
 
     /**
-     * TODO: Same-file rename via text matching. Finds all identifier nodes with the same name
-     * and produces edit operations. Cannot handle cross-file renames or validate naming conflicts.
+     * Scope-aware same-file rename. Resolves the declaration the cursor's identifier refers
+     * to, then renames only the occurrences that resolve to that same declaration -- so
+     * renaming a local variable no longer sweeps up every same-named variable and property
+     * in the file (issue #459). Falls back to whole-file text matching only when the name
+     * cannot be resolved to any in-scope declaration (e.g. an unresolved member access).
      * A compiler adapter would rename across the workspace and update import paths.
      */
     override fun rename(
@@ -1093,18 +1111,78 @@ class TreeSitterAdapter : AbstractAdapter() {
         column: Int,
         newName: String,
     ): WorkspaceEdit? {
-        val (tree, name) = getIdentifierAt(uri, line, column, "rename") ?: return null
-        val locations = queryEngine.findAllIdentifiers(tree, name, uri)
+        val tree = parsedTrees[uri] ?: return null
+        val id = identifierNodeAt(tree, line, column) ?: return null
+        val name = id.text
+        val allOccurrences = queryEngine.findAllIdentifiers(tree, name, uri)
 
-        if (locations.isEmpty()) return null
+        if (allOccurrences.isEmpty()) return null
 
-        logger.info("rename '{}' -> '{}' ({} occurrences)", name, newName, locations.size)
+        // The rename target: if the cursor is already on a declaration's name identifier,
+        // that IS the declaration; otherwise resolve the reference through the scope chain.
+        val cursorLocation = Location(uri, id.startLine, id.startColumn, id.endLine, id.endColumn)
+        val declaration =
+            if (isDeclarationName(id)) {
+                cursorLocation
+            } else {
+                queryEngine.resolveByNameInScope(tree, id.startLine, id.startColumn, name, uri)
+            }
+
+        val locations =
+            if (declaration == null) {
+                logger.info("rename '{}': no in-scope declaration, falling back to text match", name)
+                allOccurrences
+            } else {
+                allOccurrences.filter { loc ->
+                    when {
+                        loc == declaration -> {
+                            true
+                        }
+
+                        // The name identifier of a DIFFERENT declaration (e.g. an inner
+                        // variable shadowing the rename target) must not be touched, even
+                        // though resolving from its position reaches the outer target.
+                        isDeclarationNameAt(tree, loc) -> {
+                            false
+                        }
+
+                        else -> {
+                            queryEngine.resolveByNameInScope(tree, loc.startLine, loc.startColumn, name, uri) == declaration
+                        }
+                    }
+                }
+            }
+
+        logger.info("rename '{}' -> '{}' ({} of {} occurrences)", name, newName, locations.size, allOccurrences.size)
         val edits =
             locations.map { loc ->
                 val range = Range(Position(loc.startLine, loc.startColumn), Position(loc.endLine, loc.endColumn))
                 TextEdit(range, newName)
             }
         return WorkspaceEdit(mapOf(uri to edits))
+    }
+
+    /**
+     * True when [id] is the name identifier of a declaration node (variable, parameter,
+     * property, method, class, ...) rather than a reference to one -- detected by the parent
+     * declaring a `name` field that spans exactly this node.
+     */
+    private fun isDeclarationName(id: XtcNode): Boolean {
+        val nameNode = id.parent?.childByFieldName("name") ?: return false
+        return nameNode.startLine == id.startLine &&
+            nameNode.startColumn == id.startColumn &&
+            nameNode.endLine == id.endLine &&
+            nameNode.endColumn == id.endColumn
+    }
+
+    /** [isDeclarationName] for the identifier node at a known occurrence location. */
+    private fun isDeclarationNameAt(
+        tree: XtcTree,
+        loc: Location,
+    ): Boolean {
+        val node = tree.nodeAt(loc.startLine, loc.startColumn) ?: return false
+        val id = findIdentifierNode(node) ?: return false
+        return isDeclarationName(id)
     }
 
     override fun getSignatureHelp(

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueries.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueries.kt
@@ -57,6 +57,15 @@ internal object XtcQueries {
     /**
      * Combined query for all declarations (for document symbols).
      * Uses field-based matching for robust, position-independent queries.
+     *
+     * Typedefs are declarations too (issue #459: cmd-click on `JsonArray` found
+     * nothing because typedefs were absent here and thus from the workspace index).
+     *
+     * Shorthand constructor parameters of class-like declarations (`const
+     * Point(Int x, Int y)`) declare properties in Ecstasy, so each parameter
+     * name is captured as a @property. Issue #459: go-to-declaration on
+     * `structure.y` jumped to an unrelated `y` in doc/archive because the
+     * shorthand-declared `y` was invisible to the same-file lookup.
      */
     val allDeclarations =
         """
@@ -71,5 +80,12 @@ internal object XtcQueries {
         (method_declaration name: (identifier) @name) @method
         (constructor_declaration) @constructor
         (property_declaration name: (identifier) @name) @property
+        (typedef_declaration name: (identifier) @name) @typedef
+        (class_declaration (constructor_parameters (parameters (parameter name: (identifier) @name)))) @property
+        (mixin_declaration (constructor_parameters (parameters (parameter name: (identifier) @name)))) @property
+        (service_declaration (constructor_parameters (parameters (parameter name: (identifier) @name)))) @property
+        (const_declaration (constructor_parameters (parameters (parameter name: (identifier) @name)))) @property
+        (enum_declaration (constructor_parameters (parameters (parameter name: (identifier) @name)))) @property
+        (annotation_declaration (constructor_parameters (parameters (parameter name: (identifier) @name)))) @property
         """.trimIndent()
 }

--- a/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
+++ b/lang/lsp-server/src/main/kotlin/org/xvm/lsp/treesitter/XtcQueryEngine.kt
@@ -173,6 +173,14 @@ class XtcQueryEngine(
                         findMemberInBody(current, name)
                     }
 
+                    "class_declaration", "const_declaration", "service_declaration",
+                    "mixin_declaration", "enum_declaration", "annotation_declaration",
+                    -> {
+                        // Shorthand constructor parameters (`const Point(Int x, Int y)`)
+                        // declare properties, visible throughout the class body.
+                        findShorthandProperty(current, name)
+                    }
+
                     else -> {
                         null
                     }
@@ -228,6 +236,12 @@ class XtcQueryEngine(
                     "enum_body", "mixin_body", "service_body", "const_body",
                     -> {
                         enumerateMembers(current, uri)
+                    }
+
+                    "class_declaration", "const_declaration", "service_declaration",
+                    "mixin_declaration", "enum_declaration", "annotation_declaration",
+                    -> {
+                        enumerateShorthandProperties(current, uri)
                     }
 
                     else -> {
@@ -318,6 +332,42 @@ class XtcQueryEngine(
     }
 
     /**
+     * Find a shorthand constructor parameter (`const Point(Int x, Int y)`) of a class-like
+     * declaration. These declare properties in Ecstasy, visible throughout the class body.
+     */
+    private fun findShorthandProperty(
+        declaration: XtcNode,
+        name: String,
+    ): XtcNode? =
+        declaration
+            .childByType("constructor_parameters")
+            ?.childByType("parameters")
+            ?.children
+            ?.asSequence()
+            ?.filter { it.type == "parameter" }
+            ?.mapNotNull { it.childByFieldName("name") }
+            ?.firstOrNull { it.text == name }
+
+    /**
+     * Enumerate every shorthand constructor parameter of a class-like declaration as a
+     * PROPERTY symbol.
+     */
+    private fun enumerateShorthandProperties(
+        declaration: XtcNode,
+        uri: String,
+    ): List<SymbolInfo> =
+        declaration
+            .childByType("constructor_parameters")
+            ?.childByType("parameters")
+            ?.children
+            ?.asSequence()
+            ?.filter { it.type == "parameter" }
+            ?.mapNotNull { it.childByFieldName("name") }
+            ?.map { name -> name.toSymbolInfo(name.text, SymbolKind.PROPERTY, uri) }
+            ?.toList()
+            .orEmpty()
+
+    /**
      * Search a class/module/package/interface/enum/mixin/service/const body for a declared
      * member (property, method, getter, nested type) whose name matches. Members are visible
      * throughout the body, so position is not constrained.
@@ -380,6 +430,9 @@ class XtcQueryEngine(
                 "method" to SymbolKind.METHOD,
                 "constructor" to SymbolKind.CONSTRUCTOR,
                 "property" to SymbolKind.PROPERTY,
+                // Typedefs surface as CLASS, matching memberNodeKinds' mapping
+                // for typedef_declaration.
+                "typedef" to SymbolKind.CLASS,
             )
 
         // Used by findDeclarationAt for the upward AST walk from the cursor.

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/NavigationTest.kt
@@ -312,6 +312,92 @@ class NavigationTest : TreeSitterTestBase() {
             assertThat(definition).isNotNull
             assertThat(definition!!.startLine).isEqualTo(1)
         }
+
+        /**
+         * Issue #459: `structure.y` in reflect.x navigated to an unrelated `y` in
+         * doc/archive/examples because `y`, declared only as a shorthand constructor
+         * parameter of `const Point(Int x, Int y)`, was invisible to the same-file
+         * declaration lookup and fell through to the workspace-wide name grep.
+         * Shorthand constructor parameters declare properties, so the same-file
+         * lookup must find them.
+         */
+        @Test
+        @DisplayName("should resolve const shorthand property in same file")
+        fun shouldResolveConstShorthandPropertyInSameFile() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    const Point(Int x, Int y);
+                    void run() {
+                        structure.y = 2;
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor on `y` in `structure.y` -- line 3, col 18
+            val definition = logged("shouldResolveConstShorthandPropertyInSameFile", ts.findDefinition(uri, 3, 18))
+
+            assertThat(definition).isNotNull
+            assertThat(definition!!.uri).isEqualTo(uri)
+            // The `y` parameter of `const Point(Int x, Int y)` on line 1
+            assertThat(definition.startLine).isEqualTo(1)
+        }
+
+        /**
+         * Issue #459: with the whole word selected, the editor reports the caret at
+         * the exclusive end of the identifier, where nodeAt() returns the following
+         * token. The definition lookup must tolerate that by retrying one column left.
+         */
+        @Test
+        @DisplayName("should find definition when caret is at the end of the word")
+        fun shouldFindDefinitionAtWordEnd() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    @Inject Console console;
+                    void run() {
+                        console.print("hi");
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // `console` on line 3 spans cols 8..15; col 15 is the exclusive end
+            // (caret position when the whole word is selected)
+            val definition = logged("shouldFindDefinitionAtWordEnd", ts.findDefinition(uri, 3, 15))
+
+            assertThat(definition).isNotNull
+            assertThat(definition!!.startLine).isEqualTo(1)
+        }
+
+        /**
+         * Issue #459: cmd-click on a typedef name found nothing. Same-file case:
+         * the scope walk must treat a typedef_declaration as a body member.
+         */
+        @Test
+        @DisplayName("should navigate to typedef declaration in same file")
+        fun shouldNavigateToTypedefInSameFile() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    typedef String as Name;
+                    void run() {
+                        Name n = "x";
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor on `Name` usage -- line 3, col 8
+            val definition = logged("shouldNavigateToTypedefInSameFile", ts.findDefinition(uri, 3, 8))
+
+            assertThat(definition).isNotNull
+            assertThat(definition!!.startLine).isEqualTo(1)
+        }
     }
 
     // ========================================================================

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/RenameTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/RenameTest.kt
@@ -85,5 +85,103 @@ class RenameTest : TreeSitterTestBase() {
 
             assertThat(ts.prepareRename(uri, 100, 0)).isNull()
         }
+
+        /**
+         * Issue #459: renaming a local variable renamed ALL same-named variables and
+         * properties in the file. Rename must be scope-aware: only occurrences that
+         * resolve to the same declaration as the cursor's identifier get edited.
+         * Here `count` exists as a module property, as a local in run(), and as a
+         * local in other() -- renaming the local in run() must leave the property
+         * and other()'s local untouched.
+         */
+        @Test
+        @DisplayName("should rename only the scoped local variable")
+        fun shouldRenameOnlyScopedLocalVariable() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    Int count = 0;
+                    void run() {
+                        Int count = 1;
+                        count = count + 1;
+                    }
+                    void other() {
+                        Int count = 2;
+                        count = 3;
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor on `count` usage inside run() -- line 4, col 8
+            val edit = ts.rename(uri, 4, 8, "total")
+
+            assertThat(edit).isNotNull
+            val edits = edit!!.changes[uri]
+            assertThat(edits).isNotNull
+            // declaration on line 3 + two usages on line 4; NOT the module property
+            // (line 1) and NOT other()'s local (lines 7-8)
+            assertThat(edits!!).hasSize(3)
+            assertThat(edits.map { it.range.start.line }).containsExactlyInAnyOrder(3, 4, 4)
+        }
+
+        /**
+         * Renaming an outer variable must not touch an inner declaration that
+         * shadows it (nor the shadowed uses, which resolve to the inner one).
+         */
+        @Test
+        @DisplayName("should not rename a shadowing inner declaration")
+        fun shouldNotRenameShadowingInnerDeclaration() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    void run() {
+                        Int value = 1;
+                        value = 2;
+                        if (value > 0) {
+                            Int value = 10;
+                            value = 20;
+                        }
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // cursor on the outer `value` declaration -- line 2, col 12
+            val edit = ts.rename(uri, 2, 12, "amount")
+
+            assertThat(edit).isNotNull
+            val edits = edit!!.changes[uri]
+            assertThat(edits).isNotNull
+            // outer declaration (line 2), outer use (line 3), condition use (line 4);
+            // NOT the inner shadowing declaration (line 5) or its use (line 6)
+            assertThat(edits!!.map { it.range.start.line }).containsExactlyInAnyOrder(2, 3, 4)
+        }
+
+        /**
+         * Issue #459: with the whole identifier selected, the caret sits at the
+         * exclusive end of the word. prepareRename must still find the identifier.
+         */
+        @Test
+        @DisplayName("should prepare rename when caret is at the end of the word")
+        fun shouldPrepareRenameAtWordEnd() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    class Person {
+                    }
+                }
+                """.trimIndent()
+
+            ts.compile(uri, source)
+            // `Person` spans cols 10..16 on line 1; col 16 is the exclusive end
+            val result = ts.prepareRename(uri, 1, 16)
+
+            assertThat(result).isNotNull
+            assertThat(result!!.placeholder).isEqualTo("Person")
+        }
     }
 }

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/TreeSitterAdapterTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/adapter/TreeSitterAdapterTest.kt
@@ -275,6 +275,110 @@ class TreeSitterAdapterTest : TreeSitterTestBase() {
         }
 
         /**
+         * Access-qualified type expressions (issue #459): a visibility modifier
+         * is a legal type prefix per the BNF's ExtendedPrefixTypeExpression, in
+         * the same slot as `immutable`. Used in cast contexts:
+         * `.as(protected JsonMapStore<String, String>)` and the parenthesized
+         * `.revealAs((protected TxManager<TestSchema>))` from the jsondb tests.
+         * The `access_qualified_type` rule carries prec.dynamic(-1) so that
+         * `protected Int x;` still parses as modifier + property declaration.
+         */
+        @Test
+        @DisplayName("should parse access-qualified type in cast expressions")
+        fun shouldParseAccessQualifiedTypeInCast() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    void run() {
+                        val store = schema.getMapStore().as(protected JsonMapStore<String, String>);
+                        assert TxManager<TestSchema> mgr := client.&txManager.revealAs((protected TxManager<TestSchema>));
+                        protected Int x = 1;
+                    }
+                }
+                """.trimIndent()
+
+            val result = ts.compile(uri, source)
+
+            assertThat(result.success).isTrue()
+            assertThat(result.diagnostics)
+                .noneMatch { it.severity == Diagnostic.Severity.ERROR }
+        }
+
+        /**
+         * Parameterized virtual child types (issue #459): `Base<Int>.Child2<String>`
+         * in value position must parse as a single `member_type`, not as a
+         * `member_expression` followed by an unparseable `<String>`. From
+         * `manualTests/src/main/x/generics.x`.
+         */
+        @Test
+        @DisplayName("should parse parameterized virtual child type in value position")
+        fun shouldParseParameterizedVirtualChildType() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    void run() {
+                        Type t1 = Base<Int>.Child;
+                        Type t2 = Base<Int>.Child2<String>;
+                        Base<Int>.Child2<String> c2 = bi.new Child2<String>();
+                    }
+                }
+                """.trimIndent()
+
+            val result = ts.compile(uri, source)
+
+            assertThat(result.success).isTrue()
+            assertThat(result.diagnostics)
+                .noneMatch { it.severity == Diagnostic.Severity.ERROR }
+        }
+
+        /**
+         * The exact shape of `manualTests/annos.x#testAnnotations3()` reported
+         * as a false negative in issue #459: a local `annotation ... into ...`
+         * declaration inside a method body, followed by annotated local classes
+         * that use it. Must produce no ERROR diagnostics.
+         */
+        @Test
+        @DisplayName("should parse local annotation declaration with annotated local classes")
+        fun shouldParseLocalAnnotationDeclarationWithAnnotatedLocalClasses() {
+            val uri = freshUri()
+            val source =
+                """
+                module myapp {
+                    void testAnnotations3() {
+                        interface Predicate {
+                            Boolean eval();
+                        }
+
+                        annotation PreComputed(Boolean value = False) into Predicate {
+                            @Override Boolean eval() = value;
+                        }
+
+                        @PreComputed(True)
+                        class ClassA implements Predicate {
+                            ClassB b = new ClassB();
+
+                            @Override
+                            Boolean eval() = b.eval();
+                        }
+
+                        @PreComputed(True)
+                        class ClassB implements Predicate {}
+
+                        assert new ClassA().eval() == True;
+                    }
+                }
+                """.trimIndent()
+
+            val result = ts.compile(uri, source)
+
+            assertThat(result.success).isTrue()
+            assertThat(result.diagnostics)
+                .noneMatch { it.severity == Diagnostic.Severity.ERROR }
+        }
+
+        /**
          * Stacked switch labels: `default: case 0..39: ...` (or any combination
          * of `case ...:` and `default:` labels for the same arm). The grammar's
          * `case_clause` and `expression_case_clause` rules previously allowed a

--- a/lang/lsp-server/src/test/kotlin/org/xvm/lsp/index/WorkspaceIndexerTest.kt
+++ b/lang/lsp-server/src/test/kotlin/org/xvm/lsp/index/WorkspaceIndexerTest.kt
@@ -92,6 +92,44 @@ class WorkspaceIndexerTest {
             indexer.close()
         }
 
+        /**
+         * Issue #459: cmd-click on `JsonArray` (a typedef in json.x, used from
+         * JsonArrayBuilder.x) found nothing because typedef declarations never
+         * reached the workspace index. Shorthand constructor parameters
+         * (`const Point(Int x, Int y)`) declare properties and must be indexed
+         * too -- `structure.y` navigated to an unrelated file without this.
+         */
+        @Test
+        @DisplayName("should index typedefs and shorthand constructor properties")
+        fun shouldIndexTypedefsAndShorthandProperties(
+            @TempDir tempDir: Path,
+        ) {
+            Files.writeString(
+                tempDir.resolve("json.x"),
+                """
+                module json {
+                    typedef Doc as JsonArray;
+                    const Point(Int x, Int y);
+                }
+                """.trimIndent(),
+            )
+
+            val index = WorkspaceIndex()
+            val indexer = WorkspaceIndexer(index, parser!!.getLanguage())
+
+            indexer.scanWorkspace(listOf(tempDir.toString())).join()
+
+            assertThat(index.findByName("JsonArray"))
+                .isNotEmpty
+                .allMatch { it.kind == SymbolKind.CLASS }
+            assertThat(index.findByName("x")).isNotEmpty
+            assertThat(index.findByName("y"))
+                .isNotEmpty
+                .allMatch { it.kind == SymbolKind.PROPERTY }
+
+            indexer.close()
+        }
+
         @Test
         @DisplayName("should index nested directories")
         fun shouldIndexNestedDirs(

--- a/lang/tree-sitter/treeSitterParseSkipList.parked.txt
+++ b/lang/tree-sitter/treeSitterParseSkipList.parked.txt
@@ -74,6 +74,14 @@
 #    breaks ~16 files with `TODO foo bar` text. Sweep 876/876.
 #
 # Sweep is at 880/880 with 13 parked entries (newly uncovered, see below).
+#
+# 5. Access-qualified types (issue #459): `.as(protected Foo<K, V>)` and
+#    `.revealAs((protected Foo))` closed by adding `access_qualified_type`
+#    (`visibility_modifier _non_bi_type` with prec.dynamic(-1) so the
+#    `protected Int x;` declaration reading still wins the GLR fork).
+#    Un-parked the 5 jsondb storage/tx_manager/test_db files. The
+#    remaining jsondb_test.x entry needs module-level `incorporates`,
+#    which is a separate gap.
 
 # === Newly-uncovered grammar gaps (formerly hidden in intentional.txt) ===
 #
@@ -100,10 +108,5 @@ manualTests/src/main/x/archive/addressDB_json/module.x                      # 3 
 manualTests/src/main/x/archive/sock-shop/socks-cart.x                       # 2 errors
 manualTests/src/main/x/dbTests/PeopleTest.x                                 # 3 errors
 manualTests/src/main/x/jsondb/jsondb_test.x                                 # 2 errors
-manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreConfigTest.x  # 12 errors
-manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x        # 16 errors
-manualTests/src/main/x/jsondb/jsondb_test/test_db/TestClient.x              # 19 errors
-manualTests/src/main/x/jsondb/jsondb_test/tx_manager/TxManagerConfigTest.x  # 3 errors
-manualTests/src/main/x/jsondb/jsondb_test/tx_manager/TxManagerLogTest.x     # 7 errors
 manualTests/src/main/x/webTests/oauth.x                                     # 2 errors
 manualTests/src/main/x/errors.x                                             # 4 errors


### PR DESCRIPTION
Fixes the Ecstasy Language Plugin problems Gene reported in #459.

## Grammar fixes (tree-sitter template)

**1. Access-qualified type expressions.** `.as(protected JsonMapStore<String, String>)` and `.revealAs((protected TxManager<TestSchema>))` failed to parse. Per the BNF (`ExtendedPrefixTypeExpression`), an access modifier is a type prefix in the same slot as `immutable`. Added an `access_qualified_type` rule (`visibility_modifier _non_bi_type`) with `prec.dynamic(-1)` and a declared GLR conflict so `protected Int x;` still parses as modifier + declaration. This un-parks 5 jsondb corpus files from the skip list — including the `JsonMapStoreConfigTest.x` linked in the issue — bringing the parse sweep from 899 to **904 files, 0 failures**.

**2. Parameterized virtual child types** (`Type t2 = Base<Int>.Child2<String>;` from generics.x) — already fixed on master since the issue was filed; parses as a single `member_type`. Pinned with a regression test.

**3. annos.x `testAnnotations3()` false negative** — also already fixed on master (local `annotation ... into ...` declarations); the file parses with zero ERROR/MISSING nodes. Pinned with a regression test using the exact code shape.

## LSP server fixes

**4. `structure.y` navigating to `doc/archive/examples/Example2.x`.** Shorthand constructor parameters (`const Point(Int x, Int y)`) declare properties in Ecstasy, but were invisible to the declaration query and the workspace index — so `y` fell through to a workspace-wide name grep and landed on an unrelated `y`. (`x` only worked because Point also declares an explicit `Int x { ... }` property block.) Shorthand parameters are now captured as PROPERTY declarations and resolved as class members by the scope walk, so resolution stays in-file and lands on the actual parameter.

**5. Go-to-declaration failing on a fully-selected word.** With the whole identifier selected, the editor reports the caret at the exclusive end of the word, where `nodeAt()` returns the *following* token. All identifier lookups (definition, references, highlight, rename, prepareRename) now retry one column to the left.

**6. Typedef navigation.** `typedef_declaration` was missing from the `allDeclarations` query entirely, so typedefs never reached the workspace index — cmd-click on `JsonArray` (declared in json.x, used from `JsonArrayBuilder.x`) found nothing. Added and mapped as a type-kind so the cross-file fallback ranks it correctly.

**7. Scope-blind rename.** Renaming a local variable renamed every same-named variable and property in the file. Rename now resolves the declaration under the cursor and edits only occurrences that resolve to that same declaration — shadowing inner declarations and same-named symbols in other scopes are untouched. Falls back to the old text sweep only when the name can't be resolved to any in-scope declaration.

## Verification

- `:lang:tree-sitter:validateTreeSitterGrammar` — compiles, no new conflicts
- `:lang:tree-sitter:testTreeSitterParse` — **904 passed, 0 failed** (5 files un-parked)
- `:lang:lsp-server:test -Plsp.adapter=treesitter` — green, including 9 new regression tests
- `:lang:dsl:test` — green

Remaining parked corpus files fail on unrelated gaps (module-level `incorporates`, one `errors.x` construct) — noted in the skip-list comments, not part of #459.

Fixes #459.
