### PR TITLE
Fix runtime enum singleton initialization race

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/constants/SingletonConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/SingletonConstant.java
@@ -123,10 +123,13 @@ public class SingletonConstant
         // INITIALIZING to anything or from a struct to an immutable value
         assert handle != null;
 
-        CompletableFuture<ObjectHandle> cfInitialized = m_cfInitialized;
-        m_handle            = handle;
-        m_fiberInitializing = null;
-        m_cfInitialized     = null;
+        CompletableFuture<ObjectHandle> cfInitialized;
+        synchronized (this) {
+            cfInitialized       = m_cfInitialized;
+            m_handle            = handle;
+            m_fiberInitializing = null;
+            m_cfInitialized     = null;
+        }
 
         if (cfInitialized != null) {
             cfInitialized.complete(handle);
@@ -145,12 +148,14 @@ public class SingletonConstant
 
         // initialization is entered from the main context; record which fiber owns the attempt, so
         // other fibers would wait without being mistaken for recursion
-        if (m_fiberInitializing != null) {
-            return false;
-        }
+        synchronized (this) {
+            if (m_handle != null || m_fiberInitializing != null) {
+                return false;
+            }
 
-        m_fiberInitializing = fiber;
-        return true;
+            m_fiberInitializing = fiber;
+            return true;
+        }
     }
 
     /**
@@ -162,21 +167,30 @@ public class SingletonConstant
      */
     public CompletableFuture<ObjectHandle> getInitializationWaiter(Fiber fiber) {
         assert fiber != null;
-        Fiber fiberInitializing = m_fiberInitializing;
+        synchronized (this) {
+            ObjectHandle hHandle = m_handle;
+            if (hHandle != null && !(hHandle instanceof InitializingHandle)) {
+                return CompletableFuture.completedFuture(hHandle);
+            }
 
-        assert fiberInitializing != null;
-        if (fiber == fiberInitializing) {
-            // only the initializing fiber represents true recursive initialization; all others
-            // must wait for completion
-            m_handle = new InitializingHandle(this);
-            return null;
-        }
+            Fiber fiberInitializing = m_fiberInitializing;
+            if (fiberInitializing == null) {
+                return CompletableFuture.completedFuture(null);
+            }
 
-        CompletableFuture<ObjectHandle> cfInitialized = m_cfInitialized;
-        if (cfInitialized == null) {
-            m_cfInitialized = cfInitialized = new CompletableFuture<>();
+            if (fiber == fiberInitializing) {
+                // only the initializing fiber represents true recursive initialization; all others
+                // must wait for completion
+                m_handle = new InitializingHandle(this);
+                return null;
+            }
+
+            CompletableFuture<ObjectHandle> cfInitialized = m_cfInitialized;
+            if (cfInitialized == null) {
+                m_cfInitialized = cfInitialized = new CompletableFuture<>();
+            }
+            return cfInitialized;
         }
-        return cfInitialized;
     }
 
     /**
@@ -185,10 +199,13 @@ public class SingletonConstant
      * @param e  the exception that prevented initialization
      */
     public void abortInitialization(Throwable e) {
-        CompletableFuture<ObjectHandle> cfInitialized = m_cfInitialized;
-        m_handle            = null;
-        m_fiberInitializing = null;
-        m_cfInitialized     = null;
+        CompletableFuture<ObjectHandle> cfInitialized;
+        synchronized (this) {
+            cfInitialized       = m_cfInitialized;
+            m_handle            = null;
+            m_fiberInitializing = null;
+            m_cfInitialized     = null;
+        }
 
         if (cfInitialized != null) {
             cfInitialized.completeExceptionally(e);

--- a/javatools/src/main/java/org/xvm/runtime/Container.java
+++ b/javatools/src/main/java/org/xvm/runtime/Container.java
@@ -262,6 +262,13 @@ public abstract class Container
     }
 
     /**
+     * @return a ClassTemplate of the expected type for the specified type
+     */
+    public <T extends ClassTemplate> T getTemplate(TypeConstant type, Class<T> clzTemplate) {
+        return clzTemplate.cast(getTemplate(type));
+    }
+
+    /**
      * @return a ClassTemplate for the specified class identity
      */
     public ClassTemplate getTemplate(IdentityConstant idClass) {
@@ -323,10 +330,24 @@ public abstract class Container
     }
 
     /**
+     * @return a ClassTemplate of the expected type for the specified class identity
+     */
+    public <T extends ClassTemplate> T getTemplate(IdentityConstant idClass, Class<T> clzTemplate) {
+        return clzTemplate.cast(getTemplate(idClass));
+    }
+
+    /**
      * @return a ClassTemplate for a type associated with the specified constant
      */
     public ClassTemplate getTemplate(Constant constValue) {
         return getTemplate(getType(constValue)); // the type must exist
+    }
+
+    /**
+     * @return a ClassTemplate of the expected type for a type associated with the specified constant
+     */
+    public <T extends ClassTemplate> T getTemplate(Constant constValue, Class<T> clzTemplate) {
+        return clzTemplate.cast(getTemplate(constValue));
     }
 
     /**
@@ -404,6 +425,13 @@ public abstract class Container
      */
     public ClassTemplate getTemplate(String sName) {
         return getNativeContainer().getTemplate(sName);
+    }
+
+    /**
+     * @return a ClassTemplate of the expected type for the specified name (core classes only)
+     */
+    public <T extends ClassTemplate> T getTemplate(String sName, Class<T> clzTemplate) {
+        return clzTemplate.cast(getTemplate(sName));
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/MainContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/MainContainer.java
@@ -73,7 +73,7 @@ public class MainContainer
                 TypeComposition clz    = typeRequired.ensureClass(frame);
                 xEnum           en     = (xEnum) clz.getTemplate();
                 String          sValue = listValue.getLast();
-                ObjectHandle    handle = en.getEnumByName(sValue);
+                ObjectHandle    handle = en.ensureEnumByName(frame, sValue);
                 if (handle == null) {
                     // a value was injected that does not match any of the enum values
                     String msg = "Injectable " + sName + "=\"" + sValue

--- a/javatools/src/main/java/org/xvm/runtime/MainContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/MainContainer.java
@@ -71,7 +71,7 @@ public class MainContainer
             }
             if (typeRequired.isEnum()) {
                 TypeComposition clz    = typeRequired.ensureClass(frame);
-                xEnum           en     = (xEnum) clz.getTemplate();
+                var             en     = clz.getTemplate(xEnum.class);
                 String          sValue = listValue.getLast();
                 ObjectHandle    handle = en.ensureEnumByName(frame, sValue);
                 if (handle == null) {

--- a/javatools/src/main/java/org/xvm/runtime/ObjectHandle.java
+++ b/javatools/src/main/java/org/xvm/runtime/ObjectHandle.java
@@ -119,6 +119,13 @@ public abstract class ObjectHandle
     }
 
     /**
+     * @return the underlying template for this handle as the expected type
+     */
+    public <T extends ClassTemplate> T getTemplate(Class<T> clzTemplate) {
+        return clzTemplate.cast(getComposition().getTemplate());
+    }
+
+    /**
      * @return the OpSupport for the inception type of this handle
      */
     public OpSupport getOpSupport() {

--- a/javatools/src/main/java/org/xvm/runtime/TypeComposition.java
+++ b/javatools/src/main/java/org/xvm/runtime/TypeComposition.java
@@ -37,6 +37,13 @@ public interface TypeComposition {
     ClassTemplate getTemplate();
 
     /**
+     * @return the template for the defining class as the expected type
+     */
+    default <T extends ClassTemplate> T getTemplate(Class<T> clzTemplate) {
+        return clzTemplate.cast(getTemplate());
+    }
+
+    /**
      * @return the current (revealed) type of this TypeComposition
      */
     TypeConstant getType();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
@@ -64,7 +64,8 @@ public class xRTClassTemplate
         if (this == INSTANCE) {
             ConstantPool pool = f_container.getConstantPool();
 
-            ACTION_TEMPLATE = (xEnum) f_container.getTemplate("reflect.ClassTemplate.Composition.Action");
+            ACTION_TEMPLATE = f_container.getTemplate(
+                    "reflect.ClassTemplate.Composition.Action", xEnum.class);
 
             CLASS_TEMPLATE_TYPE       = pool.ensureEcstasyTypeConstant("reflect.ClassTemplate");
             CLASS_TEMPLATE_ARRAY_TYPE = pool.ensureArrayType(CLASS_TEMPLATE_TYPE);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
@@ -371,7 +371,11 @@ public class xRTClassTemplate
         ahVar[4] = haNames;
         ahVar[5] = haTypes;
 
-        return frame.call1(CREATE_CONTRIB_METHOD, hComponent, ahVar, Op.A_STACK);
+        Frame.Continuation stepNext = frameCaller ->
+                frameCaller.call1(CREATE_CONTRIB_METHOD, hComponent, ahVar, Op.A_STACK);
+        return Op.anyDeferred(ahVar)
+                ? new Utils.GetArguments(ahVar, stepNext).doNext(frame)
+                : stepNext.proceed(frame);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
@@ -277,8 +277,8 @@ public class xRTComponentTemplate
      * @return the handle to the appropriate Ecstasy {@code ComponentTemplate.Format} enum value
      */
     protected static EnumHandle makeFormatHandle(Frame frame, Component.Format format) {
-        xEnum enumForm = (xEnum) frame.f_context.f_container.
-                getTemplate("reflect.ComponentTemplate.Format");
+        var enumForm = frame.f_context.f_container.
+                getTemplate("reflect.ComponentTemplate.Format", xEnum.class);
 
         switch (format) {
         case INTERFACE:

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
@@ -277,7 +277,8 @@ public class xRTComponentTemplate
      * @return the handle to the appropriate Ecstasy {@code ComponentTemplate.Format} enum value
      */
     protected static EnumHandle makeFormatHandle(Frame frame, Component.Format format) {
-        xEnum enumForm = (xEnum) INSTANCE.f_container.getTemplate("reflect.ComponentTemplate.Format");
+        xEnum enumForm = (xEnum) frame.f_context.f_container.
+                getTemplate("reflect.ComponentTemplate.Format");
 
         switch (format) {
         case INTERFACE:

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
@@ -182,9 +182,8 @@ public class xRTMethod
      * Implements property: access.get()
      */
     public int getPropertyAccess(Frame frame, MethodHandle hMethod, int iReturn) {
-        Access       access  = hMethod.getMethodInfo().getAccess();
-        ObjectHandle hAccess = xRTType.makeAccessHandle(frame, access);
-        return frame.assignValue(iReturn, hAccess);
+        Access access = hMethod.getMethodInfo().getAccess();
+        return Utils.assignInitializedEnum(frame, xRTType.makeAccessHandle(frame, access), iReturn);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
@@ -176,7 +176,11 @@ public class xRTPropertyClassTemplate
             ahVar[3] = haNames;
             ahVar[4] = haTypes;
 
-            return frameCaller.call1(methodCreateContrib, null, ahVar, Op.A_STACK);
+            Frame.Continuation stepNext = frameCaller2 ->
+                    frameCaller2.call1(methodCreateContrib, null, ahVar, Op.A_STACK);
+            return Op.anyDeferred(ahVar)
+                    ? new Utils.GetArguments(ahVar, stepNext).doNext(frameCaller)
+                    : stepNext.proceed(frameCaller);
         };
 
         return xArray.createAndFill(frame,

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -1535,7 +1535,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Access} enum value
      */
     public static EnumHandle makeAccessHandle(Frame frame, Access access) {
-        xEnum enumAccess = (xEnum) INSTANCE.f_container.getTemplate("reflect.Access");
+        xEnum enumAccess = (xEnum) frame.f_context.f_container.getTemplate("reflect.Access");
         return switch (access) {
             case PUBLIC    -> enumAccess.getEnumByName("Public");
             case PROTECTED -> enumAccess.getEnumByName("Protected");
@@ -1553,7 +1553,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Form} enum value
      */
     protected static EnumHandle makeFormHandle(Frame frame, TypeConstant type) {
-        xEnum enumForm = (xEnum) INSTANCE.f_container.getTemplate("reflect.Type.Form");
+        xEnum enumForm = (xEnum) frame.f_context.f_container.getTemplate("reflect.Type.Form");
 
         switch (type.getFormat()) {
         case TerminalType:

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -1535,7 +1535,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Access} enum value
      */
     public static EnumHandle makeAccessHandle(Frame frame, Access access) {
-        xEnum enumAccess = (xEnum) frame.f_context.f_container.getTemplate("reflect.Access");
+        var enumAccess = frame.f_context.f_container.getTemplate("reflect.Access", xEnum.class);
         return switch (access) {
             case PUBLIC    -> enumAccess.getEnumByName("Public");
             case PROTECTED -> enumAccess.getEnumByName("Protected");
@@ -1553,7 +1553,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Form} enum value
      */
     protected static EnumHandle makeFormHandle(Frame frame, TypeConstant type) {
-        xEnum enumForm = (xEnum) frame.f_context.f_container.getTemplate("reflect.Type.Form");
+        var enumForm = frame.f_context.f_container.getTemplate("reflect.Type.Form", xEnum.class);
 
         switch (type.getFormat()) {
         case TerminalType:

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
@@ -598,7 +598,7 @@ public class xRTTypeTemplate
      * @return the handle to the appropriate Ecstasy {@code Access} enum value
      */
     public EnumHandle makeAccessHandle(Frame frame, Constants.Access access) {
-        xEnum enumAccess = (xEnum) frame.f_context.f_container.getTemplate("reflect.Access");
+        var enumAccess = frame.f_context.f_container.getTemplate("reflect.Access", xEnum.class);
         switch (access) {
         case PUBLIC:
             return enumAccess.getEnumByName("Public");
@@ -626,7 +626,7 @@ public class xRTTypeTemplate
      * @return the handle to the appropriate Ecstasy {@code TypeTemplate.Form} enum value
      */
     protected EnumHandle makeFormHandle(Frame frame, TypeConstant type) {
-        xEnum enumForm = (xEnum) frame.f_context.f_container.getTemplate("reflect.TypeTemplate.Form");
+        var enumForm = frame.f_context.f_container.getTemplate("reflect.TypeTemplate.Form", xEnum.class);
 
         switch (type.getFormat()) {
         case ParameterizedType:

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
@@ -598,7 +598,7 @@ public class xRTTypeTemplate
      * @return the handle to the appropriate Ecstasy {@code Access} enum value
      */
     public EnumHandle makeAccessHandle(Frame frame, Constants.Access access) {
-        xEnum enumAccess = (xEnum) f_container.getTemplate("reflect.Access");
+        xEnum enumAccess = (xEnum) frame.f_context.f_container.getTemplate("reflect.Access");
         switch (access) {
         case PUBLIC:
             return enumAccess.getEnumByName("Public");
@@ -626,7 +626,7 @@ public class xRTTypeTemplate
      * @return the handle to the appropriate Ecstasy {@code TypeTemplate.Form} enum value
      */
     protected EnumHandle makeFormHandle(Frame frame, TypeConstant type) {
-        xEnum enumForm = (xEnum) f_container.getTemplate("reflect.TypeTemplate.Form");
+        xEnum enumForm = (xEnum) frame.f_context.f_container.getTemplate("reflect.TypeTemplate.Form");
 
         switch (type.getFormat()) {
         case ParameterizedType:

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
@@ -365,16 +365,24 @@ public class xArray
 
         if (hThat.isMutable() && (mutability == Mutability.Mutable || mutability == Mutability.Fixed)) {
             ObjectHandle[] ahArg = new ObjectHandle[] {
-                MUTABILITY.getEnumByOrdinal(mutability.ordinal()),
+                MUTABILITY.ensureEnumByOrdinal(frame, mutability.ordinal()),
                 hThat
             };
-            return construct2(frame, clzArray, ahArg, iReturn);
+            Frame.Continuation stepNext = frameCaller ->
+                    construct2(frameCaller, clzArray, ahArg, iReturn);
+            return Op.anyDeferred(ahArg)
+                    ? new Utils.GetArguments(ahArg, stepNext).doNext(frame)
+                    : construct2(frame, clzArray, ahArg, iReturn);
         } else {
             ObjectHandle[] ahArg = new ObjectHandle[] {
                 hThat.m_hDelegate,
-                MUTABILITY.getEnumByOrdinal(mutability.ordinal())
+                MUTABILITY.ensureEnumByOrdinal(frame, mutability.ordinal())
             };
-            return construct4(frame, clzArray, ahArg, iReturn);
+            Frame.Continuation stepNext = frameCaller ->
+                    construct4(frameCaller, clzArray, ahArg, iReturn);
+            return Op.anyDeferred(ahArg)
+                    ? new Utils.GetArguments(ahArg, stepNext).doNext(frame)
+                    : construct4(frame, clzArray, ahArg, iReturn);
         }
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
@@ -127,7 +127,7 @@ public class xArray
         CREATE_LIST_SET    = Utils.CONST_HELPER.findMethod("createListSet", 2);
 
         // cache Mutability template
-        MUTABILITY = (xEnum) f_container.getTemplate("collections.Array.Mutability");
+        MUTABILITY = f_container.getTemplate("collections.Array.Mutability", xEnum.class);
 
         OBJECT_ARRAY_CLZ  = f_container.resolveClass(pool.ensureArrayType(pool.typeObject()));
         STRING_ARRAY_CLZ  = f_container.resolveClass(pool.ensureArrayType(pool.typeString()));

--- a/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
@@ -428,7 +428,7 @@ public class xEnum
 
         @Override
         public xEnum getTemplate() {
-            return (xEnum) super.getTemplate();
+            return super.getTemplate(xEnum.class);
         }
 
         @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
@@ -97,7 +97,8 @@ public class xEnum
             xEnum templateEnum = (xEnum) getSuper();
 
             EnumHandle hEnum = templateEnum.getEnumByConstant(constValue.getClassConstant());
-            constValue.setHandle(hEnum);
+            // For natural enums, hEnum is the mutable struct until completeConstruction() returns.
+            // Utils.initConstants() publishes the finalized singleton handle after construction.
 
             return hEnum.isStruct()
                     ? completeConstruction(frame, hEnum)
@@ -285,8 +286,32 @@ public class xEnum
         return ix >= 0 ? m_listHandles.get(ix) : null;
     }
 
+    /**
+     * Obtain an initialized enum value handle by name.
+     *
+     * @return the initialized enum value handle, a deferred handle, or null
+     */
+    public ObjectHandle ensureEnumByName(Frame frame, String sName) {
+        EnumHandle hEnum = getEnumByName(sName);
+        return hEnum == null
+                ? null
+                : Utils.ensureInitializedEnum(frame, hEnum);
+    }
+
     public EnumHandle getEnumByOrdinal(int ix) {
         return ix >= 0 ? m_listHandles.get(ix) : null;
+    }
+
+    /**
+     * Obtain an initialized enum value handle by ordinal.
+     *
+     * @return the initialized enum value handle, a deferred handle, or null
+     */
+    public ObjectHandle ensureEnumByOrdinal(Frame frame, int ix) {
+        EnumHandle hEnum = getEnumByOrdinal(ix);
+        return hEnum == null
+                ? null
+                : Utils.ensureInitializedEnum(frame, hEnum);
     }
 
     /**

--- a/javatools/src/test/java/org/xvm/runtime/SingletonConstantTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/SingletonConstantTest.java
@@ -1,0 +1,133 @@
+package org.xvm.runtime;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.Constant;
+import org.xvm.asm.FileStructure;
+
+import org.xvm.asm.constants.SingletonConstant;
+
+import org.xvm.runtime.ObjectHandle.InitializingHandle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Tests for singleton runtime initialization state.
+ */
+public class SingletonConstantTest {
+    @Test
+    public void concurrentInitializationHasSingleOwner()
+            throws Exception {
+        SingletonConstant constant = createConstant();
+        int               cThreads = 32;
+        CountDownLatch    ready    = new CountDownLatch(cThreads);
+        CountDownLatch    start    = new CountDownLatch(1);
+        ExecutorService   service  = Executors.newFixedThreadPool(cThreads);
+        try {
+            List<Future<Boolean>> results = new ArrayList<>(cThreads);
+
+            for (int i = 0; i < cThreads; i++) {
+                results.add(service.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return constant.markInitializing(createFiber());
+                }));
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+
+            int cOwners = 0;
+            for (Future<Boolean> result : results) {
+                if (result.get(5, TimeUnit.SECONDS)) {
+                    cOwners++;
+                }
+            }
+
+            assertEquals(1, cOwners);
+        } finally {
+            service.shutdownNow();
+        }
+    }
+
+    @Test
+    public void concurrentWaitersShareCompletion()
+            throws Exception {
+        SingletonConstant constant = createConstant();
+
+        assertTrue(constant.markInitializing(createFiber()));
+
+        CompletableFuture<ObjectHandle> waiter1 = constant.getInitializationWaiter(createFiber());
+        CompletableFuture<ObjectHandle> waiter2 = constant.getInitializationWaiter(createFiber());
+
+        assertSame(waiter1, waiter2);
+        assertFalse(waiter1.isDone());
+
+        constant.setHandle(ObjectHandle.DEFAULT);
+
+        assertSame(ObjectHandle.DEFAULT, waiter1.get(5, TimeUnit.SECONDS));
+        assertSame(ObjectHandle.DEFAULT, constant.getHandle());
+    }
+
+    @Test
+    public void sameFiberRecursionInstallsPlaceholderWithoutWaiter() {
+        SingletonConstant constant = createConstant();
+        Fiber             fiber    = createFiber();
+
+        assertTrue(constant.markInitializing(fiber));
+        assertNull(constant.getInitializationWaiter(fiber));
+        assertInstanceOf(InitializingHandle.class, constant.getHandle());
+    }
+
+    private static SingletonConstant createConstant() {
+        FileStructure file = new FileStructure("test");
+        return new SingletonConstant(file.getConstantPool(), Constant.Format.SingletonConst,
+                file.getModule().getIdentityConstant());
+    }
+
+    private static Fiber createFiber() {
+        return new Fiber(null, new ServiceContext.Message(null) {
+            @Override
+            public boolean isAsync() {
+                return false;
+            }
+
+            @Override
+            public int getCallDepth() {
+                return 0;
+            }
+
+            @Override
+            public ObjectHandle getTimeoutHandle() {
+                return null;
+            }
+
+            @Override
+            public long getTimeoutStamp() {
+                return 0;
+            }
+
+            @Override
+            Frame createFrame(ServiceContext context) {
+                return null;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Problem
- `manualTests:runParallel` starts manual test modules concurrently inside one runtime/container, so lazy runtime initialization paths can run at the same time.
- Natural enum construction was publishing the enum constant handle before construction completed. At that point the handle can still be the mutable `:struct`, so another fiber could observe and use it as the enum's final value.
- `SingletonConstant` also allowed the initialization owner/future state to be checked and updated without one atomic critical section, so two service contexts could race around the same singleton.

Original failure
The motivating failure was from `manualTests:runParallel` in https://github.com/xtclang/xvm/actions/runs/31867080587/job/94969815227?pr=525. The important part is that a public reflected enum property expected `ParameterTemplate.Category`, but received the natural enum's construction struct:

```text
Exception during execution of module "TestGenerics" (#6): ecstasy:TypeMismatch: Expected "ecstasy:reflect.ParameterTemplate.Category", actual "immutable ecstasy:reflect.ParameterTemplate.Category.TypeParameter:struct"
    at reflect.RTParameterTemplate.construct(String?, Int, ecstasy:reflect.TypeTemplate, immutable Object?, ecstasy:reflect.ParameterTemplate.Category) (L_SET _native:reflect.RTParameterTemplate.category, #4)
    at reflect.RTMethodTemplate.parameters.get().->(Int) (RTMethodTemplate.x:35)
    at reflect.RTMethodTemplate.parameters.get() (RTMethodTemplate.x:27)
    at reflect.Type.createHasher().isImplemented(String, Int) (Type.x:961)
    at reflect.Type.createHasher() (Type.x:973)
    at reflect.RTType.hasher.calc() (RTType.x:71)
    at annotations.Lazy.get() (Lazy.x:39)
    at reflect.RTType.hashed() (RTType.x:62)
    at maps.HashMap.construct(Int) (HashMap.x:20)
    at collections.HashSet.construct(Int) (HashSet.x:18)
    at reflect.TypeSystem.construct(Array<Module>, Array<Boolean>, Set<String>) (TypeSystem.x:29)
    at reflect.Class.displayName.get() (Class.x:150)
    at reflect.Type.estimateStringLength() (Type.x:673)
    at reflect.Type.estimateStringLength() (Type.x:681)
    at text.Stringable.toString() (Stringable.x:35)
    at testVirtualChild() (generics.x:26)
    at run() (generics.x:8)
    at ^TestGenerics (run())
        =========
    at ^Runner (CallLaterRequest: native)
```

That shape is the race: `ParameterTemplate.Category.TypeParameter` had escaped as a `:struct` while another fiber was reflecting method parameters during `TestGenerics` startup.

Why these call sites are dangerous
- The fixed native/public paths cross from internal template state into user-visible values or native constructor arguments during lazy startup.
- Injection, reflect enum helper values, reflect contribution calls, and array mutability construction can all run while another fiber is initializing the enum singleton.
- Those paths therefore must either wait for enum initialization or return a deferred handle. Returning the raw handle from the template's enum list is not safe for natural enums because that list may temporarily contain construction structs.

What is intentionally left alone
- There are still ugly static `INSTANCE` template fields elsewhere. Most of those are assigned during native container/bootstrap before service fibers are running, and are then used as stable template caches or dispatch shortcuts rather than as lazy singleton value publication.
- That pattern is still not ideal: it is JVM-global, container-coupled, and makes initialization ordering harder to reason about. This PR avoids broad churn there because those sites are not the same race class as publishing partially constructed enum values or non-atomically claiming singleton initialization ownership.
- For paths touched by this fix, reflect enum helpers now resolve through the current frame container instead of relying on the static instance.

Fix
- Publish enum singleton handles only after construction finalizes.
- Guard `SingletonConstant` initialization owner/future transitions with a monitor while keeping the completed handle volatile for cheap reads.
- Route public/native enum lookups through initialized/deferred handles, including injection, reflect access/form/format helpers, array mutability forwarding, and reflect contribution calls.
- Resolve deferred enum arguments before passing them into native calls that expect finalized handles.
- Add checked typed `getTemplate(..., Class<T>)` helpers and convert only the already-touched `xEnum` template lookups to those helpers for readability. These helpers use `Class.cast(...)`, so they do not require unchecked-cast suppression.
- Add a focused `SingletonConstant` concurrency regression test.

Verification
- `./gradlew :javatools:compileJava --console=plain --warning-mode=all --no-daemon`
- `./gradlew :javatools:test --tests org.xvm.runtime.SingletonConstantTest --console=plain --warning-mode=all --no-daemon`
- `./gradlew :javatools:test --console=plain --warning-mode=all --no-daemon`
- `./gradlew :manualTests:runParallel --console=plain --warning-mode=all --no-daemon` (3 passes for the race fix; 1 final pass after the typed helper cleanup)
