### PR TITLE
Fix keysAt() undercount in JsonMapStore when the last pending mod sorts before the final history key

### DIFF
--- a/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
+++ b/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
@@ -398,10 +398,29 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
         switch (model) {
         case Empty:
         case Small..Medium:
+
+            /**
+             * Determine whether the history contains a live value at the specified read point.
+             *
+             * This check applies only when the current transaction has no modification for the
+             * corresponding key; a current modification shadows the historical value.
+             *
+             * @return True iff the history contains a non-deleted value at readId
+             */
+            Boolean isHistoryVisible(History valueHistory, Int readId) {
+                if (Int txFloor := valueHistory.floor(readId),
+                        MapValue value := valueHistory.get(txFloor),
+                        value != Deleted) {
+                    return True;
+                }
+                return False;
+            }
+
             // all the keys and values are in memory; just ship all the keys back in one array
-            Key[]   keys        = new Key[](size);
-            Int     readId      = txId;
-            val     histEntries = history.entries.iterator();
+            Key[] keys        = new Key[](size);
+            Int   readId      = txId;
+            val   histEntries = history.entries.iterator();
+
             WriteTx: if (Changes tx := checkTx(txId)) {
                 readId = tx.readId;
                 if (tx.peekMods().empty) {
@@ -411,38 +430,35 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
                 // complicated: keep an iterator of the changes to merge into the iterator of
                 // the underlying (readId) transaction version
                 val modEntries = tx.ensureMods().entries.iterator();
-                assert var modEntry := modEntries.next();
+                assert Map.Entry<Key, MapValue> modEntry := modEntries.next();
 
                 // create an iterator of the keys in the history to use as the "main" iterator
-                NextKey: while (True) {
-                    if (val histEntry := histEntries.next()) {
+                // for the "zipper" loop
+                NextHistoryKey: while (True) {
+                    if (Map.Entry<Key, History> histEntry := histEntries.next()) {
                         while (True) {
                             // determine if we are at a junction point between the history and
                             // the transactional modifications
                             switch (histEntry.key <=> modEntry.key) {
                             case Lesser:
-                                // this is the common case: lots more keys in the history
-                                // than in a given transaction
-                                History valueHistory = histEntry.value;
-                                if (Int txFloor := valueHistory.floor(readId),
-                                        MapValue value := valueHistory.get(txFloor),
-                                        value != Deleted) {
+                                // this history entry has no matching transaction modification
+                                if (isHistoryVisible(histEntry.value, readId)) {
                                     keys += histEntry.key;
                                 }
-                                continue NextKey;
+                                continue NextHistoryKey;
 
                             case Equal:
+                                // the current transaction's modification shadows history
                                 if (modEntry.value != Deleted) {
                                     keys += modEntry.key; // i.e. same as histEntry.key
                                 }
 
                                 if (modEntry := modEntries.next()) {
-                                    continue NextKey;
+                                    continue NextHistoryKey;
                                 } else {
                                     // we have exhausted the transaction's modifications;
-                                    // just break out and drain the remainder of the keys
-                                    // in the map history
-                                    break NextKey;
+                                    // just break out and drain the remainder of the history map
+                                    break NextHistoryKey;
                                 }
 
                             case Greater:
@@ -452,22 +468,16 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
                                 }
 
                                 if (modEntry := modEntries.next()) {
-                                    break; // do NOT go to NextKey
+                                    break; // do NOT go to NextHistoryKey
                                 } else {
-                                    // we have exhausted the transaction's modifications; the
-                                    // current histEntry was already pulled from the iterator
-                                    // this round but was never classified against a mod
-                                    // (unlike the Equal case, where histEntry.key==modEntry.key
-                                    // already covers it) -- classify it here before draining
-                                    // the remainder of history, or it is silently dropped and
-                                    // keys.size ends up one short of size().
-                                    History valueHistory = histEntry.value;
-                                    if (Int txFloor := valueHistory.floor(readId),
-                                            MapValue value := valueHistory.get(txFloor),
-                                            value != Deleted) {
+                                    // the current history key follows the last modified key from
+                                    // the transaction; the history entry has already been taken
+                                    // from the iterator, so add its key before exiting the "zipper"
+                                    // loop (the rest will be drained below)
+                                    if (isHistoryVisible(histEntry.value, readId)) {
                                         keys += histEntry.key;
                                     }
-                                    break NextKey;
+                                    break NextHistoryKey;
                                 }
                             }
                         }
@@ -479,18 +489,14 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
                             }
                         } while (modEntry := modEntries.next());
 
-                        break NextKey;
+                        break NextHistoryKey;
                     }
                 }
             }
 
             // take whatever keys remain in the history iterator
             for (val histEntry : histEntries) {
-                History valueHistory = histEntry.value;
-
-                if (Int txFloor := valueHistory.floor(readId),
-                        MapValue value := valueHistory.get(txFloor),
-                        value != Deleted) {
+                if (isHistoryVisible(histEntry.value, readId)) {
                     keys += histEntry.key;
                 }
             }

--- a/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
+++ b/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
@@ -454,9 +454,19 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
                                 if (modEntry := modEntries.next()) {
                                     break; // do NOT go to NextKey
                                 } else {
-                                    // we have exhausted the transaction's modifications;
-                                    // just break out and drain the remainder of the keys
-                                    // in the map history
+                                    // we have exhausted the transaction's modifications; the
+                                    // current histEntry was already pulled from the iterator
+                                    // this round but was never classified against a mod
+                                    // (unlike the Equal case, where histEntry.key==modEntry.key
+                                    // already covers it) -- classify it here before draining
+                                    // the remainder of history, or it is silently dropped and
+                                    // keys.size ends up one short of size().
+                                    History valueHistory = histEntry.value;
+                                    if (Int txFloor := valueHistory.floor(readId),
+                                            MapValue value := valueHistory.get(txFloor),
+                                            value != Deleted) {
+                                        keys += histEntry.key;
+                                    }
                                     break NextKey;
                                 }
                             }

--- a/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
+++ b/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
@@ -451,22 +451,6 @@ class JsonMapStoreTest {
 
     /**
      * Regression test for a `keys.size == size` desync in `JsonMapStore.keysAt()`.
-     *
-     * `keysAt()` merges two sorted streams -- committed `history` entries and the current
-     * transaction's own pending `mods` -- to build the live key list, while `size` is computed
-     * independently (and correctly) by `sizeAt()`. In the `Greater` case (the current pending
-     * mod's key sorts before the just-pulled `histEntry`), when that mod is the *last* pending
-     * mod, the code took the "mods exhausted" branch and broke out of the merge loop without
-     * ever classifying `histEntry` -- it had already been consumed from the `history` iterator
-     * this round, so it is neither added in the `Greater` branch (which only adds the mod's own
-     * key) nor recoverable by the trailing "drain the remainder of history" loop (the iterator
-     * has already moved past it). That key silently disappears from the result, and
-     * `keys.size` ends up exactly one short of `size`.
-     *
-     * This reproduces deterministically (not key-order-dependent by luck) by seeding two
-     * committed keys ("B", "C") and then, within a single open transaction, inserting one new
-     * key ("A") that sorts before both -- "A" is the only (and therefore last) pending mod, and
-     * "B" is the `histEntry` that gets dropped.
      */
     @Test
     void shouldNotLoseHistoryKeyWhenLastPendingModSortsBeforeIt() {

--- a/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
+++ b/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
@@ -11,6 +11,9 @@ import jsondb.Client.DBObjectImpl;
 import jsondb.Client.DBMapImpl;
 import jsondb.TxManager;
 
+import oodb.Connection;
+import oodb.Transaction;
+
 import test_db.*;
 
 import xunit.annotations.RegisterExtension;
@@ -444,5 +447,53 @@ class JsonMapStoreTest {
         assert stored == person;
         // get the value should load it back into memory
         assert store.isValueOffHeap(key) == False;
+    }
+
+    /**
+     * Regression test for a `keys.size == size` desync in `JsonMapStore.keysAt()`.
+     *
+     * `keysAt()` merges two sorted streams -- committed `history` entries and the current
+     * transaction's own pending `mods` -- to build the live key list, while `size` is computed
+     * independently (and correctly) by `sizeAt()`. In the `Greater` case (the current pending
+     * mod's key sorts before the just-pulled `histEntry`), when that mod is the *last* pending
+     * mod, the code took the "mods exhausted" branch and broke out of the merge loop without
+     * ever classifying `histEntry` -- it had already been consumed from the `history` iterator
+     * this round, so it is neither added in the `Greater` branch (which only adds the mod's own
+     * key) nor recoverable by the trailing "drain the remainder of history" loop (the iterator
+     * has already moved past it). That key silently disappears from the result, and
+     * `keys.size` ends up exactly one short of `size`.
+     *
+     * This reproduces deterministically (not key-order-dependent by luck) by seeding two
+     * committed keys ("B", "C") and then, within a single open transaction, inserting one new
+     * key ("A") that sorts before both -- "A" is the only (and therefore last) pending mod, and
+     * "B" is the `histEntry` that gets dropped.
+     */
+    @Test
+    void shouldNotLoseHistoryKeyWhenLastPendingModSortsBeforeIt() {
+        assert TestClient client := clientProvider.getClient();
+        TestSchema        schema = client.testSchema;
+
+        // Seed committed history with keys that sort AFTER the key inserted below.
+        schema.mapData.put("B", "existing-b");
+        schema.mapData.put("C", "existing-c");
+
+        Connection<TestSchema> conn = client.ensureConnection();
+        using (conn.createTransaction()) {
+            // "A" sorts before "B" and "C", and is the only (last) pending mod in this tx.
+            schema.mapData.put("A", "new-a");
+
+            Int      sizeInTx = schema.mapData.size;
+            String[] keysInTx = schema.mapData.keys.toArray();
+
+            assert keysInTx.size == sizeInTx
+                    as $|keysAt() undercounts by one: expected {sizeInTx} keys \
+                        |({keysInTx.size} returned) -- "B" was dropped by the merge walk \
+                        |because it was the histEntry pulled just before the last pending \
+                        |mod ("A") was classified as Greater.
+                        ;
+            assert keysInTx.contains("A");
+            assert keysInTx.contains("B");
+            assert keysInTx.contains("C");
+        }
     }
 }


### PR DESCRIPTION
## Summary

`JsonMapStore.keysAt()` merges two sorted streams — committed `history` entries and the current transaction's own pending `mods` — to build the live key list, while `size` is computed independently (and correctly) by `sizeAt()`.

In the `Greater` case (the current pending mod's key sorts before the just-pulled `histEntry`), when that mod is the **last** pending mod, the code took the "mods exhausted" branch and broke out of the merge loop without ever classifying `histEntry`. It had already been consumed from the `history` iterator that round, so it was neither added by the `Greater` branch (which only adds the mod's own key) nor recoverable by the trailing "drain the remainder of history" loop (the iterator had already moved past it). That key silently disappeared from the result, leaving `keys.size` exactly one short of `size`.

## Fix

Classify the pulled `histEntry` (check `floor(readId)`/liveness, same as the trailing drain loop does) before breaking out of the merge loop in the "mods exhausted" branch, instead of dropping it silently.

## Test

Added `shouldNotLoseHistoryKeyWhenLastPendingModSortsBeforeIt`, a deterministic (not key-order-dependent by luck) reproducer: seed two committed keys ("B", "C") and then, within a single open transaction, insert one new key ("A") that sorts before both — "A" is the only (and therefore last) pending mod, and "B" is the `histEntry` that gets dropped without the fix.

Verified: fails on `master` (`keys.size` one short of `size`), passes with the fix. Full `JsonMapStoreTest` class: 17/17 passing.

## Note

This is a narrower, self-contained fix extracted from a broader investigation into intermittent `keys.size == size` desyncs under heavy concurrent load. That broader investigation turned up a separate, unrelated deadlock in the interpreter's shared per-container `Injector` service, filed separately as #541 — not addressed here.
