### PR TITLE
Fix Dependabot alerts: npm lockfile refresh + build-classpath forces

### DIFF
--- a/lang/intellij-plugin/build.gradle.kts
+++ b/lang/intellij-plugin/build.gradle.kts
@@ -12,6 +12,21 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
+// Build-classpath security constraints: the IntelliJ Platform Gradle Plugin drags vulnerable
+// transitive dependencies onto this project's build classpath. Force known-patched versions
+// until the plugin itself updates (tracked by Dependabot alerts on this repo).
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            force(
+                "com.fasterxml.jackson.core:jackson-databind:2.21.5",
+                "com.fasterxml.jackson.core:jackson-core:2.21.5",
+                "org.jsoup:jsoup:1.23.1",
+            )
+        }
+    }
+}
+
 plugins {
     alias(libs.plugins.xdk.build.properties)
     alias(libs.plugins.lang.kotlin.jvm)

--- a/lang/vscode-extension/package-lock.json
+++ b/lang/vscode-extension/package-lock.json
@@ -2466,15 +2466,15 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -3527,9 +3527,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -4261,9 +4261,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -4860,9 +4860,9 @@
             }
         },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6744,9 +6744,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
## Summary

Addresses 26 of the 30 open [Dependabot alerts](https://github.com/xtclang/xvm/security/dependabot); the remaining 4 need no code change or are deliberately deferred (details below).

## npm — `lang/vscode-extension` (12 alerts fixed)

`npm audit fix` refreshes the lockfile to the patched releases:

| Package | Fixed version | Alerts |
|---|---|---|
| `undici` | 7.29.0 | 5 (1 high, 4 medium) |
| `brace-expansion` | 2.1.4 / 5.0.9 | 3 high |
| `fast-uri` | 3.1.5 | 3 high |
| `js-yaml` | 4.3.1 | 1 high |

`npm audit` is clean afterwards, and the extension's npm build passes.

## Gradle build classpath — `lang/intellij-plugin` (14 alerts fixed)

The jackson (13 alerts) and jsoup (1 alert) findings are transitives of the **IntelliJ Platform Gradle Plugin** on the build classpath — they never ship in any artifact; the exposure is the build toolchain itself. A `buildscript` `resolutionStrategy` in `lang/intellij-plugin/build.gradle.kts` now forces:

- `com.fasterxml.jackson.core:jackson-databind` / `jackson-core` → **2.21.5** (was 2.19.0/2.20.2)
- `org.jsoup:jsoup` → **1.23.1** (was 1.16.1)

Verified via `buildEnvironment` that every requested version resolves to the forced one. (The force must live in the subproject's own build file — a root-level `buildscript` block does not reach subproject plugin classpaths.) The forces are a stopgap until the IntelliJ plugin updates its own dependencies; the comment in the build file says so.

## Not changed, and why

- **`ch.qos.logback:logback-core` (3 alerts, low)** — stale: created in July against a graph that predates #509 (Aug 7), which bumped logback to 1.6.1, above every patched version (max 1.5.34). The next `dependency-submission` CI run from master should auto-resolve these alerts.
- **`org.jetbrains.kotlin:kotlin-gradle-plugin` (1 alert, medium)** — **deferred**: the only patched version is `2.4.20-Beta1`, and the `lang-kotlin` pin drives the whole lang Kotlin toolchain (kotlin-jvm + serialization plugins). Moving that to a beta over a build-cache deserialization advisory is not a good trade; revisit when 2.4.20 final ships.

## Validation

Full lang `assemble` (LSP server, DAP server, IntelliJ plugin, VS Code extension incl. its npm build against the new lockfile) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuabbmCJcPk2kz8rcLjAR