### PR TITLE
DRAFT POC: warm in-process XtcEngine on master (compile + run, no JVM fork)

### DIFF
--- a/POC-NOTES.md
+++ b/POC-NOTES.md
@@ -34,7 +34,7 @@ navigation) — the compiler-API surface the adapter would query — plus the sm
 
 ---
 
-## What is proven — 9 green tests (`org.xvm.api.XtcEngineTest`)
+## What is proven — 11 green tests (`org.xvm.api.XtcEngineTest`)
 
 | Test | Proves |
 |---|---|
@@ -47,6 +47,8 @@ navigation) — the compiler-API surface the adapter would query — plus the sm
 | `compiledModulesCanBeSyncedToDiskAndReloaded` | `writeTo(dir)` → reload via a plain `DirRepository` |
 | `reportsCompileDiagnosticsAndStreamsThemToTheCaller` | diagnostics stream to the caller's sink |
 | `theEngineIsUsableThroughTheToolApiContractAlone` | the `ToolApi` contract is sufficient by itself |
+| `compilesAModuleFromDisk` | **`compile(Path...)`** - on-disk source compiles and runs identically |
+| `aPathThatIsNotAModuleIsADiagnosticNotACrash` | a bad path is a diagnostic, not an exception |
 
 Gate: `./gradlew xdk:installDist`, then `./gradlew :javatools:test :javatools_utils:test` — green.
 Run them as **separate invocations**; in one invocation the test's module reads race
@@ -101,10 +103,13 @@ sealing, display purity. None is needed here.
 
 ## Known gaps
 
-1. **No `compile(Path...)` source-tree entry point** — only in-memory sources. An LSP workspace and
-   the Gradle plugin both want on-disk module directory trees. `org.xvm.tool.ModuleInfo` already
-   walks a module directory into a parsed node tree, so this is wiring, not new compiler work.
-   **Biggest remaining gap; low difficulty.**
+1. ~~No `compile(Path...)` source-tree entry point.~~ **DONE.** `ModuleInfo` walks a module file or
+   directory into the same `TypeCompositionStatement` the in-memory path produces, so both entry
+   points now share ONE pipeline - the load-bearing stage order exists in a single place. A path that
+   is not a module produces a diagnostic rather than an exception (`ModuleInfo` signals bad input by
+   throwing `IllegalArgumentException`; an LSP must not die because someone opened the wrong
+   directory). `compile(...)` propagates the `IOException` that `ModuleRepository.storeModule`
+   declares, rather than wrapping it in an unchecked exception.
 2. **Diagnostics carry `line` but no column/end position.** LSP wants a `Range` to underline. Needs
    checking whether `ErrorInfo` carries start/end offsets.
 3. **No incremental or cancellable compile.** An LSP recompiles per keystroke; today each call is a

--- a/POC-NOTES.md
+++ b/POC-NOTES.md
@@ -1,85 +1,117 @@
-# XtcEngine POC on master — status and known gaps
+# XtcEngine POC on master — status, and how it relates to the LSP
 
-Branch: `lagergren/xtc-engine-poc`, based on `origin/master` `82683bcd2`.
-Goal: prove a warm, in-process compile+run engine works on master, so a Gradle plugin (and an
-LSP server) can stop forking a JVM per invocation.
+Branch: `lagergren/xtc-engine-poc` (PR #546), based on `master`.
 
-## What is proven (3 green tests, `org.xvm.api.XtcEngineTest`)
+**Goal:** prove a warm, in-process compile+run engine works on `master`, so tooling stops forking a
+JVM and re-bootstrapping the runtime for every operation.
 
-1. **Compile Ecstasy source held in a String** — no files, no CLI.
-2. **Run the compiled module in a nested container**, in the same JVM, and await event-driven
-   completion.
-3. **One warm engine serves repeated compile+run cycles** — the runtime bootstrap is paid once.
-4. **Diagnostics stream to the caller's own `ErrorListener`** as they are produced, and a failed
-   compile is self-describing (the result always carries diagnostics).
+---
 
-Gate: `./gradlew xdk:installDist` then `./gradlew :javatools:test :javatools_utils:test` — both
-green. (Run them SEPARATELY; in one invocation the test's module reads race installDist's writes.)
+## Why this is (essentially) all that was missing for the LSP
 
-## What was changed on master (deliberately minimal — 5 files)
+The LSP is **already built**, in `lang/`: `lsp-server` (full lsp4j protocol, `publishDiagnostics`,
+document services), `dap-server`, `intellij-plugin`, `tree-sitter` grammar, and the VS Code
+extension. Language intelligence is served through a pluggable **`Adapter`**:
+
+| Adapter | Backend | Status |
+|---|---|---|
+| `MockAdapter` | regex | testing/fallback |
+| `TreeSitterAdapter` | tree-sitter | **works today** — "syntax-aware (~80% LSP features)" |
+| `XdkAdapter` | **XDK compiler** | **STUB** — *"all methods log but return empty results"* |
+
+So the editor half, the protocol half, and the syntactic half are done. The one hole is the
+**compiler-backed adapter** — the thing that needs to actually *compile* a buffer and hand back real
+diagnostics, and to *run* a module. That is exactly what this POC supplies:
+
+- `compile(...)` over in-memory buffers → structured `Diagnostic`s (severity, **code**, message,
+  source, line), streamed to the caller's `ErrorListener` as produced → feeds `publishDiagnostics`.
+- `start(...)` → a `RunControl` for running/debugging a module from the editor.
+
+**In short: `lang` owns the LSP; this owns compile-and-run. Together they close the `XdkAdapter`
+stub.** What remains beyond that is genuinely semantic (hover, type inference, cross-file
+navigation) — the compiler-API surface the adapter would query — plus the small items in
+"Known gaps" below.
+
+---
+
+## What is proven — 9 green tests (`org.xvm.api.XtcEngineTest`)
+
+| Test | Proves |
+|---|---|
+| `compilesAndRunsAModuleHeldInAString` | compile from a `String` + run in one JVM, no CLI |
+| `theRunResultReachesTheHost` | the module's `Int run()` value reaches the host, exactly |
+| `aVoidRunCompletesWithNoResult` | "returned nothing" ≠ "failed" |
+| `aThrowingRunCompletesExceptionally` | the **failure path**: a throwing run surfaces its error |
+| `oneWarmEngineServesRepeatedCompileAndRunCycles` | repeated compile→run on ONE warm engine |
+| `compilesMultipleModulesInOneRequest` | several modules per request, all runnable |
+| `compiledModulesCanBeSyncedToDiskAndReloaded` | `writeTo(dir)` → reload via a plain `DirRepository` |
+| `reportsCompileDiagnosticsAndStreamsThemToTheCaller` | diagnostics stream to the caller's sink |
+| `theEngineIsUsableThroughTheToolApiContractAlone` | the `ToolApi` contract is sufficient by itself |
+
+Gate: `./gradlew xdk:installDist`, then `./gradlew :javatools:test :javatools_utils:test` — green.
+Run them as **separate invocations**; in one invocation the test's module reads race
+`installDist`'s writes.
+
+---
+
+## What changed on master (deliberately minimal)
 
 | File | Change |
 |---|---|
-| `MainContainer` | capture the `callLater` future that was being discarded; add `futureResult()` |
-| `Container` | add `runModule(String, ObjectHandle...)` returning the completion future |
-| `NestedContainer` | add `createForHost(...)`; add a parent injection fallback **only** for host containers (`f_hProvider == null`), else a host-run module gets no `Console` |
-| `FileStructure` | **master bug fix** — see below |
-| `DirRepository` | **master bug fix** — synchronize the scan cache (see below) |
-| `api/ToolApi.java` | new: the named CONTRACT a tool embeds (compile + run + shared types) |
-| `api/XtcEngine.java` | new: the engine - one implementation of `ToolApi` |
+| `MainContainer` | capture the `callLater` future that was being **discarded**; expose `futureResult()` |
+| `Container` | `runModule(...)` returning the completion future, asking for the return value the method declares |
+| `NestedContainer` | `createForHost(...)`; parent injection fallback **only** for host containers |
+| `FileStructure` | **master bug fix** — ambient-pool NPE (below) |
+| `DirRepository` | **master bug fix** — synchronize the scan cache (also standalone as PR #547) |
+| `api/ToolApi.java` | new — the named CONTRACT a tool embeds |
+| `api/XtcEngine.java` | new — the engine; one implementation of `ToolApi` |
 
-Deliberately NOT lifted from the reference branch: pool-publication fencing
-(`markRuntimePublished`), the INSTANCE-removal/owner-lazy work, sealing, display purity. None is
-needed for the POC.
+Deliberately **not** lifted from the reference branch: pool-publication fencing, INSTANCE removal,
+sealing, display purity. None is needed here.
 
-## Master bug found by the POC (deterministic, with a red proof)
+---
 
-`FileStructure.getErrorListener()` read the ambient `ConstantPool.getCurrentPool()` and
-dereferenced it **without a null check**. That thread-local is null on any thread with no pool
-bound — i.e. every Java host thread driving the runtime — so the embedding path NPE'd inside a
-*diagnostic accessor*:
+## Master bugs found and fixed on the way
 
-```
-NullPointerException: Cannot invoke "ConstantPool.getErrorListener()" because "poolCurrent" is null
-  at FileStructure.getErrorListener(FileStructure.java:1397)
-  at TypeConstant.ensureTypeInfo(TypeConstant.java:1659)
-  at Container.findModuleMethod(Container.java:252)
-```
+1. **`FileStructure.getErrorListener()` NPE'd on the embedding path.** It read the ambient
+   `ConstantPool.getCurrentPool()` and dereferenced it with no null check; that thread-local is null
+   on any thread with no pool bound — i.e. every Java host thread — so the API died inside a
+   *diagnostic accessor*. Null-guarded here; the real fix is passing the pool explicitly.
+2. **`DirRepository`'s scan cache was not thread-safe** — unsynchronized `HashMap`/`TreeMap` rebuilt
+   with `clear()`+`put()`, plus a live `keySet()` view handed to callers. Proven red with a
+   `ConcurrentModificationException`. Submitted standalone as **PR #547**.
+3. **A module's `run()` return value never reached the host** — two separate defects:
+   `callLater` hardcodes `cReturns = 0` (so the future completed with an empty tuple), and the
+   native instantiate-and-run op ignored the caller-designated return slot in favour of `A_STACK`.
+   Both fixed, both covered by tests.
 
-Fixed here with a null guard (one line). The deeper fix is to pass the pool EXPLICITLY rather than
-consult an ambient thread-local — this is a concrete instance of the ambient-ownership hazard.
-**Worth filing as a master bug**: the reproduction is simply "call the embedding API from a Java
-thread", and `XtcEngineTest` is the red proof.
+---
 
-## Second master bug fixed here: `DirRepository` scan cache is not thread-safe
+## Modes: what works today
 
-`loadModule`/`getModuleNames`/`storeModule` were unsynchronized over a plain `HashMap` (a non-final
-field reassigned wholesale) and a plain `TreeMap` (rebuilt with `clear()` + a `put()` loop). Two
-parallel compiles resolving library modules race those rebuilds against `get()` and against the live
-`keySet()` view `getModuleNames()` returns - proven red on master with a
-`ConcurrentModificationException` by `DirRepositoryConcurrentScanTest`, which is included here and
-now passes.
+| Mode | Status | Notes |
+|---|---|---|
+| **Sequential compile** | ✅ proven | multiple modules per request too |
+| **Sequential run** | ✅ proven | results and failures both surface |
+| **Interleaved compile+run, one warm engine** | ✅ proven | the actual point of the API |
+| **Parallel compile** | ⚠️ unblocked, untested | both known blockers now closed: `DirRepository` here/#547, and the static compiler counters already on master via #538 |
+| **Parallel run** | ❌ | needs the shared-pool publication work; the deep one |
 
-This is **the last remaining blocker for parallel compiles**: the other one the audit identified,
-the static compiler counters, is already fixed on master by #538 (all four are `AtomicInteger`).
+---
 
-## Known gaps (to address after review)
+## Known gaps
 
-1. ~~A module's `run()` return value does not reach the host.~~ **FIXED** - two distinct defects,
-   both now covered by tests: `callLater` hardcodes `cReturns = 0`, so the future completed with an
-   EMPTY tuple (`runModule` now calls `postRequest(..., fReturn ? 1 : 0)` directly); and the native
-   instantiate-and-run op ignored the caller-designated return slot in favour of `A_STACK`, so even
-   with a return requested the value landed where the future never reads (it now returns into
-   `iRet`).
-2. **`RunControl.kill()` does not force-unwind a running fiber.** It cancels the caller's wait and
-   releases the container; real cancellation needs `Container.terminate(ServiceContext)` wired to a
-   cooperative check.
-3. **`NativeFunctionHandle` binds to `xRTFunction.INSTANCE.f_container`** on master (a process-static
-   template instance). Fine for a single native plane; it is the static-INSTANCE ownership hazard,
-   and would need attention before multiple planes or heavy concurrency.
-4. **No `compile(Path...)` source-tree entry point yet** — only in-memory sources. This is what the
-   Gradle plugin's warm-compile phase and an LSP workspace both need next.
-5. **No pool-publication fence.** Master has none, so a long-running host doing many compiles/runs
-   over one shared pool is exposed to the interning/publication races documented separately. The POC
-   does sequential work and does not hit them; a production plugin should be re-checked under
-   parallel load.
+1. **No `compile(Path...)` source-tree entry point** — only in-memory sources. An LSP workspace and
+   the Gradle plugin both want on-disk module directory trees. `org.xvm.tool.ModuleInfo` already
+   walks a module directory into a parsed node tree, so this is wiring, not new compiler work.
+   **Biggest remaining gap; low difficulty.**
+2. **Diagnostics carry `line` but no column/end position.** LSP wants a `Range` to underline. Needs
+   checking whether `ErrorInfo` carries start/end offsets.
+3. **No incremental or cancellable compile.** An LSP recompiles per keystroke; today each call is a
+   whole-module compile. `RunControl.kill()` likewise cancels the caller's wait but does not unwind
+   a running fiber.
+4. **`NativeFunctionHandle` binds to `xRTFunction.INSTANCE.f_container`** on master (a process-static
+   template instance) — fine for a single native plane.
+5. **No pool-publication fence.** Sequential work is fine; the shared pool grows slowly
+   (~1–2 constants per distinct-typed run, measured separately), which matters for an all-day daemon
+   more than for a build invocation.

--- a/POC-NOTES.md
+++ b/POC-NOTES.md
@@ -1,0 +1,70 @@
+# XtcEngine POC on master — status and known gaps
+
+Branch: `lagergren/xtc-engine-poc`, based on `origin/master` `82683bcd2`.
+Goal: prove a warm, in-process compile+run engine works on master, so a Gradle plugin (and an
+LSP server) can stop forking a JVM per invocation.
+
+## What is proven (3 green tests, `org.xvm.api.XtcEngineTest`)
+
+1. **Compile Ecstasy source held in a String** — no files, no CLI.
+2. **Run the compiled module in a nested container**, in the same JVM, and await event-driven
+   completion.
+3. **One warm engine serves repeated compile+run cycles** — the runtime bootstrap is paid once.
+4. **Diagnostics stream to the caller's own `ErrorListener`** as they are produced, and a failed
+   compile is self-describing (the result always carries diagnostics).
+
+Gate: `./gradlew xdk:installDist` then `./gradlew :javatools:test :javatools_utils:test` — both
+green. (Run them SEPARATELY; in one invocation the test's module reads race installDist's writes.)
+
+## What was changed on master (deliberately minimal — 5 files)
+
+| File | Change |
+|---|---|
+| `MainContainer` | capture the `callLater` future that was being discarded; add `futureResult()` |
+| `Container` | add `runModule(String, ObjectHandle...)` returning the completion future |
+| `NestedContainer` | add `createForHost(...)`; add a parent injection fallback **only** for host containers (`f_hProvider == null`), else a host-run module gets no `Console` |
+| `FileStructure` | **master bug fix** — see below |
+| `api/XtcEngine.java` | new: the engine itself (compile pipeline + run + `RunControl` + JFR events) |
+
+Deliberately NOT lifted from the reference branch: pool-publication fencing
+(`markRuntimePublished`), the INSTANCE-removal/owner-lazy work, sealing, display purity. None is
+needed for the POC.
+
+## Master bug found by the POC (deterministic, with a red proof)
+
+`FileStructure.getErrorListener()` read the ambient `ConstantPool.getCurrentPool()` and
+dereferenced it **without a null check**. That thread-local is null on any thread with no pool
+bound — i.e. every Java host thread driving the runtime — so the embedding path NPE'd inside a
+*diagnostic accessor*:
+
+```
+NullPointerException: Cannot invoke "ConstantPool.getErrorListener()" because "poolCurrent" is null
+  at FileStructure.getErrorListener(FileStructure.java:1397)
+  at TypeConstant.ensureTypeInfo(TypeConstant.java:1659)
+  at Container.findModuleMethod(Container.java:252)
+```
+
+Fixed here with a null guard (one line). The deeper fix is to pass the pool EXPLICITLY rather than
+consult an ambient thread-local — this is a concrete instance of the ambient-ownership hazard.
+**Worth filing as a master bug**: the reproduction is simply "call the embedding API from a Java
+thread", and `XtcEngineTest` is the red proof.
+
+## Known gaps (to address after review)
+
+1. **A module's `run()` return value does not reach the host.** The completion future yields the
+   invocation's return TUPLE, and that tuple comes back EMPTY even for `Int run() { return 42; }`.
+   `RunControl.result()` therefore returns empty. Compile, run, and completion all work; only the
+   return-value plumbing in `Container.runModule` is unfinished. `result()` already unwraps a
+   `TupleHandle` correctly once the value is populated.
+2. **`RunControl.kill()` does not force-unwind a running fiber.** It cancels the caller's wait and
+   releases the container; real cancellation needs `Container.terminate(ServiceContext)` wired to a
+   cooperative check.
+3. **`NativeFunctionHandle` binds to `xRTFunction.INSTANCE.f_container`** on master (a process-static
+   template instance). Fine for a single native plane; it is the static-INSTANCE ownership hazard,
+   and would need attention before multiple planes or heavy concurrency.
+4. **No `compile(Path...)` source-tree entry point yet** — only in-memory sources. This is what the
+   Gradle plugin's warm-compile phase and an LSP workspace both need next.
+5. **No pool-publication fence.** Master has none, so a long-running host doing many compiles/runs
+   over one shared pool is exposed to the interning/publication races documented separately. The POC
+   does sequential work and does not hit them; a production plugin should be re-checked under
+   parallel load.

--- a/POC-NOTES.md
+++ b/POC-NOTES.md
@@ -24,6 +24,7 @@ green. (Run them SEPARATELY; in one invocation the test's module reads race inst
 | `Container` | add `runModule(String, ObjectHandle...)` returning the completion future |
 | `NestedContainer` | add `createForHost(...)`; add a parent injection fallback **only** for host containers (`f_hProvider == null`), else a host-run module gets no `Console` |
 | `FileStructure` | **master bug fix** — see below |
+| `DirRepository` | **master bug fix** — synchronize the scan cache (see below) |
 | `api/XtcEngine.java` | new: the engine itself (compile pipeline + run + `RunControl` + JFR events) |
 
 Deliberately NOT lifted from the reference branch: pool-publication fencing
@@ -49,13 +50,26 @@ consult an ambient thread-local — this is a concrete instance of the ambient-o
 **Worth filing as a master bug**: the reproduction is simply "call the embedding API from a Java
 thread", and `XtcEngineTest` is the red proof.
 
+## Second master bug fixed here: `DirRepository` scan cache is not thread-safe
+
+`loadModule`/`getModuleNames`/`storeModule` were unsynchronized over a plain `HashMap` (a non-final
+field reassigned wholesale) and a plain `TreeMap` (rebuilt with `clear()` + a `put()` loop). Two
+parallel compiles resolving library modules race those rebuilds against `get()` and against the live
+`keySet()` view `getModuleNames()` returns - proven red on master with a
+`ConcurrentModificationException` by `DirRepositoryConcurrentScanTest`, which is included here and
+now passes.
+
+This is **the last remaining blocker for parallel compiles**: the other one the audit identified,
+the static compiler counters, is already fixed on master by #538 (all four are `AtomicInteger`).
+
 ## Known gaps (to address after review)
 
-1. **A module's `run()` return value does not reach the host.** The completion future yields the
-   invocation's return TUPLE, and that tuple comes back EMPTY even for `Int run() { return 42; }`.
-   `RunControl.result()` therefore returns empty. Compile, run, and completion all work; only the
-   return-value plumbing in `Container.runModule` is unfinished. `result()` already unwraps a
-   `TupleHandle` correctly once the value is populated.
+1. ~~A module's `run()` return value does not reach the host.~~ **FIXED** - two distinct defects,
+   both now covered by tests: `callLater` hardcodes `cReturns = 0`, so the future completed with an
+   EMPTY tuple (`runModule` now calls `postRequest(..., fReturn ? 1 : 0)` directly); and the native
+   instantiate-and-run op ignored the caller-designated return slot in favour of `A_STACK`, so even
+   with a return requested the value landed where the future never reads (it now returns into
+   `iRet`).
 2. **`RunControl.kill()` does not force-unwind a running fiber.** It cancels the caller's wait and
    releases the container; real cancellation needs `Container.terminate(ServiceContext)` wired to a
    cooperative check.

--- a/POC-NOTES.md
+++ b/POC-NOTES.md
@@ -25,7 +25,8 @@ green. (Run them SEPARATELY; in one invocation the test's module reads race inst
 | `NestedContainer` | add `createForHost(...)`; add a parent injection fallback **only** for host containers (`f_hProvider == null`), else a host-run module gets no `Console` |
 | `FileStructure` | **master bug fix** — see below |
 | `DirRepository` | **master bug fix** — synchronize the scan cache (see below) |
-| `api/XtcEngine.java` | new: the engine itself (compile pipeline + run + `RunControl` + JFR events) |
+| `api/ToolApi.java` | new: the named CONTRACT a tool embeds (compile + run + shared types) |
+| `api/XtcEngine.java` | new: the engine - one implementation of `ToolApi` |
 
 Deliberately NOT lifted from the reference branch: pool-publication fencing
 (`markRuntimePublished`), the INSTANCE-removal/owner-lazy work, sealing, display purity. None is

--- a/javatools/src/main/java/org/xvm/api/ToolApi.java
+++ b/javatools/src/main/java/org/xvm/api/ToolApi.java
@@ -1,0 +1,166 @@
+package org.xvm.api;
+
+
+import java.io.File;
+import java.io.IOException;
+
+import java.time.Instant;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import org.xvm.asm.ErrorListener;
+
+import org.xvm.asm.constants.ModuleConstant;
+
+import org.xvm.compiler.BuildRepository;
+
+import org.xvm.runtime.ObjectHandle;
+
+import org.xvm.util.Severity;
+
+
+/**
+ * The contract a TOOL embeds to compile and run Ecstasy in-process: an LSP server, a build daemon,
+ * an IDE plugin, a test runner.
+ *
+ * <p>This interface exists to make that contract explicit and shared, rather than implicit in one
+ * class. {@link XtcEngine} implements it; the upstream {@code ToolConnector} is the other intended
+ * implementation, and the two were designed against the same requirements
+ * (see {@code docs/reentrancy/toolconnector-api-proposal.md}). Naming the contract means a caller
+ * can be written against {@code ToolApi} and satisfied by either.</p>
+ *
+ * <h2>What the contract guarantees</h2>
+ * <ol>
+ *   <li><b>The runtime is booted once and reused.</b> An implementation is a resident engine, not a
+ *       per-invocation launcher: the whole point is to stop forking a JVM and re-bootstrapping the
+ *       runtime for every compile and run.</li>
+ *   <li><b>Diagnostics are never silently lost.</b> A failed compile returns a result that carries
+ *       its diagnostics, AND streams them to the caller's {@link ErrorListener} as they are
+ *       produced. The listener is TOTAL - pass {@link ErrorListener#BLACKHOLE} to discard - so no
+ *       implementation or caller needs a null check.</li>
+ *   <li><b>Runs are observable.</b> Starting a run yields a {@link RunControl}, not a bare future:
+ *       a long-running host needs to ASK about a run it started (is it going, when did it start and
+ *       stop, what did it return, can I stop it).</li>
+ *   <li><b>Nothing handed in is aliased.</b> Inputs are immutable value records passed as varargs,
+ *       never mutable collections the caller retains a live reference to.</li>
+ * </ol>
+ *
+ * <p>Closing an implementation releases its runtime.</p>
+ */
+public interface ToolApi
+        extends AutoCloseable {
+    // ----- compile -------------------------------------------------------------------------------
+
+    /**
+     * Compile one or more in-memory module sources together, resolving cross-module references
+     * among them.
+     *
+     * @param errs   the caller's diagnostic sink; {@link ErrorListener#BLACKHOLE} to discard
+     * @param units  the module sources (name + text) as immutable value records
+     *
+     * @return the compile result, which always carries its diagnostics
+     */
+    @NotNull CompileResult compile(@NotNull ErrorListener errs, @NotNull SourceUnit @NotNull... units);
+
+    // ----- run -----------------------------------------------------------------------------------
+
+    /**
+     * Run a compiled module and return a handle for observing and controlling it.
+     *
+     * @param result       a successful {@link #compile} result containing the module
+     * @param sModuleName  the module to run
+     *
+     * @return a control handle for the running module
+     */
+    @NotNull RunControl start(@NotNull CompileResult result, @NotNull String sModuleName);
+
+    @Override
+    void close();
+
+    // ----- shared types --------------------------------------------------------------------------
+
+    /**
+     * One in-memory module source: the module's name plus its source text.
+     *
+     * @param moduleName  the module's name (for diagnostics/labels)
+     * @param source      the module source text
+     */
+    record SourceUnit(@NotNull String moduleName, @NotNull String source) {
+    }
+
+    /**
+     * A structured compile/run diagnostic. {@code code} is the stable identifier a tool should
+     * switch on, rather than parsing {@code message} - the same reasoning behind the upstream
+     * {@code ToolConnector}'s {@code TC-xx} vocabulary.
+     *
+     * @param severity  the severity
+     * @param code      the message code
+     * @param message   the rendered message text
+     * @param source    the source name/uri, or null
+     * @param line      the 1-based line, or 0 if unknown
+     */
+    record Diagnostic(@NotNull Severity severity, @NotNull String code, @NotNull String message,
+                      @Nullable String source, int line) {
+    }
+
+    /**
+     * The outcome of a compile: the compiled module ids (empty on failure), every diagnostic
+     * produced, and the in-memory repository holding the compiled modules.
+     */
+    interface CompileResult {
+        /** @return the compiled module ids; empty on failure */
+        @NotNull List<ModuleConstant> modules();
+
+        /** @return every diagnostic produced, whether or not the compile succeeded */
+        @NotNull List<Diagnostic> diagnostics();
+
+        /** @return the in-memory repository holding the compiled modules */
+        @NotNull BuildRepository buildRepository();
+
+        /** @return true iff modules were produced and nothing at ERROR or above was reported */
+        boolean isSuccess();
+
+        /**
+         * Persist the compiled modules to disk as {@code .xtc} binaries - the "sync to disk" half of
+         * the in-memory-first model.
+         *
+         * @param dir  the output directory (created if absent)
+         *
+         * @return the files written, one per module
+         */
+        @NotNull List<File> writeTo(@NotNull File dir) throws IOException;
+    }
+
+    /**
+     * Management and monitoring for a running module - the same role as the upstream
+     * {@code ToolConnector.Control}, with absence expressed as {@link Optional} rather than null so
+     * "still running", "failed", and "returned nothing" cannot be confused.
+     */
+    interface RunControl {
+        /** @return true iff the module is still running */
+        boolean running();
+
+        /** @return when the run started */
+        @NotNull Instant whenStarted();
+
+        /** @return when the run stopped, or empty while it is still running */
+        @NotNull Optional<Instant> whenStopped();
+
+        /** @return the module's {@code run()} result once it completed normally, else empty */
+        @NotNull Optional<Long> result();
+
+        /** @return the failure if the run completed exceptionally, else empty */
+        @NotNull Optional<Throwable> error();
+
+        /** Stop the run as promptly as the implementation allows. */
+        void kill();
+
+        /** @return the event-driven completion future, for callers that prefer to await it */
+        @NotNull CompletableFuture<ObjectHandle> completion();
+    }
+}

--- a/javatools/src/main/java/org/xvm/api/ToolApi.java
+++ b/javatools/src/main/java/org/xvm/api/ToolApi.java
@@ -64,8 +64,14 @@ public interface ToolApi
      * @param units  the module sources (name + text) as immutable value records
      *
      * @return the compile result, which always carries its diagnostics
+     *
+     * @throws IOException  if the compiled modules cannot be stored; the underlying
+     *                      {@code ModuleRepository.storeModule} declares this, and it is propagated
+     *                      rather than wrapped in an unchecked exception so a caller that can handle
+     *                      a failed write is given the chance to
      */
-    @NotNull CompileResult compile(@NotNull ErrorListener errs, @NotNull SourceUnit @NotNull... units);
+    @NotNull CompileResult compile(@NotNull ErrorListener errs, @NotNull SourceUnit @NotNull... units)
+            throws IOException;
 
     // ----- run -----------------------------------------------------------------------------------
 

--- a/javatools/src/main/java/org/xvm/api/XtcEngine.java
+++ b/javatools/src/main/java/org/xvm/api/XtcEngine.java
@@ -1,0 +1,729 @@
+package org.xvm.api;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+import java.time.Instant;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import java.util.concurrent.CompletableFuture;
+
+import java.util.stream.Collectors;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import org.xvm.asm.ClassStructure;
+import org.xvm.asm.Constants;
+import org.xvm.asm.DirRepository;
+import org.xvm.asm.ErrorList;
+import org.xvm.asm.ErrorListener;
+import org.xvm.asm.ErrorListener.ErrorInfo;
+import org.xvm.asm.FileStructure;
+import org.xvm.asm.LinkedRepository;
+import org.xvm.asm.ModuleRepository;
+import org.xvm.asm.ModuleStructure;
+
+import org.xvm.asm.constants.ModuleConstant;
+import org.xvm.asm.constants.TypeConstant;
+
+import org.xvm.compiler.BuildRepository;
+import org.xvm.compiler.Compiler;
+import org.xvm.compiler.CompilerException;
+import org.xvm.compiler.Parser;
+import org.xvm.compiler.Source;
+
+import org.xvm.compiler.ast.Statement;
+import org.xvm.compiler.ast.StatementBlock;
+import org.xvm.compiler.ast.TypeCompositionStatement;
+
+import org.xvm.runtime.Container;
+import org.xvm.runtime.NativeContainer;
+import org.xvm.runtime.NestedContainer;
+import org.xvm.runtime.ObjectHandle;
+import org.xvm.runtime.Runtime;
+
+import org.xvm.runtime.template.collections.xTuple;
+
+import org.xvm.util.Severity;
+
+
+/**
+ * A first-class, resident Java embedding engine for compiling and running Ecstasy code - the
+ * surface an LSP server, a watch-mode build daemon, or an in-process test runner should use
+ * instead of the CLI-oriented {@link Connector}/{@code Launcher} path.
+ *
+ * <p>One engine boots the runtime ONCE (a {@link Runtime} plus the native "-1" container plane) and
+ * is reused for the whole session, so compiles stay warm and runs share one native plane:</p>
+ *
+ * <pre>{@code
+ * try (var engine = XtcEngine.builder().modulePath(xdkLibDir).build()) {
+ *     CompileResult result = engine.compile("Hello", sourceText);   // in-memory, LSP-buffer friendly
+ *     if (result.isSuccess()) {
+ *         engine.run(result, "Hello").join();                       // nested child, event-driven completion
+ *     } else {
+ *         result.diagnostics().forEach(...);                        // structured errors/warnings
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p><b>Deployment model.</b> Runs execute as {@link NestedContainer#createForHost nested containers}
+ * under the shared native plane - the sanctioned one-root-plus-nested-children model (the shape
+ * {@code Runner.x} and the platform kernel use), reached from Java without a guest host module. This
+ * is deliberately NOT sibling main containers over one plane, which leak, nor a fresh bootstrap per
+ * run, which throws away warmth.</p>
+ *
+ * <p><b>Concurrency.</b> Compiles are independent (each builds its own module graph) and runs are
+ * independent nested containers scheduled on the shared runtime executor, so both can be issued in
+ * parallel - subject to the runtime's shared-lazy-state being concurrency-safe (the native-injection
+ * singletons and pool caches this branch hardened).</p>
+ *
+ * <p><b>TODO - unified pipeline diagnostics.</b> Today {@link #compile} returns per-request
+ * {@link Diagnostic}s and {@link #run} surfaces failures through the completion future's exceptional
+ * value. An LSP ultimately wants ONE diagnostic/logging channel spanning the whole compile-to-run
+ * pipeline, with request correlation - a single sink that a compile's {@link org.xvm.asm.ErrorListener},
+ * a run's unhandled-exception handler, and engine logging all feed, tagged by request id. The intended
+ * shape: an engine-level {@code DiagnosticSink} interface passed to {@link Builder}, adapted into an
+ * {@code ErrorListener} for compiles and registered as the run container's unhandled-exception/console
+ * target, so the host receives a coherent, ordered, source-anchored stream across both. That belongs
+ * in a follow-up so the per-request shape here does not calcify into the contract.</p>
+ */
+public final class XtcEngine
+        implements AutoCloseable {
+    private final ModuleRepository repoLibrary;
+    private final Runtime          runtime;
+    private final NativeContainer  containerNative;
+
+    private XtcEngine(@NotNull ModuleRepository repoLibrary) {
+        this.repoLibrary = Objects.requireNonNull(repoLibrary, "repoLibrary");
+        this.runtime     = new Runtime();
+        this.runtime.start();
+        // NOTE (master port): the reference uses a NativeContainer.create(...) factory that also
+        // enforces one-root-per-runtime; master exposes the public constructor directly.
+        this.containerNative = new NativeContainer(this.runtime, this.repoLibrary);
+    }
+
+    public static @NotNull Builder builder() {
+        return new Builder();
+    }
+
+    // ----- compile -------------------------------------------------------------------------------
+
+    /**
+     * Compile a single in-memory module source (an LSP buffer).
+     *
+     * @param sModuleName  the module's name (for diagnostics/labels)
+     * @param sSource      the module source text
+     *
+     * @return the compile result: the compiled modules (empty on failure) plus all diagnostics
+     */
+    public @NotNull CompileResult compile(@NotNull String sModuleName, @NotNull String sSource) {
+        return compile(new SourceUnit(sModuleName, sSource));
+    }
+
+    /**
+     * Compile one or more in-memory module sources together, resolving cross-module references among
+     * them. Each {@link SourceUnit} is one module (name plus source text); pass any number.
+     *
+     * <p>The result's {@link CompileResult#buildRepository() build repository} is an in-memory
+     * {@code ModuleRepository} holding the compiled modules: run them straight from it, or flush it -
+     * fully or partially - into any sink repository (a {@code DirRepository} is the disk sink). There is
+     * no disk-specific path, because an {@code .xtc} is just a serialized byte stream whose destination
+     * is the caller's business.</p>
+     *
+     * <p>Inputs are immutable value records passed as varargs, never a mutable collection: nothing handed
+     * in can be aliased or mutated behind the engine's back.</p>
+     *
+     * <p>TODO - source trees: an LSP workspace also has on-disk module DIRECTORY TREES (a module as a
+     * directory of {@code .x} files). Supporting those means building the module node tree with
+     * {@link org.xvm.tool.ModuleInfo} (which already walks a source directory into a parsed
+     * {@code TypeCompositionStatement} node tree) and feeding the module statements into the same
+     * pipeline below - a {@code compile(Path...)} overload on top of ModuleInfo, not a shell-out to the
+     * Launcher. A {@code Path} is one convenient source, not the model: the content-based form here is
+     * the core, so the API assumes no local compilation environment.</p>
+     *
+     * <p>TODO - granularity: this compiles a whole module, but the shape must NOT preclude method-level /
+     * incremental recompilation later. That is driven EXTERNALLY - the build's incremental compiler
+     * decides what to recompile and re-invokes at whatever granularity; the compiler gaining a stable
+     * per-method recompilation entry point is a separate project. What this API owes, at any granularity
+     * and however often it is called in parallel or sequence, is that a compile must NOT mutate or corrupt
+     * shared/global runtime state - exactly why the pool-publication marker and synthesis windows in this
+     * runtime exist. Keep that invariant and every granularity, ordering, and concurrency stays possible.</p>
+     *
+     * @param units  the module sources to compile (name + source), as immutable value records
+     *
+     * @return the compile result
+     */
+    public @NotNull CompileResult compile(@NotNull SourceUnit @NotNull... units) {
+        return compile(ErrorListener.BLACKHOLE, units);
+    }
+
+    /**
+     * Compile one or more in-memory module sources, streaming every diagnostic to the CALLER's own
+     * {@link ErrorListener} as it is produced, in addition to collecting them into the returned
+     * {@link CompileResult}.
+     *
+     * <p>This is the {@code ToolConnector}-shaped entry point (cpurdy/LSPAPI passes an
+     * {@code ErrorListener} to every compile/run): a long-running host - an LSP server, a build
+     * daemon, a test runner - already owns a diagnostic sink and wants messages as they happen,
+     * correlated with its own request id, rather than only as a batch at the end. The returned
+     * result still carries the full {@link Diagnostic} list, so a caller that wants the batch form
+     * (or wants both) is unaffected.</p>
+     *
+     * <p>The listener is never null: pass {@link ErrorListener#BLACKHOLE} (what the no-listener
+     * overload uses) to discard the stream. Making it total removes the null-check-at-every-use
+     * pattern that the glued-on {@code ErrorListener} plumbing spread through the older code.</p>
+     *
+     * @param errsCaller  the caller's diagnostic sink; {@link ErrorListener#BLACKHOLE} to discard
+     * @param units       the module sources to compile
+     *
+     * @return the compile result
+     */
+    public @NotNull CompileResult compile(@NotNull ErrorListener errsCaller,
+                                          @NotNull SourceUnit @NotNull... units) {
+        Objects.requireNonNull(errsCaller, "errsCaller (use ErrorListener.BLACKHOLE to discard)");
+        Objects.requireNonNull(units, "units");
+
+        var event     = new CompileEvent();
+        event.modules = Arrays.stream(units).map(SourceUnit::moduleName).collect(Collectors.joining(","));
+        event.begin();
+        try {
+            return compileInternal(errsCaller, event, units);
+        } finally {
+            event.commit();
+        }
+    }
+
+    private @NotNull CompileResult compileInternal(@NotNull ErrorListener errsCaller,
+                                                   @NotNull CompileEvent event,
+                                                   @NotNull SourceUnit @NotNull... units) {
+        // Always tee - never a null listener to test for. This IS an ErrorList (master's Compiler
+        // takes the concrete type), so it both collects for the CompileResult and forwards every
+        // diagnostic to the caller's sink, which may be BLACKHOLE.
+        var errsCollect = new TeeErrorListener(Integer.MAX_VALUE, errsCaller);
+        ErrorList errs  = errsCollect;
+        var repoBuild = new BuildRepository();
+
+        // A read-through library repo with the build repo at the front: exactly the shape the CLI
+        // Launcher configures. "Read-through" means every library module loaded through it is cached
+        // into repoBuild - which is how the turtle prototype ends up co-resident with the modules being
+        // compiled so its NakedRef type can be injected across them all (see below). The caller never
+        // has to name the turtle/native-bridge modules per request the way the CLI does with -L flags;
+        // the engine already resolved them when it booted its native container from this same path.
+        var repoCompile = new LinkedRepository(true, repoBuild, repoLibrary);
+        var compilers   = new ArrayList<Compiler>();
+
+        // pre-load and link the system libraries (ecstasy + turtle prototype) so they are cached into
+        // repoBuild before anything is compiled against them - the Launcher's prelinkSystemLibraries step
+        prelinkSystemLibraries(repoCompile);
+
+        // stage 1: parse each source and create its initial module structure in the build repo
+        for (var unit : units) {
+            TypeCompositionStatement stmtModule = parseModule(unit.source(), errs);
+            if (stmtModule == null) {
+                continue; // parse errors already in errs
+            }
+            var           compiler = new Compiler(stmtModule, errs);
+            FileStructure struct   = compiler.generateInitialFileStructure();
+            if (struct == null) {
+                continue;
+            }
+            try {
+                repoBuild.storeModule(struct.getModule());
+            } catch (Exception e) {
+                throw new IllegalStateException("storing module " + unit.moduleName(), e);
+            }
+            compilers.add(compiler);
+        }
+
+        // stages 2-5: link, resolve names, inject turtle, validate, generate code - IN THIS ORDER.
+        // The ordering matches org.xvm.tool.Compiler exactly and is load-bearing. NakedRef must be
+        // injected AFTER link+resolveNames because each compiled module AND each library dependency it
+        // links against (ecstasy, cached into repoBuild by the read-through load) needs the type set on
+        // its own pool before validation builds Ref TypeInfo - otherwise it fails "Mack module is
+        // missing". On-disk modules carry this baked in at build time; in-memory ones inject it here.
+        compilers.forEach(compiler -> compiler.linkModules(repoCompile));
+        runPhase(compilers, Compiler::resolveNames);
+        injectNakedRefType(repoBuild);
+        runPhase(compilers, Compiler::validateExpressions);
+        runPhase(compilers, Compiler::generateCode);
+
+        // On success, ASSEMBLE each compiled module (round-trip it through serialization) into a fresh
+        // result repository. A freshly-compiled in-memory FileStructure still holds ops whose arguments
+        // are unresolved AST references; assembly is what rewrites them into constant-pool indices and
+        // finalizes the pool - exactly what the CLI gets for free by writing the module to a .xtc file.
+        // Without this, a run fails at the first op with an AssertionError on the constant id. Running
+        // the assembled (deserialized) module is then identical to loading a module off disk.
+        var modules    = new ArrayList<ModuleConstant>();
+        var repoResult = new BuildRepository();
+        if (!errsCollect.hasSeriousErrors()) {
+            for (var compiler : compilers) {
+                FileStructure struct = compiler.getFileStructure();
+                if (struct != null) {
+                    ModuleStructure assembled = assemble(struct);
+                    repoResult.storeModule(assembled);
+                    modules.add(assembled.getIdentityConstant());
+                }
+            }
+        }
+        var result = new CompileResult(List.copyOf(modules), diagnostics(errsCollect), repoResult);
+        event.compiled    = result.modules().size();
+        event.diagnostics = result.diagnostics().size();
+        event.success     = result.isSuccess();
+        return result;
+    }
+
+    /**
+     * Assemble a freshly-compiled FileStructure into a runnable module by round-tripping it through
+     * serialization: {@code writeTo} reregisters constants and finalizes op arguments into pool
+     * indices, and reading the bytes back yields a module in the same shape the runtime loads from a
+     * {@code .xtc} on disk. This is the in-memory equivalent of the CLI's emit-to-disk step.
+     */
+    private static ModuleStructure assemble(FileStructure struct) {
+        try {
+            var bytes = new ByteArrayOutputStream();
+            struct.writeTo(bytes);
+            return new FileStructure(new ByteArrayInputStream(bytes.toByteArray())).getModule();
+        } catch (IOException e) {
+            throw new IllegalStateException("assembling module " + struct.getModuleId(), e);
+        }
+    }
+
+    private static @Nullable TypeCompositionStatement parseModule(String sSource, ErrorListener errs) {
+        Statement stmt;
+        try {
+            stmt = new Parser(new Source(sSource), errs).parseSource();
+        } catch (CompilerException e) {
+            // an unrecoverable parse (half-typed LSP buffers hit this constantly) - the parser logged
+            // what it could to errs; do not let it escape as a hard exception
+            return null;
+        }
+        if (stmt == null) {
+            return null;
+        }
+        // a source file parses to a StatementBlock whose final statement is the module
+        Statement stmtModule = stmt instanceof StatementBlock block && !block.getStatements().isEmpty()
+                ? block.getStatements().getLast()
+                : stmt;
+        return stmtModule instanceof TypeCompositionStatement tcs ? tcs : null;
+    }
+
+    /**
+     * Force-load and link the system libraries (ecstasy + turtle prototype) through the read-through
+     * compile repo, so they are cached co-resident in the build repo before anything compiles against
+     * them. This is the in-process equivalent of the Launcher's {@code prelinkSystemLibraries}, and it
+     * is what lets the engine supply turtle/native from its own configured module path instead of
+     * making every caller name those modules explicitly.
+     */
+    private static void prelinkSystemLibraries(ModuleRepository repo) {
+        for (var sModule : List.of(Constants.ECSTASY_MODULE, Constants.TURTLE_MODULE)) {
+            ModuleStructure module = repo.loadModule(sModule);
+            if (module != null) {
+                FileStructure struct = module.getFileStructure();
+                if (struct != null) {
+                    struct.linkModules(repo, false);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set the NakedRef type from the turtle prototype on the pool of every module in the build repo -
+     * the compiled modules AND the library dependencies the read-through load cached alongside them.
+     * This mirrors {@code org.xvm.tool.Compiler.injectNativeTurtle} exactly: the compiler needs the
+     * NakedRef type available to each ConstantPool that participates in building Ref TypeInfo.
+     */
+    private static void injectNakedRefType(BuildRepository repoBuild) {
+        ModuleStructure moduleTurtle = repoBuild.loadModule(Constants.TURTLE_MODULE);
+        if (moduleTurtle == null) {
+            return;
+        }
+        TypeConstant typeNakedRef = ((ClassStructure) moduleTurtle.getChild("NakedRef")).getFormalType();
+        for (var sModule : repoBuild.getModuleNames()) {
+            repoBuild.loadModule(sModule).getConstantPool().setNakedRefType(typeNakedRef);
+        }
+    }
+
+    /** The bounded fixed-point retry loop the compiler stages need (mirrors the CLI driver). */
+    private static void runPhase(List<Compiler> compilers, CompilerPhase phase) {
+        for (int cTriesLeft = 0x3F; cTriesLeft > 0; cTriesLeft--) {
+            boolean fDone = true;
+            for (var compiler : compilers) {
+                fDone &= phase.run(compiler, cTriesLeft == 1);
+                if (compiler.isAbortDesired()) {
+                    return;
+                }
+            }
+            if (fDone) {
+                return;
+            }
+        }
+        compilers.forEach(Compiler::logRemainingDeferredAsErrors);
+    }
+
+    @FunctionalInterface
+    private interface CompilerPhase {
+        boolean run(Compiler compiler, boolean fLastAttempt);
+    }
+
+    // ----- run -----------------------------------------------------------------------------------
+
+    /**
+     * Run a compiled module's {@code run(...)} entry point as a nested container under the shared native
+     * plane, returning the EVENT-DRIVEN completion future. The future completes normally when the run
+     * finishes and exceptionally (carrying the XTC exception) if it threw - the caller awaits it with
+     * its own deadline, no polling.
+     *
+     * @param result       a successful {@link #compile} result containing the module
+     * @param sModuleName  the module to run
+     *
+     * @return the run-completion future
+     */
+    public @NotNull CompletableFuture<ObjectHandle> run(@NotNull CompileResult result, @NotNull String sModuleName) {
+        boolean fFound = result.modules().stream().anyMatch(id -> id.getName().equals(sModuleName));
+        if (!fFound) {
+            throw new IllegalArgumentException("module not in compile result: " + sModuleName);
+        }
+
+        // The native container assembles the run-time FileStructure: it merges its own boot-resolved
+        // turtle prototype (whose pool already carries the NakedRef type) into a fresh combined pool, so
+        // an assembled app module runs here exactly as a module loaded from disk would - no hand-patching
+        // of the run-time pool is needed (that is the whole point of assembling the module at compile).
+        var             repoRun   = new LinkedRepository(result.buildRepository(), repoLibrary);
+        ModuleStructure moduleApp = repoRun.loadModule(sModuleName);
+        FileStructure   struct    = containerNative.createFileStructure(moduleApp);
+
+        ModuleConstant idMissing = struct.linkModules(repoRun, true);
+        if (idMissing != null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("missing dependency: " + idMissing.getName()));
+        }
+
+        Container containerRun = NestedContainer.createForHost(containerNative, struct.getModuleId(), List.of());
+        return containerRun.runModule("run");
+    }
+
+    /**
+     * Run a compiled module and return a {@link RunControl} - the same shape the upstream
+     * {@code ToolConnector.Control} defines - instead of a bare future.
+     *
+     * <p>A completion future answers "is it done, and what did it return"; a long-running host also
+     * needs to ASK about a run it started: is it still going, when did it start and stop, and can I
+     * stop it. An LSP cancelling a stale run, or a test runner enforcing a timeout, needs exactly
+     * that. The future is still available from {@link RunControl#completion()}, so nothing is lost.</p>
+     *
+     * @param result       a successful {@link #compile} result containing the module
+     * @param sModuleName  the module to run
+     *
+     * @return a control handle for the running module
+     */
+    public @NotNull RunControl start(@NotNull CompileResult result, @NotNull String sModuleName) {
+        var event = new RunEvent();
+        event.module = sModuleName;
+        event.begin();
+
+        Instant                         whenStarted = Instant.now();
+        CompletableFuture<ObjectHandle> future      = run(result, sModuleName);
+        var                             control     = new RunControlImpl(whenStarted, future);
+
+        future.whenComplete((handle, error) -> {
+            control.stop();
+            event.succeeded = error == null;
+            event.commit();
+        });
+        return control;
+    }
+
+    /**
+     * Management and monitoring for a running module - the engine's form of the upstream
+     * {@code ToolConnector.Control}.
+     */
+    public interface RunControl {
+        /** @return true iff the module is still running */
+        boolean running();
+
+        /** @return when the run started */
+        @NotNull Instant whenStarted();
+
+        /** @return when the run stopped, or empty while it is still running */
+        @NotNull Optional<Instant> whenStopped();
+
+        /**
+         * @return the module's {@code run()} result once it has completed normally, else empty. An
+         *         Ecstasy {@code Int} exit code arrives as a {@code Long}, matching the upstream
+         *         {@code Control.result()} contract - but as an {@link Optional}, so "still running",
+         *         "failed" and "returned null" cannot be confused with each other.
+         */
+        @NotNull Optional<Long> result();
+
+        /** @return the failure if the run completed exceptionally, else empty */
+        @NotNull Optional<Throwable> error();
+
+        /**
+         * Stop the run as promptly as the runtime allows.
+         *
+         * <p>Honest limitation: this cancels the completion future so the CALLER stops waiting, and
+         * the container is released for collection. It does not yet forcibly unwind a fiber that is
+         * mid-execution - that needs the runtime's own termination path
+         * ({@code Container.terminate(ServiceContext)}) wired to a cooperative cancellation check,
+         * which is deliberately not faked here.</p>
+         */
+        void kill();
+
+        /** @return the event-driven completion future, for callers that prefer to await it */
+        @NotNull CompletableFuture<ObjectHandle> completion();
+    }
+
+    private static final class RunControlImpl
+            implements RunControl {
+        private final Instant                         whenStarted;
+        private final CompletableFuture<ObjectHandle> future;
+        private volatile Instant                      whenStopped;
+
+        RunControlImpl(@NotNull Instant whenStarted, @NotNull CompletableFuture<ObjectHandle> future) {
+            this.whenStarted = whenStarted;
+            this.future      = future;
+        }
+
+        void stop() {
+            whenStopped = Instant.now();
+        }
+
+        @Override
+        public boolean running() {
+            return !future.isDone();
+        }
+
+        @Override
+        public Instant whenStarted() {
+            return whenStarted;
+        }
+
+        @Override
+        public @NotNull Optional<Instant> whenStopped() {
+            return Optional.ofNullable(whenStopped);
+        }
+
+        @Override
+        public @NotNull Optional<Long> result() {
+            if (!future.isDone() || future.isCompletedExceptionally()) {
+                return Optional.empty();
+            }
+            // getNow cannot block here: the future is already completed normally.
+            // callLater yields the invocation's RETURN TUPLE, so unwrap element 0 when present.
+            ObjectHandle handle = future.getNow(null);
+            if (handle instanceof xTuple.TupleHandle hTuple) {
+                ObjectHandle[] ahValue = hTuple.m_ahValue;
+                handle = ahValue != null && ahValue.length > 0 ? ahValue[0] : null;
+            }
+            return handle instanceof ObjectHandle.JavaLong hLong
+                    ? Optional.of(hLong.getValue())
+                    : Optional.empty();
+        }
+
+        @Override
+        public @NotNull Optional<Throwable> error() {
+            return future.isCompletedExceptionally() && !future.isCancelled()
+                    ? Optional.of(future.exceptionNow())
+                    : Optional.empty();
+        }
+
+        @Override
+        public void kill() {
+            future.cancel(true);
+            stop();
+        }
+
+        @Override
+        public CompletableFuture<ObjectHandle> completion() {
+            return future;
+        }
+    }
+
+    // ----- lifecycle -----------------------------------------------------------------------------
+
+    @Override
+    public void close() {
+        runtime.shutdownXVM();
+    }
+
+    // ----- diagnostics ---------------------------------------------------------------------------
+
+    private static List<Diagnostic> diagnostics(ErrorList errs) {
+        var list = new ArrayList<Diagnostic>(errs.getErrors().size());
+        for (ErrorInfo err : errs.getErrors()) {
+            Source source = err.getSource();
+            list.add(new Diagnostic(err.getSeverity(), err.getCode(), err.getMessageText(),
+                    source == null ? null : source.getFileName(), err.getLine()));
+        }
+        return List.copyOf(list);
+    }
+
+    /**
+     * Forwards every diagnostic to a second listener while keeping the first as the authority for
+     * abort/serious-error decisions. Used to stream compile diagnostics to a caller's sink without
+     * giving up the engine's own collection of them.
+     */
+    private static final class TeeErrorListener
+            extends ErrorList {
+        private final ErrorListener secondary;
+
+        TeeErrorListener(int cMaxErrors, @NotNull ErrorListener secondary) {
+            super(cMaxErrors);
+            this.secondary = secondary;
+        }
+
+        @Override
+        public boolean log(ErrorInfo err) {
+            boolean fAbort = super.log(err);
+            secondary.log(err);
+            return fAbort;
+        }
+    }
+
+    // ----- JFR telemetry -------------------------------------------------------------------------
+
+    /**
+     * A compile, as a JFR event: the first concrete piece of the unified-telemetry plan
+     * (docs/reentrancy/plans/unified-logging-jfr-telemetry.md). A long-running host - LSP server,
+     * build daemon, test runner - can then profile compile cost and diagnostic volume with standard
+     * JDK tooling instead of bespoke timing. Events cost nothing when JFR is not recording.
+     */
+    @Name("org.xvm.Compile")
+    @Label("XTC Compile")
+    @Category({"Ecstasy", "Engine"})
+    static final class CompileEvent extends Event {
+        // DELIBERATELY non-final: JFR populates an event by field assignment between begin() and
+        // commit(), and reads the fields reflectively at commit time - they cannot be final. This is
+        // the only mutable state in this class; everything else here is final or an immutable record.
+        @Label("Modules")     private String  modules;
+        @Label("Compiled")    private int     compiled;
+        @Label("Diagnostics") private int     diagnostics;
+        @Label("Success")     private boolean success;
+    }
+
+    /**
+     * A nested-container run, as a JFR event. Duration spans the run's whole lifetime (the event is
+     * committed when the completion future settles), so a host sees run cost without instrumenting
+     * the runtime itself.
+     */
+    @Name("org.xvm.Run")
+    @Label("XTC Run")
+    @Category({"Ecstasy", "Engine"})
+    static final class RunEvent extends Event {
+        // non-final for the same JFR reason as CompileEvent above
+        @Label("Module")    private String  module;
+        @Label("Succeeded") private boolean succeeded;
+    }
+
+    /**
+     * One in-memory module source to compile: the module's name plus its source text. An immutable
+     * value record - the API never takes a mutable collection of sources.
+     *
+     * @param moduleName  the module's name (for diagnostics/labels)
+     * @param source      the module source text
+     */
+    public record SourceUnit(@NotNull String moduleName, @NotNull String source) {
+    }
+
+    /**
+     * A structured compile/run diagnostic (the LSP-facing shape).
+     *
+     * @param severity  the severity
+     * @param code      the message code
+     * @param message   the rendered message text
+     * @param source    the source name/uri, or null
+     * @param line      the 1-based line, or 0 if unknown
+     */
+    public record Diagnostic(@NotNull Severity severity, @NotNull String code, @NotNull String message,
+                            @Nullable String source, int line) {
+    }
+
+    /**
+     * The outcome of a {@link #compile}: the compiled module ids (empty on failure), every diagnostic
+     * produced, and the in-memory build repository holding the compiled modules.
+     *
+     * <p>Compilation is ALWAYS in-memory - the natural fit for an LSP, which recompiles tentatively on
+     * every edit and never wants to touch disk for a buffer that may change again in milliseconds. The
+     * modules held here are already assembled (runnable), so {@link #run} executes them directly with no
+     * disk round-trip. When a caller DOES want binaries on disk - to hand off to another tool, to run in
+     * a separate process, or simply to publish a finished build - it calls {@link #writeTo} to sync the
+     * compiled modules out as {@code .xtc} files. "Compile directly to disk" is therefore just
+     * {@code engine.compile(...).writeTo(dir)}: compile in memory, then persist.</p>
+     */
+    public record CompileResult(@NotNull List<ModuleConstant> modules, @NotNull List<Diagnostic> diagnostics,
+                                @NotNull BuildRepository buildRepository) {
+        public boolean isSuccess() {
+            return !modules.isEmpty()
+                && diagnostics.stream().noneMatch(d -> d.severity().ordinal() >= Severity.ERROR.ordinal());
+        }
+
+        /**
+         * Persist the compiled modules to disk as {@code .xtc} binaries (one file per module, named by
+         * the module's unqualified name), the "sync to disk" half of the in-memory-first model. The
+         * files land in the standard XDK on-disk layout, so they reload through an ordinary
+         * {@link DirRepository} exactly like any other compiled module.
+         *
+         * @param dir  the output directory (created if absent)
+         *
+         * @return the files written, one per module
+         */
+        public @NotNull List<File> writeTo(@NotNull File dir) throws IOException {
+            if (!isSuccess()) {
+                throw new IllegalStateException("cannot persist a failed compilation: " + diagnostics);
+            }
+            if (!dir.isDirectory() && !dir.mkdirs()) {
+                throw new IOException("not a writable directory: " + dir);
+            }
+            var repoDir = new DirRepository(dir, false);
+            var written = new ArrayList<File>(modules.size());
+            for (var id : modules) {
+                repoDir.storeModule(buildRepository.loadModule(id.getName()));
+                written.add(new File(dir, id.getUnqualifiedName() + ".xtc"));
+            }
+            return List.copyOf(written);
+        }
+    }
+
+    // ----- builder -------------------------------------------------------------------------------
+
+    public static final class Builder {
+        private final List<File> modulePath = new ArrayList<>();
+
+        public @NotNull Builder modulePath(@NotNull File @NotNull... dirs) {
+            for (File dir : dirs) {
+                modulePath.add(Objects.requireNonNull(dir, "module path dir"));
+            }
+            return this;
+        }
+
+        public @NotNull XtcEngine build() {
+            var repositories = new ArrayList<ModuleRepository>();
+            for (File dir : modulePath) {
+                if (dir.isDirectory()) {
+                    repositories.add(new DirRepository(dir, true));
+                }
+            }
+            if (repositories.isEmpty()) {
+                throw new IllegalStateException("no valid module-path directories were provided");
+            }
+            ModuleRepository repo = repositories.size() == 1
+                    ? repositories.get(0)
+                    : new LinkedRepository(repositories.toArray(ModuleRepository.NO_REPOS));
+            return new XtcEngine(repo);
+        }
+    }
+}

--- a/javatools/src/main/java/org/xvm/api/XtcEngine.java
+++ b/javatools/src/main/java/org/xvm/api/XtcEngine.java
@@ -6,6 +6,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
+import java.nio.file.Path;
+
 import java.time.Instant;
 
 import java.util.ArrayList;
@@ -15,6 +17,8 @@ import java.util.Objects;
 import java.util.Optional;
 
 import java.util.concurrent.CompletableFuture;
+
+import java.util.function.Function;
 
 import java.util.stream.Collectors;
 
@@ -45,6 +49,7 @@ import org.xvm.compiler.Compiler;
 import org.xvm.compiler.CompilerException;
 import org.xvm.compiler.Parser;
 import org.xvm.compiler.Source;
+import org.xvm.compiler.Token;
 
 import org.xvm.compiler.ast.Statement;
 import org.xvm.compiler.ast.StatementBlock;
@@ -55,6 +60,8 @@ import org.xvm.runtime.NativeContainer;
 import org.xvm.runtime.NestedContainer;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.Runtime;
+
+import org.xvm.tool.ModuleInfo;
 
 import org.xvm.runtime.template.collections.xTuple;
 
@@ -130,7 +137,8 @@ public final class XtcEngine
      *
      * @return the compile result: the compiled modules (empty on failure) plus all diagnostics
      */
-    public @NotNull CompileResult compile(@NotNull String sModuleName, @NotNull String sSource) {
+    public @NotNull CompileResult compile(@NotNull String sModuleName, @NotNull String sSource)
+            throws IOException {
         return compile(new SourceUnit(sModuleName, sSource));
     }
 
@@ -167,7 +175,8 @@ public final class XtcEngine
      *
      * @return the compile result
      */
-    public @NotNull CompileResult compile(@NotNull SourceUnit @NotNull... units) {
+    public @NotNull CompileResult compile(@NotNull SourceUnit @NotNull... units)
+            throws IOException {
         return compile(ErrorListener.BLACKHOLE, units);
     }
 
@@ -194,7 +203,8 @@ public final class XtcEngine
      */
     @Override
     public @NotNull CompileResult compile(@NotNull ErrorListener errsCaller,
-                                          @NotNull SourceUnit @NotNull... units) {
+                                          @NotNull SourceUnit @NotNull... units)
+            throws IOException {
         Objects.requireNonNull(errsCaller, "errsCaller (use ErrorListener.BLACKHOLE to discard)");
         Objects.requireNonNull(units, "units");
 
@@ -202,15 +212,99 @@ public final class XtcEngine
         event.modules = Arrays.stream(units).map(SourceUnit::moduleName).collect(Collectors.joining(","));
         event.begin();
         try {
-            return compileInternal(errsCaller, event, units);
+            return compileInternal(errsCaller, event, errs -> Arrays.stream(units)
+                    .map(unit -> parseModule(unit.source(), errs))
+                    .toList());
         } finally {
             event.commit();
         }
     }
 
+    /**
+     * Compile one or more modules from ON-DISK SOURCE: either a module's {@code .x} file or the
+     * directory tree containing it.
+     *
+     * <p>This is the entry point a build tool and an LSP workspace actually need - a workspace is
+     * directories of {@code .x} files, not a single string. It is NOT a shell-out to the launcher:
+     * {@link ModuleInfo} walks the source tree into the same parsed module statement that the
+     * in-memory path produces, and both then share one pipeline.</p>
+     *
+     * @param errsCaller  the caller's diagnostic sink; {@link ErrorListener#BLACKHOLE} to discard
+     * @param paths       module source files or directories
+     *
+     * @return the compile result
+     */
+    public @NotNull CompileResult compile(@NotNull ErrorListener errsCaller,
+                                          @NotNull Path @NotNull... paths)
+            throws IOException {
+        Objects.requireNonNull(errsCaller, "errsCaller (use ErrorListener.BLACKHOLE to discard)");
+        Objects.requireNonNull(paths, "paths");
+
+        var event     = new CompileEvent();
+        event.modules = Arrays.stream(paths).map(Path::toString).collect(Collectors.joining(","));
+        event.begin();
+        try {
+            return compileInternal(errsCaller, event, errs -> Arrays.stream(paths)
+                    .map(path -> parseModuleTree(path, errs))
+                    .toList());
+        } finally {
+            event.commit();
+        }
+    }
+
+    /** Compile on-disk source with diagnostics collected only. */
+    public @NotNull CompileResult compile(@NotNull Path @NotNull... paths)
+            throws IOException {
+        return compile(ErrorListener.BLACKHOLE, paths);
+    }
+
+    /**
+     * Walk an on-disk module (a {@code .x} file, or the directory containing it) into the same
+     * parsed module statement the in-memory path produces.
+     *
+     * @return the module statement, or null if it could not be parsed or is not a module
+     */
+    private static @Nullable TypeCompositionStatement parseModuleTree(@NotNull Path path,
+                                                                      @NotNull ErrorListener errs) {
+        try {
+            var  info = new ModuleInfo(path.toFile(), true);
+            var  node = info.getSourceTree(errs);
+            TypeCompositionStatement stmtModule = node == null ? null : node.type();
+            if (stmtModule == null) {
+                // EVERY failure path here must log: the contract is that a failed compile is
+                // self-describing, so returning null silently would leave the caller with
+                // "it didn't work" and nothing else.
+                errs.log(Severity.ERROR, Compiler.MODULE_MISSING, new Object[] {path.toString()}, null);
+                return null;
+            }
+            if (stmtModule.getCategory().getId() != Token.Id.MODULE) {
+                errs.log(Severity.ERROR, Compiler.MODULE_MISSING, new Object[] {path.toString()}, null);
+                return null;
+            }
+            return stmtModule;
+        } catch (IllegalArgumentException e) {
+            // ModuleInfo validates its input by throwing IllegalArgumentException ("Unable to
+            // identify a module directory for ..."). Pointing a tool at a path that is not a module
+            // is ordinary USER error, so it becomes a diagnostic: an LSP must not die because
+            // someone opened the wrong directory. The catch is deliberately narrow - it does not
+            // swallow arbitrary RuntimeExceptions, which would hide real defects.
+            errs.log(Severity.ERROR, Compiler.MODULE_MISSING, new Object[] {path.toString()}, null);
+            return null;
+        }
+    }
+
+    /**
+     * The one compile pipeline. Both entry points - in-memory {@link SourceUnit}s and on-disk source
+     * trees - reduce to a list of parsed module statements and share everything from here on, so the
+     * load-bearing stage ORDER exists in exactly one place.
+     *
+     * @param parse  produces the module statements to compile, logging to the supplied listener
+     */
     private @NotNull CompileResult compileInternal(@NotNull ErrorListener errsCaller,
                                                    @NotNull CompileEvent event,
-                                                   @NotNull SourceUnit @NotNull... units) {
+                                                   @NotNull Function<ErrorListener,
+                                                            List<TypeCompositionStatement>> parse)
+            throws IOException {
         // Always tee - never a null listener to test for. This IS an ErrorList (master's Compiler
         // takes the concrete type), so it both collects for the CompileResult and forwards every
         // diagnostic to the caller's sink, which may be BLACKHOLE.
@@ -231,9 +325,11 @@ public final class XtcEngine
         // repoBuild before anything is compiled against them - the Launcher's prelinkSystemLibraries step
         prelinkSystemLibraries(repoCompile);
 
-        // stage 1: parse each source and create its initial module structure in the build repo
-        for (var unit : units) {
-            TypeCompositionStatement stmtModule = parseModule(unit.source(), errs);
+        // stage 1: obtain each module's parsed statement and create its initial structure in the
+        // build repo. Where the statement CAME from - an in-memory string or an on-disk tree walked
+        // by ModuleInfo - is the caller's business and the only thing that differs between the two
+        // public entry points.
+        for (TypeCompositionStatement stmtModule : parse.apply(errs)) {
             if (stmtModule == null) {
                 continue; // parse errors already in errs
             }
@@ -242,11 +338,10 @@ public final class XtcEngine
             if (struct == null) {
                 continue;
             }
-            try {
-                repoBuild.storeModule(struct.getModule());
-            } catch (Exception e) {
-                throw new IllegalStateException("storing module " + unit.moduleName(), e);
-            }
+            // ModuleRepository.storeModule DECLARES IOException; propagate it rather than wrapping
+            // it in an unchecked exception, so a caller that can handle a failed write is given the
+            // chance to (and one that cannot is not surprised by a RuntimeException).
+            repoBuild.storeModule(struct.getModule());
             compilers.add(compiler);
         }
 

--- a/javatools/src/main/java/org/xvm/api/XtcEngine.java
+++ b/javatools/src/main/java/org/xvm/api/XtcEngine.java
@@ -102,7 +102,7 @@ import org.xvm.util.Severity;
  * in a follow-up so the per-request shape here does not calcify into the contract.</p>
  */
 public final class XtcEngine
-        implements AutoCloseable {
+        implements ToolApi {
     private final ModuleRepository repoLibrary;
     private final Runtime          runtime;
     private final NativeContainer  containerNative;
@@ -192,6 +192,7 @@ public final class XtcEngine
      *
      * @return the compile result
      */
+    @Override
     public @NotNull CompileResult compile(@NotNull ErrorListener errsCaller,
                                           @NotNull SourceUnit @NotNull... units) {
         Objects.requireNonNull(errsCaller, "errsCaller (use ErrorListener.BLACKHOLE to discard)");
@@ -392,7 +393,8 @@ public final class XtcEngine
      *
      * @return the run-completion future
      */
-    public @NotNull CompletableFuture<ObjectHandle> run(@NotNull CompileResult result, @NotNull String sModuleName) {
+    public @NotNull CompletableFuture<ObjectHandle> run(@NotNull ToolApi.CompileResult result,
+                                                       @NotNull String sModuleName) {
         boolean fFound = result.modules().stream().anyMatch(id -> id.getName().equals(sModuleName));
         if (!fFound) {
             throw new IllegalArgumentException("module not in compile result: " + sModuleName);
@@ -430,7 +432,9 @@ public final class XtcEngine
      *
      * @return a control handle for the running module
      */
-    public @NotNull RunControl start(@NotNull CompileResult result, @NotNull String sModuleName) {
+    @Override
+    public @NotNull ToolApi.RunControl start(@NotNull ToolApi.CompileResult result,
+                                            @NotNull String sModuleName) {
         var event = new RunEvent();
         event.module = sModuleName;
         event.begin();
@@ -447,48 +451,9 @@ public final class XtcEngine
         return control;
     }
 
-    /**
-     * Management and monitoring for a running module - the engine's form of the upstream
-     * {@code ToolConnector.Control}.
-     */
-    public interface RunControl {
-        /** @return true iff the module is still running */
-        boolean running();
-
-        /** @return when the run started */
-        @NotNull Instant whenStarted();
-
-        /** @return when the run stopped, or empty while it is still running */
-        @NotNull Optional<Instant> whenStopped();
-
-        /**
-         * @return the module's {@code run()} result once it has completed normally, else empty. An
-         *         Ecstasy {@code Int} exit code arrives as a {@code Long}, matching the upstream
-         *         {@code Control.result()} contract - but as an {@link Optional}, so "still running",
-         *         "failed" and "returned null" cannot be confused with each other.
-         */
-        @NotNull Optional<Long> result();
-
-        /** @return the failure if the run completed exceptionally, else empty */
-        @NotNull Optional<Throwable> error();
-
-        /**
-         * Stop the run as promptly as the runtime allows.
-         *
-         * <p>Honest limitation: this cancels the completion future so the CALLER stops waiting, and
-         * the container is released for collection. It does not yet forcibly unwind a fiber that is
-         * mid-execution - that needs the runtime's own termination path
-         * ({@code Container.terminate(ServiceContext)}) wired to a cooperative cancellation check,
-         * which is deliberately not faked here.</p>
-         */
-        void kill();
-
-        /** @return the event-driven completion future, for callers that prefer to await it */
-        @NotNull CompletableFuture<ObjectHandle> completion();
-    }
 
     private static final class RunControlImpl
-            implements RunControl {
+            implements ToolApi.RunControl {
         private final Instant                         whenStarted;
         private final CompletableFuture<ObjectHandle> future;
         private volatile Instant                      whenStopped;
@@ -629,28 +594,7 @@ public final class XtcEngine
         @Label("Succeeded") private boolean succeeded;
     }
 
-    /**
-     * One in-memory module source to compile: the module's name plus its source text. An immutable
-     * value record - the API never takes a mutable collection of sources.
-     *
-     * @param moduleName  the module's name (for diagnostics/labels)
-     * @param source      the module source text
-     */
-    public record SourceUnit(@NotNull String moduleName, @NotNull String source) {
-    }
 
-    /**
-     * A structured compile/run diagnostic (the LSP-facing shape).
-     *
-     * @param severity  the severity
-     * @param code      the message code
-     * @param message   the rendered message text
-     * @param source    the source name/uri, or null
-     * @param line      the 1-based line, or 0 if unknown
-     */
-    public record Diagnostic(@NotNull Severity severity, @NotNull String code, @NotNull String message,
-                            @Nullable String source, int line) {
-    }
 
     /**
      * The outcome of a {@link #compile}: the compiled module ids (empty on failure), every diagnostic
@@ -665,7 +609,9 @@ public final class XtcEngine
      * {@code engine.compile(...).writeTo(dir)}: compile in memory, then persist.</p>
      */
     public record CompileResult(@NotNull List<ModuleConstant> modules, @NotNull List<Diagnostic> diagnostics,
-                                @NotNull BuildRepository buildRepository) {
+                                @NotNull BuildRepository buildRepository)
+            implements ToolApi.CompileResult {
+        @Override
         public boolean isSuccess() {
             return !modules.isEmpty()
                 && diagnostics.stream().noneMatch(d -> d.severity().ordinal() >= Severity.ERROR.ordinal());

--- a/javatools/src/main/java/org/xvm/asm/DirRepository.java
+++ b/javatools/src/main/java/org/xvm/asm/DirRepository.java
@@ -25,6 +25,22 @@ import java.util.TreeMap;
 /**
  * A simple ModuleRepository that manages its contents in a directory.
  */
+/*
+ * THREAD SAFETY: the three public entry points below are synchronized on the repository.
+ *
+ * The scan cache is a plain HashMap (modulesByFile, a non-final field reassigned wholesale) and a
+ * plain TreeMap (modulesByName, rebuilt with clear() + a put() loop). Concurrent callers - two
+ * parallel compiles resolving library modules, say - otherwise race those rebuilds against get()
+ * and against the live keySet() view getModuleNames() hands out, which throws
+ * ConcurrentModificationException (and can spin or silently drop entries).
+ *
+ * A coarse per-repository lock is the right granularity here, not a pessimisation: this is a
+ * directory-scan cache consulted once per module lookup, not a hot inner loop. Note that swapping
+ * in concurrent maps, or copy-on-write with a volatile swap, would NOT be sufficient on its own,
+ * because ModuleInfo.ensureModule() ALSO lazily deserializes ("if (module == null) module =
+ * tryLoad()") - two threads would still duplicate that work and could publish a half-built module.
+ * The lock covers both the cache rebuild and the lazy materialization reached through it.
+ */
 public class DirRepository
         implements ModuleRepository {
     // ----- constructors  -------------------------------------------------------------------------
@@ -63,20 +79,20 @@ public class DirRepository
     // ----- ModuleRepository API ------------------------------------------------------------------
 
     @Override
-    public Set<String> getModuleNames() {
+    public synchronized Set<String> getModuleNames() {
         ensureCache();
         return Collections.unmodifiableSet(modulesByName.keySet());
     }
 
     @Override
-    public ModuleStructure loadModule(String sModule) {
+    public synchronized ModuleStructure loadModule(String sModule) {
         ensureCache();
         ModuleInfo info = modulesByName.get(sModule);
         return info == null ? null : info.ensureModule();
     }
 
     @Override
-    public void storeModule(ModuleStructure module)
+    public synchronized void storeModule(ModuleStructure module)
             throws IOException {
         if (m_fRO) {
             throw new IOException("repository is read-only: " + this);

--- a/javatools/src/main/java/org/xvm/asm/FileStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/FileStructure.java
@@ -1392,8 +1392,11 @@ public class FileStructure
     public ErrorListener getErrorListener() {
         ErrorListener errs = m_errs;
         if (errs == null) {
+            // MASTER BUG (found by the embedding POC): getCurrentPool() is an ambient thread-local
+            // that is simply NULL on any thread with no pool bound - which is every Java host thread
+            // driving the runtime directly. Dereferencing it NPEs inside a diagnostic accessor.
             ConstantPool poolCurrent = ConstantPool.getCurrentPool();
-            if (poolCurrent != m_pool) {
+            if (poolCurrent != null && poolCurrent != m_pool) {
                 errs = poolCurrent.getErrorListener();
             }
         }

--- a/javatools/src/main/java/org/xvm/runtime/Container.java
+++ b/javatools/src/main/java/org/xvm/runtime/Container.java
@@ -46,6 +46,12 @@ import org.xvm.runtime.template.reflect.xModule;
 import org.xvm.runtime.template.reflect.xPackage;
 
 import org.xvm.runtime.template._native.temporal.xNanosTimer;
+import org.xvm.asm.constants.SignatureConstant;
+
+import org.xvm.runtime.template._native.reflect.xRTFunction;
+
+import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
+
 import org.xvm.util.concurrent.ConcurrentWeakHasherMap;
 
 
@@ -106,6 +112,58 @@ public abstract class Container
             }
         }
         return ctx;
+    }
+
+    /**
+     * Run a method of this container's module, returning the EVENT-DRIVEN completion future.
+     *
+     * <p>This is the embedding hook: a Java host that creates a container needs to know when the
+     * module finished and what it returned. The future completes normally with the {@code run()}
+     * result and exceptionally if the module threw.</p>
+     *
+     * @param sMethodName  the module method to invoke (typically "run")
+     * @param ahArg        the arguments
+     *
+     * @return the run-completion future
+     */
+    public CompletableFuture<ObjectHandle> runModule(String sMethodName, ObjectHandle... ahArg) {
+        ServiceContext ctx      = ensureServiceContext();
+        ModuleConstant idModule = getModule();
+        MethodConstant idMethod = findModuleMethod(sMethodName, ahArg);
+        if (idMethod == null) {
+            return CompletableFuture.failedFuture(new IllegalStateException(
+                    "Missing \"" + sMethodName + "\" method for " + idModule.getValueString()));
+        }
+
+        TypeComposition   clzModule = resolveClass(idModule.getType());
+        SignatureConstant sigMethod = idMethod.getSignature();
+        CallChain         chain     = clzModule.getMethodCallChain(sigMethod);
+        boolean           fReturn   = sigMethod.getReturnCount() > 0;
+
+        // NOTE (master port): master's NativeFunctionHandle takes only the operation and binds to
+        // xRTFunction.INSTANCE.f_container - the process-static template instance. The reference
+        // implementation passes the owning container explicitly (that static was removed there).
+        // Fine for a single native plane; see the POC's known-limitations note.
+        FunctionHandle hInstantiateAndRun = new xRTFunction.NativeFunctionHandle((frame, ah, iRet) -> {
+            SingletonConstant idSingleton = frame.poolContext().ensureSingletonConstConstant(idModule);
+            ObjectHandle      hModule     = frame.getConstHandle(idSingleton);
+            int               iReturn     = fReturn ? Op.A_STACK : Op.A_IGNORE;
+
+            Frame.Continuation invoke = frameCaller -> {
+                ObjectHandle target = frameCaller.popStack();
+                // NOTE (master port): the reference implementation additionally calls
+                // frameCaller.poolContext().markRuntimePublished(...) here. Master has no
+                // pool-publication fence, so that line is deliberately omitted.
+                return chain.invoke(frameCaller, target, ahArg, iReturn);
+            };
+            if (Op.isDeferred(hModule)) {
+                return hModule.proceed(frame, invoke);
+            }
+            frame.pushStack(hModule);
+            return invoke.proceed(frame);
+        });
+
+        return ctx.callLater(hInstantiateAndRun, Utils.OBJECTS_NONE);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/Container.java
+++ b/javatools/src/main/java/org/xvm/runtime/Container.java
@@ -147,7 +147,10 @@ public abstract class Container
         FunctionHandle hInstantiateAndRun = new xRTFunction.NativeFunctionHandle((frame, ah, iRet) -> {
             SingletonConstant idSingleton = frame.poolContext().ensureSingletonConstConstant(idModule);
             ObjectHandle      hModule     = frame.getConstHandle(idSingleton);
-            int               iReturn     = fReturn ? Op.A_STACK : Op.A_IGNORE;
+            // Return into the slot the CALLER designated (iRet), not the stack: the service entry
+            // frame completes the future from f_ahVar[0], so a hardcoded A_STACK would push the
+            // result somewhere the future never reads and the caller would see an empty result.
+            int               iReturn     = fReturn ? iRet : Op.A_IGNORE;
 
             Frame.Continuation invoke = frameCaller -> {
                 ObjectHandle target = frameCaller.popStack();
@@ -163,7 +166,10 @@ public abstract class Container
             return invoke.proceed(frame);
         });
 
-        return ctx.callLater(hInstantiateAndRun, Utils.OBJECTS_NONE);
+        // NOT callLater(...): that hardcodes cReturns=0, so the future would complete with an EMPTY
+        // tuple and the module's run() result would be dropped. Ask for the return value the method
+        // actually declares, so an embedding host can read the exit code.
+        return ctx.postRequest(null, hInstantiateAndRun, Utils.OBJECTS_NONE, fReturn ? 1 : 0);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/MainContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/MainContainer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.xvm.asm.ConstantPool;
 import org.xvm.asm.MethodStructure;
@@ -233,10 +234,18 @@ public class MainContainer
                 return iResult;
             });
 
-            m_contextMain.callLater(hInstantiateModuleAndRun, Utils.OBJECTS_NONE);
+            futureResult = m_contextMain.callLater(hInstantiateModuleAndRun, Utils.OBJECTS_NONE);
         } catch (Exception e) {
             throw new RuntimeException("failed to run: " + f_idModule + ". Cause: " + e.getMessage());
         }
+    }
+
+    /**
+     * @return the future that completes when the module's run() finishes - the event-driven
+     *         completion signal an embedding host needs, which was previously discarded
+     */
+    public CompletableFuture<ObjectHandle> futureResult() {
+        return futureResult;
     }
 
     /**
@@ -264,5 +273,8 @@ public class MainContainer
      * The return value from the "main" method. The value of "1" indicates that the method has
      * completed abnormally.
      */
+    /** completes when the module's run() finishes; previously discarded by invoke0 */
+    private CompletableFuture<ObjectHandle> futureResult;
+
     private int m_nResult = 1;
 }

--- a/javatools/src/main/java/org/xvm/runtime/NestedContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/NestedContainer.java
@@ -45,6 +45,27 @@ public class NestedContainer
         f_listShared = listShared;
     }
 
+    /**
+     * Create a container owned by a JAVA host rather than by a guest Ecstasy provider - the linchpin
+     * for embedding. A host container passes a null provider, which also selects the injection
+     * fallback in {@link #getInjectable}: a host is trusted, so it inherits the parent plane's
+     * standard resources (Console, clock, ...) instead of being sandboxed to an empty resource map.
+     *
+     * @param containerParent  the parent container (typically the native plane)
+     * @param idModule         the module to run
+     * @param listShared       modules shared with the parent
+     *
+     * @return the registered nested container
+     */
+    public static NestedContainer createForHost(Container containerParent, ModuleConstant idModule,
+                                                List<ModuleConstant> listShared) {
+        // NOTE (master port): master's registerContainer returns void (the reference returns the
+        // container and enforces single-root), so register then return.
+        NestedContainer container = new NestedContainer(containerParent, idModule, null, listShared);
+        containerParent.f_runtime.registerContainer(container);
+        return container;
+    }
+
 
     // ----- NestedContainer API -------------------------------------------------------------------
 
@@ -126,9 +147,21 @@ public class NestedContainer
     @Override
     public ObjectHandle getInjectable(Frame frame, String sName, TypeConstant type, ObjectHandle hOpts) {
         InjectionSupplier supplier = f_mapResources.get(new InjectionKey(sName, type));
-        return supplier == null
-                ? type.isNullable() ? xNullable.NULL : null
-                : supplier.supply(frame, hOpts);
+        if (supplier != null) {
+            return supplier.supply(frame, hOpts);
+        }
+
+        if (f_hProvider == null) {
+            // Trusted HOST container (created by createForHost): no guest provider populated the
+            // resource map, so fall back to the parent/native plane for the standard resources.
+            // Without this a host-run module gets no Console and dies with "Invalid resource".
+            // Guest containers (f_hProvider != null) keep master's strict sandbox.
+            ObjectHandle hResource = f_parent.getInjectable(frame, sName, type, hOpts);
+            if (hResource != null) {
+                return hResource;
+            }
+        }
+        return type.isNullable() ? xNullable.NULL : null;
     }
 
     @Override

--- a/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
+++ b/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
@@ -150,7 +150,7 @@ public class XtcEngineTest {
                 return false;
             };
 
-            var result = engine.compile(sink, new XtcEngine.SourceUnit("BadPoc", """
+            var result = engine.compile(sink, new ToolApi.SourceUnit("BadPoc", """
                     module BadPoc {
                         void run() {
                             this_is_not_a_thing();
@@ -190,6 +190,33 @@ public class XtcEngineTest {
                 assertEquals((long) i, control.result().orElseThrow(),
                         "each warm run must return its own result");
             }
+        }
+    }
+
+    /**
+     * The engine must be usable through the {@link ToolApi} contract alone - that is the point of
+     * naming the contract: a caller (or the upstream ToolConnector) can be written against the
+     * interface and satisfied by any implementation.
+     */
+    @Test
+    public void theEngineIsUsableThroughTheToolApiContractAlone() throws Exception {
+        try (ToolApi api = engine()) {                       // <- interface type, not XtcEngine
+            ToolApi.CompileResult result = api.compile(ErrorListener.BLACKHOLE,
+                    new ToolApi.SourceUnit("ApiPoc",
+                            "module ApiPoc {\n"
+                          + "    Int run() {\n"
+                          + "        return 7;\n"
+                          + "    }\n"
+                          + "}\n"));
+
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+            assertFalse(result.modules().isEmpty());
+
+            ToolApi.RunControl control = api.start(result, "ApiPoc");
+            control.completion().get(60, TimeUnit.SECONDS);
+
+            assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
+            assertEquals(7L, control.result().orElseThrow());
         }
     }
 }

--- a/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
+++ b/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
@@ -80,9 +80,63 @@ public class XtcEngineTest {
             assertNotNull(control.whenStarted());
             assertTrue(control.whenStopped().isPresent(), "a finished run has a stop time");
             assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
-            // KNOWN GAP (tracked): the module's Int run() value does not reach the host - the
-            // completion tuple comes back EMPTY, so result() is empty. Compile + run + completion
-            // all work; only the return-value plumbing in Container.runModule is unfinished.
+            assertEquals(42L, control.result().orElseThrow(),
+                    "the module's Int run() result must reach the host");
+        }
+    }
+
+    /**
+     * The run-completion future must carry the module's actual {@code run()} return value.
+     * Regression guard for two distinct defects fixed together: {@code callLater} hardcodes
+     * {@code cReturns = 0} (so the future completed with an EMPTY tuple), and the native
+     * instantiate-and-run op ignored the caller-designated return slot in favour of the stack
+     * (so even with a return requested, the value landed where the future never reads).
+     */
+    @Test
+    public void theRunResultReachesTheHost() throws Exception {
+        try (XtcEngine engine = engine()) {
+            for (long expected : new long[] {0L, 1L, 42L, 1234567890123L}) {
+                String name = "Ret" + expected;
+                var result = engine.compile(name,
+                        "module " + name + " {\n"
+                      + "    Int run() {\n"
+                      + "        return " + expected + ";\n"
+                      + "    }\n"
+                      + "}\n");
+                assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+
+                var control = engine.start(result, name);
+                control.completion().get(60, TimeUnit.SECONDS);
+
+                assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
+                assertEquals(expected, control.result().orElseThrow(),
+                        "the exact Int returned by run() must reach the host");
+            }
+        }
+    }
+
+    /**
+     * A void run() must complete cleanly and report NO result - "returned nothing" must not be
+     * confused with "failed".
+     */
+    @Test
+    public void aVoidRunCompletesWithNoResult() throws Exception {
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile("VoidPoc",
+                    "module VoidPoc {\n"
+                  + "    void run() {\n"
+                  + "        @Inject Console console;\n"
+                  + "        console.print(\"void run executed\");\n"
+                  + "    }\n"
+                  + "}\n");
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+
+            var control = engine.start(result, "VoidPoc");
+            control.completion().get(60, TimeUnit.SECONDS);
+
+            assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
+            assertFalse(control.running(), "the run should have finished");
+            assertTrue(control.result().isEmpty(), "a void run() reports no result");
         }
     }
 
@@ -133,7 +187,8 @@ public class XtcEngineTest {
                 control.completion().get(60, TimeUnit.SECONDS);
                 assertTrue(control.error().isEmpty(),
                         () -> "warm run " + name + " failed: " + control.error());
-                assertFalse(control.running(), "each warm run must finish");
+                assertEquals((long) i, control.result().orElseThrow(),
+                        "each warm run must return its own result");
             }
         }
     }

--- a/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
+++ b/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
@@ -3,12 +3,16 @@ package org.xvm.api;
 
 import java.io.File;
 
+import java.nio.file.Path;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import org.xvm.asm.DirRepository;
 import org.xvm.asm.ErrorListener;
 
 import org.xvm.util.Severity;
@@ -218,5 +222,99 @@ public class XtcEngineTest {
             assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
             assertEquals(7L, control.result().orElseThrow());
         }
+    }
+
+    /**
+     * The FAILURE path: a module that throws must complete the future EXCEPTIONALLY and surface the
+     * error through the control handle. A test runner or build plugin depends on this - a run that
+     * blows up must not look like a run that succeeded.
+     */
+    @Test
+    public void aThrowingRunCompletesExceptionally() throws Exception {
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile("ThrowPoc",
+                    "module ThrowPoc {\n"
+                  + "    void run() {\n"
+                  + "        throw new IllegalState(\"deliberate POC failure\");\n"
+                  + "    }\n"
+                  + "}\n");
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+
+            var control = engine.start(result, "ThrowPoc");
+            try {
+                control.completion().get(60, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                // expected: the run threw
+            }
+
+            assertFalse(control.running(), "a failed run has still finished");
+            assertTrue(control.error().isPresent(), "the failure must reach the host");
+            assertTrue(control.result().isEmpty(), "a failed run has no result");
+        }
+    }
+
+    /**
+     * Several modules compiled in ONE request, resolving references among themselves - the shape a
+     * build plugin needs when a project has interdependent modules.
+     */
+    @Test
+    public void compilesMultipleModulesInOneRequest() throws Exception {
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile(ErrorListener.BLACKHOLE,
+                    new ToolApi.SourceUnit("AlphaPoc",
+                            "module AlphaPoc {\n"
+                          + "    Int run() {\n"
+                          + "        return 1;\n"
+                          + "    }\n"
+                          + "}\n"),
+                    new ToolApi.SourceUnit("BetaPoc",
+                            "module BetaPoc {\n"
+                          + "    Int run() {\n"
+                          + "        return 2;\n"
+                          + "    }\n"
+                          + "}\n"));
+
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+            assertEquals(2, result.modules().size(), "both modules must be compiled");
+
+            // and both are runnable from the one warm engine
+            var a = engine.start(result, "AlphaPoc");
+            a.completion().get(60, TimeUnit.SECONDS);
+            assertEquals(1L, a.result().orElseThrow());
+
+            var b = engine.start(result, "BetaPoc");
+            b.completion().get(60, TimeUnit.SECONDS);
+            assertEquals(2L, b.result().orElseThrow());
+        }
+    }
+
+    /**
+     * In-memory compile, then SYNC TO DISK as ordinary .xtc binaries, then load them back through a
+     * plain DirRepository. "Compile directly to disk" is just compile-then-writeTo, and the output
+     * must be indistinguishable from anything else the toolchain produced - which is exactly what a
+     * Gradle plugin needs to emit build artifacts.
+     */
+    @Test
+    public void compiledModulesCanBeSyncedToDiskAndReloaded(@TempDir Path tempDir) throws Exception {
+        File out = tempDir.resolve("out").toFile();
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile("DiskPoc",
+                    "module DiskPoc {\n"
+                  + "    Int run() {\n"
+                  + "        return 5;\n"
+                  + "    }\n"
+                  + "}\n");
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+
+            List<File> written = result.writeTo(out);
+            assertEquals(1, written.size(), "one file per module");
+            assertTrue(written.get(0).isFile(), "the .xtc must exist on disk");
+            assertTrue(written.get(0).length() > 0, "and be non-empty");
+        }
+
+        // reload through an ordinary repository - nothing engine-specific about the output
+        var repo = new DirRepository(out, true);
+        assertTrue(repo.getModuleNames().stream().anyMatch(n -> n.startsWith("DiskPoc")),
+                () -> "the written module must reload: " + repo.getModuleNames());
     }
 }

--- a/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
+++ b/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
@@ -3,6 +3,7 @@ package org.xvm.api;
 
 import java.io.File;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import java.util.ArrayList;
@@ -316,5 +317,51 @@ public class XtcEngineTest {
         var repo = new DirRepository(out, true);
         assertTrue(repo.getModuleNames().stream().anyMatch(n -> n.startsWith("DiskPoc")),
                 () -> "the written module must reload: " + repo.getModuleNames());
+    }
+
+    /**
+     * Compile from ON-DISK source - the shape an LSP workspace and a build tool actually have
+     * (directories of .x files, not one string). Goes through ModuleInfo into the SAME pipeline as
+     * the in-memory path, and the result runs identically.
+     */
+    @Test
+    public void compilesAModuleFromDisk(@TempDir Path tempDir) throws Exception {
+        Path src = tempDir.resolve("DiskSrc.x");
+        Files.writeString(src,
+                "module DiskSrc {\n"
+              + "    Int run() {\n"
+              + "        return 11;\n"
+              + "    }\n"
+              + "}\n");
+
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile(src);
+
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+            assertEquals(1, result.modules().size());
+
+            var control = engine.start(result, "DiskSrc");
+            control.completion().get(60, TimeUnit.SECONDS);
+            assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
+            assertEquals(11L, control.result().orElseThrow(),
+                    "a module compiled from disk runs exactly like an in-memory one");
+        }
+    }
+
+    /**
+     * Pointing the tool at a path that is not a module is ordinary USER error: it must produce a
+     * DIAGNOSTIC, not blow up. An LSP cannot die because someone opened the wrong directory.
+     */
+    @Test
+    public void aPathThatIsNotAModuleIsADiagnosticNotACrash(@TempDir Path tempDir) throws Exception {
+        Path notAModule = tempDir.resolve("empty-dir");
+        Files.createDirectories(notAModule);
+
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile(notAModule);       // must not throw
+
+            assertFalse(result.isSuccess(), "a non-module path cannot compile successfully");
+            assertFalse(result.diagnostics().isEmpty(), "and must say why");
+        }
     }
 }

--- a/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
+++ b/javatools/src/test/java/org/xvm/api/XtcEngineTest.java
@@ -1,0 +1,140 @@
+package org.xvm.api;
+
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.ErrorListener;
+
+import org.xvm.util.Severity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+
+/**
+ * Proves the embedding API works on master: compile Ecstasy source held in a String, then run the
+ * compiled module in a nested container - all inside ONE JVM, with no process fork and no CLI.
+ *
+ * <p>This is the capability a fast Gradle plugin (and an LSP server) needs: today each compile/run
+ * forks a JVM and re-bootstraps the runtime. A warm, resident engine removes both costs.</p>
+ */
+public class XtcEngineTest {
+    /** Where the gradle build leaves the compiled XDK; TEST-ONLY discovery. */
+    private static File xdkLib() {
+        for (String s : List.of("xdk/build/install/xdk/lib", "../xdk/build/install/xdk/lib")) {
+            File dir = new File(s);
+            if (dir.isDirectory() && new File(dir, "ecstasy.xtc").isFile()) {
+                return dir;
+            }
+        }
+        return null;
+    }
+
+    private static File xdkJavatools() {
+        for (String s : List.of("xdk/build/install/xdk/javatools", "../xdk/build/install/xdk/javatools")) {
+            File dir = new File(s);
+            if (dir.isDirectory()) {
+                return dir;
+            }
+        }
+        return null;
+    }
+
+    private static XtcEngine engine() {
+        File lib = xdkLib();
+        assumeTrue(lib != null, "a built XDK is required (./gradlew xdk:installDist)");
+        File javatools = xdkJavatools();
+        return javatools == null
+                ? XtcEngine.builder().modulePath(lib).build()
+                : XtcEngine.builder().modulePath(lib, javatools).build();
+    }
+
+    @Test
+    public void compilesAndRunsAModuleHeldInAString() throws Exception {
+        try (XtcEngine engine = engine()) {
+            var result = engine.compile("TestPoc", """
+                    module TestPoc {
+                        Int run() {
+                            return 42;
+                        }
+                    }
+                    """);
+
+            assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+            assertEquals(1, result.modules().size());
+
+            // run it in a nested container and await the event-driven completion
+            var control = engine.start(result, "TestPoc");
+            control.completion().get(60, TimeUnit.SECONDS);
+
+            assertFalse(control.running(), "the run should have finished");
+            assertNotNull(control.whenStarted());
+            assertTrue(control.whenStopped().isPresent(), "a finished run has a stop time");
+            assertTrue(control.error().isEmpty(), () -> "run failed: " + control.error());
+            // KNOWN GAP (tracked): the module's Int run() value does not reach the host - the
+            // completion tuple comes back EMPTY, so result() is empty. Compile + run + completion
+            // all work; only the return-value plumbing in Container.runModule is unfinished.
+        }
+    }
+
+    @Test
+    public void reportsCompileDiagnosticsAndStreamsThemToTheCaller() throws Exception {
+        try (XtcEngine engine = engine()) {
+            // the caller's own sink, exactly as an LSP server would supply
+            var streamed = new ArrayList<String>();
+            ErrorListener sink = err -> {
+                streamed.add(err.getCode());
+                return false;
+            };
+
+            var result = engine.compile(sink, new XtcEngine.SourceUnit("BadPoc", """
+                    module BadPoc {
+                        void run() {
+                            this_is_not_a_thing();
+                        }
+                    }
+                    """));
+
+            assertFalse(result.isSuccess(), "a broken module must not report success");
+            assertFalse(result.diagnostics().isEmpty(), "the failure must be self-describing");
+            assertTrue(result.diagnostics().stream()
+                            .anyMatch(d -> d.severity().compareTo(Severity.ERROR) >= 0),
+                    "at least one ERROR diagnostic expected");
+            assertFalse(streamed.isEmpty(),
+                    "diagnostics must also stream to the caller's ErrorListener as produced");
+        }
+    }
+
+    @Test
+    public void oneWarmEngineServesRepeatedCompileAndRunCycles() throws Exception {
+        // the actual point of the API: pay the runtime bootstrap ONCE, not per invocation
+        try (XtcEngine engine = engine()) {
+            for (int i = 1; i <= 3; i++) {
+                String name = "Repeat" + i;
+                var result = engine.compile(name, """
+                        module %s {
+                            Int run() {
+                                return %d;
+                            }
+                        }
+                        """.formatted(name, i));
+                assertTrue(result.isSuccess(), () -> "compile failed: " + result.diagnostics());
+
+                var control = engine.start(result, name);
+                control.completion().get(60, TimeUnit.SECONDS);
+                assertTrue(control.error().isEmpty(),
+                        () -> "warm run " + name + " failed: " + control.error());
+                assertFalse(control.running(), "each warm run must finish");
+            }
+        }
+    }
+}

--- a/javatools/src/test/java/org/xvm/asm/DirRepositoryConcurrentScanTest.java
+++ b/javatools/src/test/java/org/xvm/asm/DirRepositoryConcurrentScanTest.java
@@ -1,0 +1,113 @@
+package org.xvm.asm;
+
+
+import java.io.File;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+
+/**
+ * Regression / red-on-master proof for the DirRepository scan-cache race.
+ *
+ * <p>{@code DirRepository} caches its directory scan in a plain {@code HashMap modulesByFile} (a
+ * non-final field reassigned by {@code rebuildCache}) and a plain {@code TreeMap modulesByName}
+ * (rebuilt with {@code clear()} + {@code put()}). On master none of {@code loadModule}/
+ * {@code getModuleNames}/{@code ensureCache}/{@code rebuildCache} is synchronized, so concurrent
+ * callers race {@code clear()}/{@code put()} against {@code get()}/iteration. A fresh repository
+ * starts with {@code lastScan == 0}, so the first concurrent access has every thread run
+ * {@code rebuildCache} on the same maps at once. Two concurrent container-0 compiles reach exactly
+ * this path.</p>
+ *
+ * <p><b>Proven red on master</b> {@code 82683bcd2}: this exact test throws
+ * {@code java.util.ConcurrentModificationException} (verified in a master worktree with
+ * master-built modules parsed into the cache). It passes here because
+ * {@code DirRepository.loadModule}/{@code getModuleNames}/{@code storeModule} are {@code
+ * synchronized} on this branch (the coarse per-repository lock is the correct granularity for a
+ * lookup cache).</p>
+ */
+public class DirRepositoryConcurrentScanTest {
+    private static final File LIB =
+            new File("xdk/build/install/xdk/lib").isDirectory()
+                    ? new File("xdk/build/install/xdk/lib")
+                    : new File("../xdk/build/install/xdk/lib");
+
+    @Test
+    public void concurrentScanDoesNotCorruptTheCache() throws Exception {
+        assumeTrue(LIB.isDirectory(), "need built .xtc modules to feed the repository");
+        File[] xtc = LIB.listFiles((d, n) -> n.endsWith(".xtc"));
+        assumeTrue(xtc != null && xtc.length >= 4, "need several .xtc modules");
+
+        Path dir    = Files.createTempDirectory("dirrepo-race");
+        int  copied = 0;
+        for (File f : xtc) {
+            if (f.getName().equals("ecstasy.xtc")) {
+                continue;   // skip the big one to keep per-scan parse cost low
+            }
+            Files.copy(f.toPath(), dir.resolve(f.getName()));
+            if (++copied >= 6) {
+                break;
+            }
+        }
+        assumeTrue(copied >= 4, "need several small .xtc modules");
+
+        int threads = 8;
+        var pool    = Executors.newFixedThreadPool(threads);
+        var failure = new AtomicReference<Throwable>();
+
+        try {
+            for (int iter = 0; iter < 80 && failure.get() == null; iter++) {
+                var repo    = new DirRepository(dir.toFile(), true);
+                var start   = new CountDownLatch(1);
+                var futures = new ArrayList<Future<?>>();
+                for (int t = 0; t < threads; t++) {
+                    futures.add(pool.submit(() -> {
+                        start.await();
+                        // First concurrent call -> every thread runs rebuildCache (clear()+put())
+                        // on the shared modulesByName TreeMap; iterating the keySet view races it.
+                        int seen = 0;
+                        for (int i = 0; i < 8; i++) {
+                            for (String name : repo.getModuleNames()) {
+                                seen += name.length();
+                            }
+                        }
+                        return seen;
+                    }));
+                }
+                start.countDown();
+                for (Future<?> f : futures) {
+                    try {
+                        f.get(20, TimeUnit.SECONDS);
+                    } catch (ExecutionException e) {
+                        failure.compareAndSet(null, e.getCause());
+                    } catch (TimeoutException e) {
+                        failure.compareAndSet(null, new AssertionError(
+                                "a scan thread hung (corrupted HashMap infinite loop?)", e));
+                    }
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Throwable t = failure.get();
+        if (t != null) {
+            fail("concurrent DirRepository scan corrupted the cache: " + t, t);
+        }
+    }
+}


### PR DESCRIPTION
**Draft POC.** Proves a warm, in-process compile+run engine works on `master`, so tooling (the Gradle plugin, an LSP server, a test runner) can stop forking a JVM and re-bootstrapping the runtime per invocation.

## Why this matters for the LSP: it fills the one stub

The LSP is **already built** in `lang/` — `lsp-server` (full lsp4j plumbing, `publishDiagnostics`, document services), `dap-server`, the IntelliJ plugin, the tree-sitter grammar. Language intelligence is served through a pluggable `Adapter`:

| Adapter | Backend | Status |
|---|---|---|
| `MockAdapter` | regex | testing/fallback |
| `TreeSitterAdapter` | tree-sitter | **works today** — "syntax-aware (~80% LSP features)" |
| `XdkAdapter` | **XDK compiler** | **STUB** — *"all methods log but return empty results"* |

So the editor, protocol and syntactic halves are done. The hole is the **compiler-backed adapter**: something that actually compiles a buffer into real diagnostics and can run a module. That is exactly what this supplies — `compile(...)` over in-memory buffers producing structured `Diagnostic`s (severity, **code**, message, source, line) streamed to the caller's `ErrorListener`, and `start(...)` returning a `RunControl`.

**`lang` owns the LSP; this owns compile-and-run.** Together they close the `XdkAdapter` stub. What remains beyond that is genuinely semantic — hover, type inference, cross-file navigation — plus the listed gaps. The `compile(Path...)` entry point for on-disk source trees - the thing an LSP workspace actually has - is now **implemented** here.

Deliberately minimal: **5 files touched + 1 new**, ~1050 lines including tests and notes. None of the deeper hardening work is lifted in.

## Naming the contract: `ToolApi`

The embedding contract was implicit in one class. `ToolApi` makes it explicit — `XtcEngine` implements it, and it is deliberately the shape `ToolConnector` targets, so the correspondence between the two is obvious rather than something a reader reconstructs. It states what the contract guarantees: the runtime is booted **once** and reused; diagnostics are never silently lost; runs are **observable** (a `RunControl`, not a bare future); and nothing handed in is aliased. `RunControl` expresses absence as `Optional`, so "still running", "failed" and "returned nothing" cannot be confused.

## What is proven — 11 green tests (`org.xvm.api.XtcEngineTest`)

1. **Compile Ecstasy source held in a `String`** — no files, no CLI.
2. **Compile from ON-DISK source** (`compile(Path...)`) — a `.x` file or a directory tree, which is what an LSP workspace and a build tool actually have. It runs identically to the in-memory path.
3. **Run the compiled module in a nested container in the same JVM**, awaiting event-driven completion.
4. **The module's `run()` return value reaches the host** — exact `Int` values, and a `void run()` reports no result rather than looking like a failure.
5. **A throwing run completes exceptionally** — the failure path: a run that blows up must not look like one that succeeded.
6. **One warm engine serves repeated compile+run cycles** — the runtime bootstrap is paid once, not per invocation.
7. **Several modules compile in one request**, and all of them run.
8. **Compiled modules sync to disk** (`writeTo`) and reload through a plain `DirRepository`.
9. Diagnostics **stream to the caller's own `ErrorListener`** as they are produced, and a failed compile is self-describing (the result always carries its diagnostics).
10. **A path that is not a module is a diagnostic, not a crash** — an LSP must not die because someone opened the wrong directory.
11. **The engine is usable through the `ToolApi` interface alone.**

Gate: `./gradlew xdk:installDist`, then `./gradlew :javatools:test :javatools_utils:test` — both green. Run them as separate invocations; in one invocation the test's module reads race `installDist`'s writes.

## The changes

| File | Change |
|---|---|
| `MainContainer` | capture the `callLater` future that was being **discarded**; expose `futureResult()` |
| `Container` | add `runModule(String, ObjectHandle...)` returning that completion future |
| `NestedContainer` | add `createForHost(...)`; add a parent injection fallback **only** for host containers (`f_hProvider == null`) — without it a host-run module gets no `Console` and dies with "Invalid resource". Guest containers keep the strict sandbox. |
| `FileStructure` | **bug fix**, see below |
| `DirRepository` | **bug fix** — synchronize the scan cache (also submitted standalone as #547) |
| `api/ToolApi.java` | new — the named CONTRACT a tool embeds; `XtcEngine` implements it, and it is the shape `ToolConnector` targets too |
| `api/XtcEngine.java` | new — the engine: compile pipeline (in-memory **and** on-disk), run, `RunControl`, JFR events |

## Error handling: no frivolous unchecked exceptions

Two deliberate choices, since this is a public API:

- `compile(...)` **propagates the `IOException` that `ModuleRepository.storeModule` declares**, rather than wrapping it in an `IllegalStateException`. A caller that can handle a failed write is given the chance to; one that cannot is not surprised by a `RuntimeException`. It is declared on the `ToolApi` contract too.
- A path that is not a module is ordinary **user** error and becomes a **diagnostic**. The catch is narrow — `IllegalArgumentException`, which is how `ModuleInfo` signals bad input — so it cannot swallow arbitrary `RuntimeException`s and hide real defects. Every failure path logs: an early cut returned null silently and produced "it failed" with zero diagnostics, violating this API's own guarantee that failures are self-describing. The test caught it.

## A master bug this found (deterministic, with a red proof)

`FileStructure.getErrorListener()` read the ambient `ConstantPool.getCurrentPool()` and dereferenced it **with no null check**. That thread-local is null on any thread with no pool bound — i.e. **every Java host thread driving the runtime** — so the embedding path NPE'd inside a *diagnostic accessor*:

```
NullPointerException: Cannot invoke "ConstantPool.getErrorListener()" because "poolCurrent" is null
  at FileStructure.getErrorListener(FileStructure.java:1397)
  at TypeConstant.ensureTypeInfo(TypeConstant.java:1659)
  at Container.findModuleMethod(Container.java:252)
```

Null-guarded here (one line) so the POC can run. **Now submitted standalone as #548**, where the repro turned out to be two lines (construct a `FileStructure`, ask it for its `ErrorListener`) — no engine required. That PR also sets out why expressing pool *ownership* as a thread-local rather than a parameter produces this family of bug repeatedly.

## Known gaps (tracked in `POC-NOTES.md`, not hidden)

1. ~~A module's `run()` return value does not reach the host.~~ **FIXED** — two separate defects, now covered by tests: `ServiceContext.callLater` hardcodes `cReturns = 0`, so the future was told to expect nothing and completed with an empty tuple (`runModule` now calls `postRequest(..., fReturn ? 1 : 0)`); and the native instantiate-and-run op ignored the caller-designated return slot in favour of `A_STACK`, so even once a return was requested the value landed where the service entry frame never reads (it completes from `f_ahVar[0]`).
2. `RunControl.kill()` cancels the caller's wait and releases the container, but does not force-unwind a running fiber.
3. `NativeFunctionHandle` binds to `xRTFunction.INSTANCE.f_container` (a process-static template instance) — fine for a single native plane.
4. ~~No `compile(Path...)` source-tree entry point.~~ **DONE** — `ModuleInfo` walks a module file or directory into the same `TypeCompositionStatement` the in-memory path produces (exactly what the CLI compiler does), so both entry points now share **one** pipeline and the load-bearing stage order lives in a single place.
5. Diagnostics carry a line number but no column/end position; LSP wants a `Range` to underline.
6. No incremental or cancellable compile — an LSP recompiles per keystroke, and today each call is a whole-module compile.
7. No pool-publication fence — sequential work is fine; parallel work needs review.

## What this unlocks, and what each mode still needs

| Mode | Works today? | Still needs |
|---|---|---|
| **Sequential compile** | ✅ proven | in-memory **and** from disk; nothing outstanding |
| **Sequential run** | ✅ proven | results and failures both surface |
| **Parallel compile** | ⚠️ unblocked here | `DirRepository`'s scan-cache race is **fixed** in this branch (and standalone in #547); the other known blocker, the static compiler counters, is **already fixed on master** by #538. Both closed, so this is now a matter of testing it under load. |
| **Parallel run** | ❌ | the shared-pool publication/interning work; this is the deep one |

