### PR TITLE
Implement blocking TCP client sockets

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
@@ -161,17 +161,11 @@ public class xRTNetwork
 
         case "nativeConnect": { // conditional Socket nativeConnect(Byte[] remoteAddressBytes,
                                 // UInt16 remotePort, Byte[] localAddressBytes, UInt16 localPort)
-            // TODO conditional ServerSocket nativeListen(Byte[] localAddressBytes, UInt16 localPort)
             byte[] abRemoteIP  = xByteArray.getBytes((ArrayHandle) ahArg[0]);
             int    nRemotePort = (int) ((JavaLong) ahArg[1]).getValue();
             byte[] abLocalIP   = xByteArray.getBytes((ArrayHandle) ahArg[2]);   // [] == null
             int    nLocalPort  = (int) ((JavaLong) ahArg[3]).getValue();
-            try {
-                // TODO
-                return frame.assignValue(aiReturn[0], xBoolean.FALSE);
-            } catch (Exception e) {
-                return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
-            }
+            return xRTSocket.connect(frame, abRemoteIP, nRemotePort, abLocalIP, nLocalPort, aiReturn);
         }
 
         case "nativeListen": { // conditional ServerSocket nativeListen(Byte[] localAddressBytes, UInt16 localPort)

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
@@ -84,17 +84,11 @@ public class xRTNetworkInterface
         switch (method.getName()) {
         case "nativeConnect": { // conditional Socket nativeConnect(Byte[] remoteAddressBytes,
                                 // UInt16 remotePort, Byte[] localAddressBytes, UInt16 localPort)
-            // TODO conditional ServerSocket nativeListen(Byte[] localAddressBytes, UInt16 localPort)
             byte[] abRemoteIP  = xByteArray.getBytes((ArrayHandle) ahArg[0]);
             int    nRemotePort = (int) ((JavaLong) ahArg[1]).getValue();
             byte[] abLocalIP   = xByteArray.getBytes((ArrayHandle) ahArg[2]);   // [] == null
             int    nLocalPort  = (int) ((JavaLong) ahArg[3]).getValue();
-            try {
-                // TODO
-                return frame.assignValue(aiReturn[0], xBoolean.FALSE);
-            } catch (Exception e) {
-                return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
-            }
+            return xRTSocket.connect(frame, abRemoteIP, nRemotePort, abLocalIP, nLocalPort, aiReturn);
         }
 
         case "nativeListen": { // conditional ServerSocket nativeListen(Byte[] localAddressBytes, UInt16 localPort)

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
@@ -3,12 +3,15 @@ package org.xvm.runtime.template._native.net;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.xvm.asm.ClassStructure;
 import org.xvm.asm.ConstantPool;
@@ -111,9 +114,6 @@ public class xRTSocket
         switch (method.getName()) {
         case "nativeReadBytes":
             return nativeReadBytes(frame, hSocket, (int) ((JavaLong) hArg).getValue(), iReturn);
-
-        case "nativeAvailable":
-            return nativeAvailable(frame, hSocket, iReturn);
         }
 
         return super.invokeNative1(frame, method, hTarget, hArg, iReturn);
@@ -164,9 +164,41 @@ public class xRTSocket
      */
     public static int connect(Frame frame, byte[] abRemoteIP, int nRemotePort,
                               byte[] abLocalIP, int nLocalPort, int[] aiReturn) {
-        Socket sock;
+        Callable<Socket> task = () ->
+                openConnectedSocket(abRemoteIP, nRemotePort, abLocalIP, nLocalPort);
+
+        CompletableFuture<Socket> cf = frame.f_context.f_container.scheduleIO(task);
+        Frame.Continuation continuation = frameCaller -> {
+            try {
+                Socket      sock    = cf.get();
+                InetAddress local   = sock.getLocalAddress();
+                byte[]      abLocal = local == null ? new byte[0] : local.getAddress();
+                int         nLocal  = sock.getLocalPort();
+                return INSTANCE.constructSocket(frameCaller, sock, abLocal, nLocal,
+                        abRemoteIP, nRemotePort, aiReturn);
+            } catch (Throwable e) {
+                Throwable cause = unwrap(e);
+                if (cause instanceof IOException) {
+                    return frameCaller.assignValue(aiReturn[0], xBoolean.FALSE);
+                }
+                return frameCaller.raiseException(
+                        xException.makeHandle(frameCaller, cause.getMessage()));
+            }
+        };
+
+        return frame.waitForIO(cf, continuation);
+    }
+
+    /**
+     * Open a client TCP socket with the same options {@link #connect} uses.
+     * On bind, option, or connect failure the Java socket is closed before this returns.
+     */
+    static Socket openConnectedSocket(byte[] abRemoteIP, int nRemotePort,
+                                      byte[] abLocalIP, int nLocalPort)
+            throws IOException {
+        Socket  sock  = new Socket();
+        boolean owned = false;
         try {
-            sock = new Socket();
             sock.setTcpNoDelay(true);
             sock.setKeepAlive(true);
             if (abLocalIP != null && abLocalIP.length > 0) {
@@ -176,17 +208,13 @@ public class xRTSocket
             }
             sock.connect(new InetSocketAddress(InetAddress.getByAddress(abRemoteIP), nRemotePort),
                     CONNECT_TIMEOUT_MS);
-        } catch (IOException e) {
-            return frame.assignValue(aiReturn[0], xBoolean.FALSE);
-        } catch (Exception e) {
-            return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+            owned = true;
+            return sock;
+        } finally {
+            if (!owned) {
+                closeQuietly(sock);
+            }
         }
-
-        InetAddress local = sock.getLocalAddress();
-        byte[] abLocal = local == null ? new byte[0] : local.getAddress();
-        int    nLocal  = sock.getLocalPort();
-
-        return INSTANCE.constructSocket(frame, sock, abLocal, nLocal, abRemoteIP, nRemotePort, aiReturn);
     }
 
     protected int constructSocket(Frame frame, Socket sock, byte[] abLocal, int nLocalPort,
@@ -257,26 +285,19 @@ public class xRTSocket
         if (cBytes <= 0) {
             return frame.assignValue(iReturn, xArray.makeByteArrayHandle(new byte[0], Mutability.Constant));
         }
-        try {
-            InputStream in  = sock.getInputStream();
-            byte[]      buf = new byte[cBytes];
-            int         off = 0;
-            while (off < cBytes) {
-                int n = in.read(buf, off, cBytes - off);
-                if (n < 0) {
-                    break;
-                }
-                off += n;
+
+        Callable<byte[]> task = () -> readBytes(sock, cBytes);
+        CompletableFuture<byte[]> cf = frame.f_context.f_container.scheduleIO(task);
+        Frame.Continuation continuation = frameCaller -> {
+            try {
+                return frameCaller.assignValue(iReturn,
+                        xArray.makeByteArrayHandle(cf.get(), Mutability.Constant));
+            } catch (Throwable e) {
+                return frameCaller.raiseException(
+                        xException.ioException(frameCaller, unwrap(e).getMessage()));
             }
-            if (off == cBytes) {
-                return frame.assignValue(iReturn, xArray.makeByteArrayHandle(buf, Mutability.Constant));
-            }
-            byte[] actual = new byte[off];
-            System.arraycopy(buf, 0, actual, 0, off);
-            return frame.assignValue(iReturn, xArray.makeByteArrayHandle(actual, Mutability.Constant));
-        } catch (IOException e) {
-            return frame.raiseException(xException.ioException(frame, e.getMessage()));
-        }
+        };
+        return frame.waitForIO(cf, continuation);
     }
 
     private static int nativeWriteBytes(Frame frame, SocketHandle hSocket, ObjectHandle[] ahArg) {
@@ -285,19 +306,85 @@ public class xRTSocket
             return frame.raiseException(xException.ioException(frame, "socket closed"));
         }
         byte[] ab = xByteArray.getBytes((ArrayHandle) ahArg[0]);
-        int    of = (int) ((JavaLong) ahArg[1]).getValue();
-        int    n  = (int) ((JavaLong) ahArg[2]).getValue();
+        long   of = ((JavaLong) ahArg[1]).getValue();
+        long   n  = ((JavaLong) ahArg[2]).getValue();
+
+        String sInvalid = invalidWriteRange(ab.length, of, n);
+        if (sInvalid != null) {
+            return frame.raiseException(xException.outOfBounds(frame, sInvalid));
+        }
         if (n <= 0) {
             return Op.R_NEXT;
         }
-        try {
-            OutputStream out = sock.getOutputStream();
-            out.write(ab, of, n);
-            out.flush();
-            return Op.R_NEXT;
-        } catch (IOException e) {
-            return frame.raiseException(xException.ioException(frame, e.getMessage()));
+
+        int ofWrite = (int) of;
+        int nWrite  = (int) n;
+        Callable<Void> task = () -> {
+            writeBytes(sock, ab, ofWrite, nWrite);
+            return null;
+        };
+        CompletableFuture<Void> cf = frame.f_context.f_container.scheduleIO(task);
+        Frame.Continuation continuation = frameCaller -> {
+            try {
+                cf.get();
+                return Op.R_NEXT;
+            } catch (Throwable e) {
+                return frameCaller.raiseException(
+                        xException.ioException(frameCaller, unwrap(e).getMessage()));
+            }
+        };
+        return frame.waitForIO(cf, continuation);
+    }
+
+    /**
+     * Validate a write {@code offset}/{@code count} coming from Ecstasy {@code Int}.
+     *
+     * @return {@code null} if the range is valid (including a zero-length no-op);
+     *         otherwise a message for an XVM {@code OutOfBounds}
+     */
+    static String invalidWriteRange(int nLength, long lOffset, long lCount) {
+        if (lCount == 0) {
+            return null;
         }
+        if (lOffset < 0 || lCount < 0
+                || lOffset > Integer.MAX_VALUE || lCount > Integer.MAX_VALUE
+                || lOffset + lCount > nLength) {
+            return "write offset " + lOffset + " count " + lCount + " length " + nLength;
+        }
+        return null;
+    }
+
+    static byte[] readBytes(Socket sock, int cBytes)
+            throws IOException {
+        if (cBytes <= 0) {
+            return new byte[0];
+        }
+        InputStream in  = sock.getInputStream();
+        byte[]      buf = new byte[cBytes];
+        int         off = 0;
+        while (off < cBytes) {
+            int n = in.read(buf, off, cBytes - off);
+            if (n < 0) {
+                break;
+            }
+            off += n;
+        }
+        if (off == cBytes) {
+            return buf;
+        }
+        byte[] actual = new byte[off];
+        System.arraycopy(buf, 0, actual, 0, off);
+        return actual;
+    }
+
+    static void writeBytes(Socket sock, byte[] ab, int of, int n)
+            throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        var out = sock.getOutputStream();
+        out.write(ab, of, n);
+        out.flush();
     }
 
     private static int nativeAvailable(Frame frame, SocketHandle hSocket, int iReturn) {
@@ -348,6 +435,12 @@ public class xRTSocket
             } catch (IOException ignore) {
             }
         }
+    }
+
+    private static Throwable unwrap(Throwable e) {
+        return e instanceof ExecutionException && e.getCause() != null
+                ? e.getCause()
+                : e;
     }
 
     private static SocketHandle requireSocketHandle(ObjectHandle h) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
@@ -1,0 +1,377 @@
+package org.xvm.runtime.template._native.net;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+
+import org.xvm.asm.ClassStructure;
+import org.xvm.asm.ConstantPool;
+import org.xvm.asm.Constants.Access;
+import org.xvm.asm.MethodStructure;
+import org.xvm.asm.Op;
+
+import org.xvm.asm.constants.TypeConstant;
+
+import org.xvm.runtime.ClassComposition;
+import org.xvm.runtime.ClassTemplate;
+import org.xvm.runtime.Container;
+import org.xvm.runtime.Frame;
+import org.xvm.runtime.ObjectHandle;
+import org.xvm.runtime.ObjectHandle.JavaLong;
+import org.xvm.runtime.ServiceContext;
+import org.xvm.runtime.TypeComposition;
+
+import org.xvm.runtime.template.xBoolean;
+import org.xvm.runtime.template.xException;
+import org.xvm.runtime.template.xService;
+
+import org.xvm.runtime.template._native.reflect.xRTFunction;
+
+import org.xvm.runtime.template.collections.xArray;
+import org.xvm.runtime.template.collections.xArray.ArrayHandle;
+import org.xvm.runtime.template.collections.xArray.Mutability;
+import org.xvm.runtime.template.collections.xByteArray;
+
+import org.xvm.runtime.template.numbers.xInt64;
+import org.xvm.runtime.template.numbers.xUInt16;
+
+
+/**
+ * Native implementation of a {@code Socket} service ({@code RTSocket}).
+ */
+public class xRTSocket
+        extends xService {
+    public static xRTSocket INSTANCE;
+
+    public static final int CONNECT_TIMEOUT_MS = 15_000;
+
+    public xRTSocket(Container container, ClassStructure structure, boolean fInstance) {
+        super(container, structure, false);
+
+        if (fInstance) {
+            INSTANCE = this;
+        }
+    }
+
+    @Override
+    public void initNative() {
+        markNativeMethod("nativeReadBytes",      null, null);
+        markNativeMethod("nativeWriteBytes",     null, null);
+        markNativeMethod("nativeAvailable",      null, null);
+        markNativeMethod("nativeShutdownInput",  null, null);
+        markNativeMethod("nativeShutdownOutput", null, null);
+        markNativeMethod("nativeClose",          null, null);
+
+        invalidateTypeInfo();
+    }
+
+    @Override
+    public TypeConstant getCanonicalType() {
+        TypeConstant type = m_typeCanonical;
+        if (type == null) {
+            var pool = f_container.getConstantPool();
+            m_typeCanonical = type = pool.ensureTerminalTypeConstant(pool.ensureClassConstant(
+                    pool.ensureModuleConstant("net.xtclang.org"), "Socket"));
+        }
+        return type;
+    }
+
+    @Override
+    protected ServiceHandle createStructHandle(TypeComposition clazz, ServiceContext context) {
+        return new SocketHandle(clazz.ensureAccess(Access.STRUCT), context);
+    }
+
+    @Override
+    public ServiceHandle createServiceHandle(ServiceContext context,
+                                             ClassComposition clz, TypeConstant typeMask) {
+        SocketHandle hService = new SocketHandle(clz.maskAs(typeMask), context);
+        context.setService(hService);
+        return hService;
+    }
+
+    @Override
+    public int invokeNative1(Frame frame, MethodStructure method, ObjectHandle hTarget,
+                             ObjectHandle hArg, int iReturn) {
+        SocketHandle hSocket = requireSocketHandle(hTarget);
+        if (hSocket == null) {
+            return frame.raiseException(xException.illegalState(frame, "not a native socket"));
+        }
+
+        if (frame.f_context != hSocket.f_context) {
+            return xRTFunction.makeAsyncNativeHandle(method).
+                    call1(frame, hTarget, new ObjectHandle[] {hArg}, iReturn);
+        }
+
+        switch (method.getName()) {
+        case "nativeReadBytes":
+            return nativeReadBytes(frame, hSocket, (int) ((JavaLong) hArg).getValue(), iReturn);
+
+        case "nativeAvailable":
+            return nativeAvailable(frame, hSocket, iReturn);
+        }
+
+        return super.invokeNative1(frame, method, hTarget, hArg, iReturn);
+    }
+
+    @Override
+    public int invokeNativeN(Frame frame, MethodStructure method,
+                             ObjectHandle hTarget, ObjectHandle[] ahArg, int iReturn) {
+        SocketHandle hSocket = requireSocketHandle(hTarget);
+        if (hSocket == null) {
+            return frame.raiseException(xException.illegalState(frame, "not a native socket"));
+        }
+
+        if (frame.f_context != hSocket.f_context) {
+            return xRTFunction.makeAsyncNativeHandle(method).call1(frame, hTarget, ahArg, iReturn);
+        }
+
+        switch (method.getName()) {
+        case "nativeReadBytes":
+            return nativeReadBytes(frame, hSocket, (int) ((JavaLong) ahArg[0]).getValue(), iReturn);
+
+        case "nativeWriteBytes":
+            return nativeWriteBytes(frame, hSocket, ahArg);
+
+        case "nativeAvailable":
+            return nativeAvailable(frame, hSocket, iReturn);
+
+        case "nativeShutdownInput":
+            return nativeShutdown(frame, hSocket, true);
+
+        case "nativeShutdownOutput":
+            return nativeShutdown(frame, hSocket, false);
+
+        case "nativeClose":
+            return nativeClose(frame, hSocket);
+        }
+
+        return super.invokeNativeN(frame, method, hTarget, ahArg, iReturn);
+    }
+
+
+    // ----- connect -------------------------------------------------------------------------------
+
+    /**
+     * TCP connect used by {@code RTNetwork.nativeConnect} / {@code RTNetworkInterface.nativeConnect}.
+     *
+     * @return one of {@link Op#R_NEXT}, {@link Op#R_CALL}, {@link Op#R_EXCEPTION}
+     */
+    public static int connect(Frame frame, byte[] abRemoteIP, int nRemotePort,
+                              byte[] abLocalIP, int nLocalPort, int[] aiReturn) {
+        Socket sock;
+        try {
+            sock = new Socket();
+            sock.setTcpNoDelay(true);
+            sock.setKeepAlive(true);
+            if (abLocalIP != null && abLocalIP.length > 0) {
+                sock.bind(new InetSocketAddress(InetAddress.getByAddress(abLocalIP), nLocalPort));
+            } else if (nLocalPort != 0) {
+                sock.bind(new InetSocketAddress(nLocalPort));
+            }
+            sock.connect(new InetSocketAddress(InetAddress.getByAddress(abRemoteIP), nRemotePort),
+                    CONNECT_TIMEOUT_MS);
+        } catch (IOException e) {
+            return frame.assignValue(aiReturn[0], xBoolean.FALSE);
+        } catch (Exception e) {
+            return frame.raiseException(xException.makeHandle(frame, e.getMessage()));
+        }
+
+        InetAddress local = sock.getLocalAddress();
+        byte[] abLocal = local == null ? new byte[0] : local.getAddress();
+        int    nLocal  = sock.getLocalPort();
+
+        return INSTANCE.constructSocket(frame, sock, abLocal, nLocal, abRemoteIP, nRemotePort, aiReturn);
+    }
+
+    protected int constructSocket(Frame frame, Socket sock, byte[] abLocal, int nLocalPort,
+                                  byte[] abRemote, int nRemotePort, int[] aiReturn) {
+        ClassTemplate    template     = this;
+        ClassComposition clz          = template.getCanonicalClass();
+        ConstantPool     pool         = pool();
+        MethodStructure  constructor  = template.getStructure().findConstructor(
+                pool.typeByteArray(), pool.typeUInt16(),
+                pool.typeByteArray(), pool.typeUInt16());
+        ObjectHandle[]   ahParams     = new ObjectHandle[constructor.getMaxVars()];
+        ahParams[0] = xArray.makeByteArrayHandle(abLocal, Mutability.Constant);
+        ahParams[1] = xUInt16.INSTANCE.makeJavaLong(nLocalPort);
+        ahParams[2] = xArray.makeByteArrayHandle(abRemote, Mutability.Constant);
+        ahParams[3] = xUInt16.INSTANCE.makeJavaLong(nRemotePort);
+
+        switch (template.construct(frame, constructor, clz, null, ahParams, Op.A_STACK)) {
+        case Op.R_NEXT:
+            return finishConnect(frame, sock, aiReturn);
+
+        case Op.R_EXCEPTION:
+            closeQuietly(sock);
+            return Op.R_EXCEPTION;
+
+        case Op.R_CALL:
+            frame.m_frameNext.addContinuation(frameCaller ->
+                    finishConnect(frameCaller, sock, aiReturn));
+            return Op.R_CALL;
+
+        default:
+            closeQuietly(sock);
+            throw new IllegalStateException();
+        }
+    }
+
+    private static int finishConnect(Frame frame, Socket sock, int[] aiReturn) {
+        ObjectHandle h = frame.popStack();
+        SocketHandle hSocket = requireSocketHandle(h);
+        if (hSocket == null) {
+            closeQuietly(sock);
+            return frame.raiseException(xException.illegalState(frame, "socket construct failed"));
+        }
+        hSocket.socket = sock;
+        if (hSocket.f_context.getService() instanceof SocketHandle hSvc && hSvc != hSocket) {
+            hSvc.socket = sock;
+        }
+        return frame.assignValues(aiReturn, xBoolean.TRUE, hSocket);
+    }
+
+
+    // ----- I/O -----------------------------------------------------------------------------------
+
+    private static Socket javaSocket(SocketHandle hSocket) {
+        if (hSocket.socket != null) {
+            return hSocket.socket;
+        }
+        if (hSocket.f_context.getService() instanceof SocketHandle hSvc) {
+            return hSvc.socket;
+        }
+        return null;
+    }
+
+    private static int nativeReadBytes(Frame frame, SocketHandle hSocket, int cBytes, int iReturn) {
+        Socket sock = javaSocket(hSocket);
+        if (sock == null || sock.isClosed()) {
+            return frame.raiseException(xException.ioException(frame, "socket closed"));
+        }
+        if (cBytes <= 0) {
+            return frame.assignValue(iReturn, xArray.makeByteArrayHandle(new byte[0], Mutability.Constant));
+        }
+        try {
+            InputStream in  = sock.getInputStream();
+            byte[]      buf = new byte[cBytes];
+            int         off = 0;
+            while (off < cBytes) {
+                int n = in.read(buf, off, cBytes - off);
+                if (n < 0) {
+                    break;
+                }
+                off += n;
+            }
+            if (off == cBytes) {
+                return frame.assignValue(iReturn, xArray.makeByteArrayHandle(buf, Mutability.Constant));
+            }
+            byte[] actual = new byte[off];
+            System.arraycopy(buf, 0, actual, 0, off);
+            return frame.assignValue(iReturn, xArray.makeByteArrayHandle(actual, Mutability.Constant));
+        } catch (IOException e) {
+            return frame.raiseException(xException.ioException(frame, e.getMessage()));
+        }
+    }
+
+    private static int nativeWriteBytes(Frame frame, SocketHandle hSocket, ObjectHandle[] ahArg) {
+        Socket sock = javaSocket(hSocket);
+        if (sock == null || sock.isClosed()) {
+            return frame.raiseException(xException.ioException(frame, "socket closed"));
+        }
+        byte[] ab = xByteArray.getBytes((ArrayHandle) ahArg[0]);
+        int    of = (int) ((JavaLong) ahArg[1]).getValue();
+        int    n  = (int) ((JavaLong) ahArg[2]).getValue();
+        if (n <= 0) {
+            return Op.R_NEXT;
+        }
+        try {
+            OutputStream out = sock.getOutputStream();
+            out.write(ab, of, n);
+            out.flush();
+            return Op.R_NEXT;
+        } catch (IOException e) {
+            return frame.raiseException(xException.ioException(frame, e.getMessage()));
+        }
+    }
+
+    private static int nativeAvailable(Frame frame, SocketHandle hSocket, int iReturn) {
+        Socket sock = javaSocket(hSocket);
+        if (sock == null || sock.isClosed()) {
+            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(0));
+        }
+        try {
+            int n = sock.getInputStream().available();
+            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(Math.max(n, 0)));
+        } catch (IOException e) {
+            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(0));
+        }
+    }
+
+    private static int nativeShutdown(Frame frame, SocketHandle hSocket, boolean fInput) {
+        Socket sock = javaSocket(hSocket);
+        if (sock == null || sock.isClosed()) {
+            return Op.R_NEXT;
+        }
+        try {
+            if (fInput) {
+                sock.shutdownInput();
+            } else {
+                sock.shutdownOutput();
+            }
+            return Op.R_NEXT;
+        } catch (SocketException e) {
+            return Op.R_NEXT;
+        } catch (IOException e) {
+            return frame.raiseException(xException.ioException(frame, e.getMessage()));
+        }
+    }
+
+    private static int nativeClose(Frame frame, SocketHandle hSocket) {
+        closeQuietly(javaSocket(hSocket));
+        hSocket.socket = null;
+        if (hSocket.f_context.getService() instanceof SocketHandle hSvc) {
+            hSvc.socket = null;
+        }
+        return Op.R_NEXT;
+    }
+
+    private static void closeQuietly(Socket sock) {
+        if (sock != null) {
+            try {
+                sock.close();
+            } catch (IOException ignore) {
+            }
+        }
+    }
+
+    private static SocketHandle requireSocketHandle(ObjectHandle h) {
+        ObjectHandle origin = h.revealOrigin();
+        if (origin instanceof SocketHandle socketHandle) {
+            return socketHandle;
+        }
+        return h instanceof SocketHandle socketHandle ? socketHandle : null;
+    }
+
+
+    // ----- handle --------------------------------------------------------------------------------
+
+    public static class SocketHandle
+            extends ServiceHandle {
+        public volatile Socket socket;
+
+        public SocketHandle(TypeComposition clazz, ServiceContext context) {
+            super(clazz, context);
+        }
+    }
+
+
+    // ----- fields --------------------------------------------------------------------------------
+
+    private TypeConstant m_typeCanonical;
+}

--- a/javatools/src/test/java/org/xvm/runtime/template/_native/net/xRTSocketLoopbackTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/template/_native/net/xRTSocketLoopbackTest.java
@@ -1,0 +1,70 @@
+package org.xvm.runtime.template._native.net;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Loopback TCP using the same {@link java.net.Socket} setup as {@link xRTSocket#connect}.
+ * The Ecstasy {@code TestTcpClient} module exercises the native through {@code Network.connect}.
+ */
+class xRTSocketLoopbackTest {
+
+    @Test
+    void echoRoundTrip() throws Exception {
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            int port = server.getLocalPort();
+            CompletableFuture<byte[]> echoed = CompletableFuture.supplyAsync(() -> {
+                try (Socket peer = server.accept()) {
+                    byte[] buf = peer.getInputStream().readNBytes(4);
+                    peer.getOutputStream().write(buf);
+                    peer.getOutputStream().flush();
+                    return buf;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            byte[] ping = {'p', 'i', 'n', 'g'};
+            try (Socket sock = openLikeNative(new byte[] {127, 0, 0, 1}, port)) {
+                sock.getOutputStream().write(ping);
+                sock.getOutputStream().flush();
+                byte[] got = sock.getInputStream().readNBytes(4);
+                assertArrayEquals(ping, got);
+            }
+            assertArrayEquals(ping, echoed.get(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void connectToClosedPortFails() throws Exception {
+        int port;
+        try (ServerSocket probe = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            port = probe.getLocalPort();
+        }
+        assertThrows(IOException.class,
+                () -> openLikeNative(new byte[] {127, 0, 0, 1}, port).close());
+    }
+
+    /**
+     * Same bind/connect flags as {@link xRTSocket#connect}; IOException is what native maps to False.
+     */
+    private static Socket openLikeNative(byte[] remoteIp, int remotePort) throws IOException {
+        Socket sock = new Socket();
+        sock.setTcpNoDelay(true);
+        sock.setKeepAlive(true);
+        sock.connect(new InetSocketAddress(InetAddress.getByAddress(remoteIp), remotePort),
+                xRTSocket.CONNECT_TIMEOUT_MS);
+        return sock;
+    }
+}

--- a/javatools/src/test/java/org/xvm/runtime/template/_native/net/xRTSocketLoopbackTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/template/_native/net/xRTSocketLoopbackTest.java
@@ -2,7 +2,6 @@ package org.xvm.runtime.template._native.net;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -12,11 +11,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Loopback TCP using the same {@link java.net.Socket} setup as {@link xRTSocket#connect}.
- * The Ecstasy {@code TestTcpClient} module exercises the native through {@code Network.connect}.
+ * Unit checks for the helpers {@link xRTSocket#connect} / read / write actually call.
+ * Full {@code Network.connect} coverage is the Ecstasy {@code TestTcpClient} module.
  */
 class xRTSocketLoopbackTest {
 
@@ -36,11 +37,10 @@ class xRTSocketLoopbackTest {
             });
 
             byte[] ping = {'p', 'i', 'n', 'g'};
-            try (Socket sock = openLikeNative(new byte[] {127, 0, 0, 1}, port)) {
-                sock.getOutputStream().write(ping);
-                sock.getOutputStream().flush();
-                byte[] got = sock.getInputStream().readNBytes(4);
-                assertArrayEquals(ping, got);
+            try (Socket sock = xRTSocket.openConnectedSocket(
+                    new byte[] {127, 0, 0, 1}, port, null, 0)) {
+                xRTSocket.writeBytes(sock, ping, 0, ping.length);
+                assertArrayEquals(ping, xRTSocket.readBytes(sock, 4));
             }
             assertArrayEquals(ping, echoed.get(5, TimeUnit.SECONDS));
         }
@@ -52,19 +52,33 @@ class xRTSocketLoopbackTest {
         try (ServerSocket probe = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
             port = probe.getLocalPort();
         }
-        assertThrows(IOException.class,
-                () -> openLikeNative(new byte[] {127, 0, 0, 1}, port).close());
+        assertThrows(IOException.class, () ->
+                xRTSocket.openConnectedSocket(new byte[] {127, 0, 0, 1}, port, null, 0));
     }
 
-    /**
-     * Same bind/connect flags as {@link xRTSocket#connect}; IOException is what native maps to False.
-     */
-    private static Socket openLikeNative(byte[] remoteIp, int remotePort) throws IOException {
-        Socket sock = new Socket();
-        sock.setTcpNoDelay(true);
-        sock.setKeepAlive(true);
-        sock.connect(new InetSocketAddress(InetAddress.getByAddress(remoteIp), remotePort),
-                xRTSocket.CONNECT_TIMEOUT_MS);
-        return sock;
+    @Test
+    void bindFailureClosesBeforeConnect() throws Exception {
+        try (ServerSocket taken = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            int port = taken.getLocalPort();
+            assertThrows(IOException.class, () ->
+                    xRTSocket.openConnectedSocket(
+                            new byte[] {127, 0, 0, 1}, 1,
+                            new byte[] {127, 0, 0, 1}, port));
+        }
+    }
+
+    @Test
+    void writeRangeRejectsBadOffsetAndCount() {
+        int nLength = 3;
+        assertNull(xRTSocket.invalidWriteRange(nLength, 0, 0));
+        assertNull(xRTSocket.invalidWriteRange(nLength, 0, 3));
+        assertNull(xRTSocket.invalidWriteRange(nLength, 2, 1));
+
+        assertTrue(xRTSocket.invalidWriteRange(nLength, -1, 1) != null);
+        assertTrue(xRTSocket.invalidWriteRange(nLength, 0, -1) != null);
+        assertTrue(xRTSocket.invalidWriteRange(nLength, 0, 4) != null);
+        assertTrue(xRTSocket.invalidWriteRange(nLength, 3, 1) != null);
+        assertTrue(xRTSocket.invalidWriteRange(nLength, Integer.MAX_VALUE + 1L, 1) != null);
+        assertTrue(xRTSocket.invalidWriteRange(nLength, 0, Integer.MAX_VALUE + 1L) != null);
     }
 }

--- a/javatools_bridge/src/main/x/_native/net/RTSocket.x
+++ b/javatools_bridge/src/main/x/_native/net/RTSocket.x
@@ -1,5 +1,6 @@
 import ecstasy.io.EndOfFile;
 import ecstasy.io.IOClosed;
+import ecstasy.io.Channel;
 
 import libnet.IPAddress;
 import libnet.Socket;
@@ -35,6 +36,11 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
      */
     private IO mode = None;
 
+    /**
+     * TODO async channel backing
+     */
+    protected/private Channel? rawChannel = Null;
+
     @Override
     public/private SocketAddress localAddress;
 
@@ -42,8 +48,22 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     public/private SocketAddress remoteAddress;
 
     @Override
-    @Lazy public/private Socket.Channel channel.calc() {
-        throw new Unsupported("Socket channel I/O is not implemented");
+    @Lazy public/private Channel channel.calc() {
+        switch (mode) {
+        case None:
+        case Async:
+            mode = Async;
+            // Unused until a native Channel is assigned; construct must not leave this unassigned.
+            val raw = rawChannel ?: TODO("Native");
+            val channel = new SocketChannel(raw);
+            return &channel.maskAs(Socket.Channel);
+
+        case Sync:
+            throw new IllegalState("The Socket is already in synchronous I/O mode");
+
+        case Closed:
+            throw new IOClosed();
+        }
     }
 
     @Override
@@ -101,6 +121,16 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
         return "Socket";
     }
 
+
+    // ----- SocketChannel class -------------------------------------------------------------------
+
+    /**
+     * TODO
+     */
+    class SocketChannel(Channel rawChannel)
+            delegates Channel(rawChannel) {
+        // TODO
+    }
 
     // ----- SocketInput class ---------------------------------------------------------------------
 

--- a/javatools_bridge/src/main/x/_native/net/RTSocket.x
+++ b/javatools_bridge/src/main/x/_native/net/RTSocket.x
@@ -14,6 +14,9 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
         implements Socket {
     /**
      * Constructor from native land.
+     *
+     * @param name            the name of this network interface
+     * @param addressesBytes  the byte array for each address of this network interface
      */
     construct(Byte[] localAddressBytes, UInt16 localPort, Byte[] remoteAddressBytes, UInt16 remotePort) {
         construct RTSocket((new IPAddress(localAddressBytes), localPort),
@@ -37,9 +40,14 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     private IO mode = None;
 
     /**
-     * TODO async channel backing
+     * TODO
      */
-    protected/private Channel? rawChannel = Null;
+    protected/private Channel rawChannel.get() {
+        TODO("Native");
+    }
+
+
+    // ----- Socket methods ------------------------------------------------------------------------
 
     @Override
     public/private SocketAddress localAddress;
@@ -53,9 +61,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
         case None:
         case Async:
             mode = Async;
-            // Unused until a native Channel is assigned; construct must not leave this unassigned.
-            val raw = rawChannel ?: TODO("Native");
-            val channel = new SocketChannel(raw);
+            val channel = new SocketChannel(rawChannel);
             return &channel.maskAs(Socket.Channel);
 
         case Sync:
@@ -67,7 +73,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
     @Override
-    @Lazy public/private BinaryInput in.calc() {
+    @Lazy BinaryInput in.calc() {
         switch (mode) {
         case None:
         case Sync:
@@ -84,7 +90,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
     @Override
-    @Lazy public/private BinaryOutput out.calc() {
+    @Lazy BinaryOutput out.calc() {
         switch (mode) {
         case None:
         case Sync:
@@ -175,7 +181,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
 
-    // ----- SocketOutput class --------------------------------------------------------------------
+    // ----- SocketInput class ---------------------------------------------------------------------
 
     /**
      * Blocking [BinaryOutput] over the native TCP socket.
@@ -195,7 +201,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
 
-    // ----- native --------------------------------------------------------------------------------
+    // ----- internal ------------------------------------------------------------------------------
 
     Byte[] nativeReadBytes(Int count) {TODO("Native");}
 

--- a/javatools_bridge/src/main/x/_native/net/RTSocket.x
+++ b/javatools_bridge/src/main/x/_native/net/RTSocket.x
@@ -42,9 +42,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     /**
      * TODO
      */
-    protected/private Channel rawChannel.get() {
-        TODO("Native");
-    }
+    protected/private Channel? rawChannel = Null;
 
 
     // ----- Socket methods ------------------------------------------------------------------------
@@ -61,7 +59,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
         case None:
         case Async:
             mode = Async;
-            val channel = new SocketChannel(rawChannel);
+            val channel = new SocketChannel(rawChannel ?: TODO("Native"));
             return &channel.maskAs(Socket.Channel);
 
         case Sync:

--- a/javatools_bridge/src/main/x/_native/net/RTSocket.x
+++ b/javatools_bridge/src/main/x/_native/net/RTSocket.x
@@ -1,5 +1,5 @@
+import ecstasy.io.EndOfFile;
 import ecstasy.io.IOClosed;
-import ecstasy.io.Channel;
 
 import libnet.IPAddress;
 import libnet.Socket;
@@ -13,9 +13,6 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
         implements Socket {
     /**
      * Constructor from native land.
-     *
-     * @param name            the name of this network interface
-     * @param addressesBytes  the byte array for each address of this network interface
      */
     construct(Byte[] localAddressBytes, UInt16 localPort, Byte[] remoteAddressBytes, UInt16 remotePort) {
         construct RTSocket((new IPAddress(localAddressBytes), localPort),
@@ -36,15 +33,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
      * The "IO mode" of the socket. Once the socket goes into sync or async mode, it's not supposed
      * switch to the other.
      */
-    private IO mode;
-
-    /**
-     * TODO
-     */
-    protected/private Channel rawChannel;
-
-
-    // ----- Socket methods ------------------------------------------------------------------------
+    private IO mode = None;
 
     @Override
     public/private SocketAddress localAddress;
@@ -53,24 +42,12 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     public/private SocketAddress remoteAddress;
 
     @Override
-    @Lazy public/private Channel channel.calc() {
-        switch (mode) {
-        case None:
-        case Async:
-            mode = Async;
-            val channel = new SocketChannel(rawChannel);
-            return &channel.maskAs(Socket.Channel);
-
-        case Sync:
-            throw new IllegalState("The Socket is already in synchronous I/O mode");
-
-        case Closed:
-            throw new IOClosed();
-        }
+    @Lazy public/private Socket.Channel channel.calc() {
+        throw new Unsupported("Socket channel I/O is not implemented");
     }
 
     @Override
-    @Lazy BinaryInput in.calc() {
+    @Lazy public/private BinaryInput in.calc() {
         switch (mode) {
         case None:
         case Sync:
@@ -87,7 +64,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
     @Override
-    @Lazy BinaryOutput out.calc() {
+    @Lazy public/private BinaryOutput out.calc() {
         switch (mode) {
         case None:
         case Sync:
@@ -104,13 +81,20 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
     @Override
-    void shutdownInput() {TODO("Native");}
+    void shutdownInput() {
+        nativeShutdownInput();
+    }
 
     @Override
-    void shutdownOutput() {TODO("Native");}
+    void shutdownOutput() {
+        nativeShutdownOutput();
+    }
 
     @Override
-    void close(Exception? cause = Null) {TODO("Native");}
+    void close(Exception? cause = Null) {
+        mode = Closed;
+        nativeClose();
+    }
 
     @Override
     String toString() {
@@ -118,39 +102,80 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
 
-    // ----- SocketChannel class -------------------------------------------------------------------
-
-    /**
-     * TODO
-     */
-    class SocketChannel(Channel rawChannel)
-            delegates Channel(rawChannel) {
-        // TODO
-    }
-
     // ----- SocketInput class ---------------------------------------------------------------------
 
     /**
-     * TODO
+     * Blocking [BinaryInput] over the native TCP socket.
      */
     class SocketInput
             implements BinaryInput {
-        // TODO
+        private Boolean reachedEof = False;
+
+        @Override
+        @RO Boolean eof.get() {
+            return reachedEof;
+        }
+
+        @Override
+        @RO Int available.get() {
+            return nativeAvailable();
+        }
+
+        @Override
+        Byte readByte() {
+            Byte[] got = nativeReadBytes(1);
+            if (got.size == 0) {
+                reachedEof = True;
+                throw new EndOfFile();
+            }
+            return got[0];
+        }
+
+        @Override
+        immutable Byte[] readBytes(Int count) {
+            if (count <= 0) {
+                return [];
+            }
+            Byte[] got = nativeReadBytes(count);
+            if (got.size < count) {
+                reachedEof = True;
+            }
+            return got.freeze(inPlace=True);
+        }
     }
 
 
-    // ----- SocketInput class ---------------------------------------------------------------------
+    // ----- SocketOutput class --------------------------------------------------------------------
 
     /**
-     * TODO
+     * Blocking [BinaryOutput] over the native TCP socket.
      */
     class SocketOutput
             implements BinaryOutput {
-        // TODO
+        @Override
+        void writeByte(Byte value) {
+            nativeWriteBytes([value].freeze(inPlace=True), 0, 1);
+        }
+
+        @Override
+        void writeBytes(Byte[] bytes, Int offset, Int count) {
+            // Service calls cannot take a mutable array; copy if needed.
+            nativeWriteBytes(bytes.freeze(inPlace=False), offset, count);
+        }
     }
 
 
-    // ----- internal ------------------------------------------------------------------------------
+    // ----- native --------------------------------------------------------------------------------
 
-    // TODO
+    Byte[] nativeReadBytes(Int count) {TODO("Native");}
+
+    void nativeWriteBytes(Byte[] bytes, Int offset, Int count) {TODO("Native");}
+
+    Int nativeAvailable() {TODO("Native");}
+
+    void nativeShutdownInput() {TODO("Native");}
+
+    void nativeShutdownOutput() {TODO("Native");}
+
+    void nativeClose() {TODO("Native");}
 }

--- a/javatools_bridge/src/main/x/_native/net/RTSocket.x
+++ b/javatools_bridge/src/main/x/_native/net/RTSocket.x
@@ -179,7 +179,7 @@ service RTSocket(SocketAddress localAddress, SocketAddress remoteAddress)
     }
 
 
-    // ----- SocketInput class ---------------------------------------------------------------------
+    // ----- SocketOutput class --------------------------------------------------------------------
 
     /**
      * Blocking [BinaryOutput] over the native TCP socket.

--- a/manualTests/src/main/x/TestTcpClient.x
+++ b/manualTests/src/main/x/TestTcpClient.x
@@ -1,11 +1,12 @@
 /**
  * Manual check that {@code Network.connect} can open a TCP client and read/write bytes.
+ * JUnit {@code xRTSocketLoopbackTest} covers the Java helpers this path uses.
  *
  * Listen/accept is not implemented, so start a tiny echo server first:
  *
  *     python3 -c 'import socket;s=socket.socket();s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);s.bind(("127.0.0.1",9999));s.listen(1);c,_=s.accept();c.sendall(c.recv(64));c.close();s.close()'
  *
- * Then from the xvm repo root (this branch). {@code compileXtc} does not install {@code xec};
+ * From the xvm repo root (this branch). {@code compileXtc} does not install {@code xec};
  * use Gradle {@code runOne} (args are comma-separated):
  *
  *     ./gradlew :manualTests:runOne -PtestName=TestTcpClient -PtestArgs=127.0.0.1,9999

--- a/manualTests/src/main/x/TestTcpClient.x
+++ b/manualTests/src/main/x/TestTcpClient.x
@@ -1,0 +1,49 @@
+/**
+ * Manual check that {@code Network.connect} can open a TCP client and read/write bytes.
+ *
+ * Listen/accept is not implemented, so start a tiny echo server first:
+ *
+ *     python3 -c 'import socket;s=socket.socket();s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);s.bind(("127.0.0.1",9999));s.listen(1);c,_=s.accept();c.sendall(c.recv(64));c.close();s.close()'
+ *
+ * Then from the xvm repo root (this branch). {@code compileXtc} does not install {@code xec};
+ * use Gradle {@code runOne} (args are comma-separated):
+ *
+ *     ./gradlew :manualTests:runOne -PtestName=TestTcpClient -PtestArgs=127.0.0.1,9999
+ *
+ * Or install a local XDK first, then:
+ *
+ *     ./gradlew :xdk:installDist
+ *     xdk/build/install/xdk/bin/xec -L manualTests/build/xtc/main/lib TestTcpClient 127.0.0.1 9999
+ */
+module TestTcpClient {
+    @Inject Console console;
+
+    package net import net.xtclang.org;
+
+    import net.IPAddress;
+    import net.Network;
+    import net.Socket;
+
+    void run(String[] args = ["127.0.0.1", "9999"]) {
+        String host = args.size > 0 ? args[0] : "127.0.0.1";
+        UInt16 port = new UInt16(args.size > 1 ? args[1] : "9999");
+
+        @Inject Network insecureNetwork;
+
+        IPAddress ip = new IPAddress(host);
+        if (Socket sock := insecureNetwork.connect((ip, port))) {
+            try {
+                Byte[] ping = "ping".utf8();
+                sock.out.writeBytes(ping);
+                Byte[] got = sock.in.readBytes(ping.size);
+                assert got.unpackUtf8() == "ping";
+                console.print($"ok {sock.localAddress} -> {sock.remoteAddress}");
+            } finally {
+                sock.close();
+            }
+        } else {
+            console.print($"connect failed: {host}:{port}");
+            assert False as "Network.connect returned False (is an echo server listening?)";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `Network.connect` via `java.net.Socket` (`xRTSocket`), replacing the stub that always returned `False`.
- Wire blocking `Socket.in` / `Socket.out` (`nativeReadBytes` / `nativeWriteBytes`). `nativeListen` and async `channel` stay TODO.
- Keep stock `RTSocket` scaffolding; `rawChannel` is `Channel? = Null` so construct succeeds before async I/O exists.
- Review follow-up: `connect` / `read` / `write` use `scheduleIO` + `waitForIO` so they do not pin the service fiber. Failed bind/options/connect closes the Java socket before a handle owns it. Write `offset`/`count` are checked as Ecstasy `Int` and raise XVM `OutOfBounds` instead of a host `IndexOutOfBoundsException`.

## Test plan

Listen/accept is still a stub, so the Ecstasy client cannot echo to itself. Start a tiny listener, then connect.

### Java (`xRTSocketLoopbackTest`)

Calls the same helpers `xRTSocket.connect` / read / write use (`openConnectedSocket`, `readBytes`, `writeBytes`, `invalidWriteRange`). Covers loopback echo, refused connect, bind-failure close, and bad write ranges. Does not boot a full XVM `Frame`; that path is `TestTcpClient`.

```bash
./gradlew :javatools:test --tests org.xvm.runtime.template._native.net.xRTSocketLoopbackTest
```

### Ecstasy (`manualTests/TestTcpClient.x`)

This is the real `Network.connect` + `in` / `out` path.

Terminal 1:

```bash
python3 -c 'import socket;s=socket.socket();s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);s.bind(("127.0.0.1",9999));s.listen(1);c,_=s.accept();c.sendall(c.recv(64));c.close();s.close()'
```

Terminal 2 — Gradle (uses this branch’s runtime):

```bash
./gradlew :manualTests:runOne -PtestName=TestTcpClient -PtestArgs=127.0.0.1,9999
```

Or `xec` after installing this tree’s XDK (do not use a stock/Homebrew `xec`; that still stubs connect):

```bash
./gradlew :xdk:installDist
./xdk/build/install/xdk/bin/xec -L manualTests/build/xtc/main/lib TestTcpClient 127.0.0.1 9999
```

Expect `ok (127.0.0.1, <local>) -> (127.0.0.1, 9999)`.

- [x] Java helper JUnit (echo, refuse, bind-fail close, write range)
- [x] `TestTcpClient` echo round-trip via this branch’s `xec`
- [ ] Confirm `socket.channel` still TODOs; sync `in`/`out` still work
- [ ] Confirm listen/accept unchanged (still stub)
