### PR TITLE
Fix DirRepository scan-cache data race (blocks parallel compilation)

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/DirRepository.java
+++ b/javatools/src/main/java/org/xvm/asm/DirRepository.java
@@ -25,6 +25,22 @@ import java.util.TreeMap;
 /**
  * A simple ModuleRepository that manages its contents in a directory.
  */
+/*
+ * THREAD SAFETY: the three public entry points below are synchronized on the repository.
+ *
+ * The scan cache is a plain HashMap (modulesByFile, a non-final field reassigned wholesale) and a
+ * plain TreeMap (modulesByName, rebuilt with clear() + a put() loop). Concurrent callers - two
+ * parallel compiles resolving library modules, say - otherwise race those rebuilds against get()
+ * and against the live keySet() view getModuleNames() hands out, which throws
+ * ConcurrentModificationException (and can spin or silently drop entries).
+ *
+ * A coarse per-repository lock is the right granularity here, not a pessimisation: this is a
+ * directory-scan cache consulted once per module lookup, not a hot inner loop. Note that swapping
+ * in concurrent maps, or copy-on-write with a volatile swap, would NOT be sufficient on its own,
+ * because ModuleInfo.ensureModule() ALSO lazily deserializes ("if (module == null) module =
+ * tryLoad()") - two threads would still duplicate that work and could publish a half-built module.
+ * The lock covers both the cache rebuild and the lazy materialization reached through it.
+ */
 public class DirRepository
         implements ModuleRepository {
     // ----- constructors  -------------------------------------------------------------------------
@@ -63,20 +79,20 @@ public class DirRepository
     // ----- ModuleRepository API ------------------------------------------------------------------
 
     @Override
-    public Set<String> getModuleNames() {
+    public synchronized Set<String> getModuleNames() {
         ensureCache();
         return Collections.unmodifiableSet(modulesByName.keySet());
     }
 
     @Override
-    public ModuleStructure loadModule(String sModule) {
+    public synchronized ModuleStructure loadModule(String sModule) {
         ensureCache();
         ModuleInfo info = modulesByName.get(sModule);
         return info == null ? null : info.ensureModule();
     }
 
     @Override
-    public void storeModule(ModuleStructure module)
+    public synchronized void storeModule(ModuleStructure module)
             throws IOException {
         if (m_fRO) {
             throw new IOException("repository is read-only: " + this);

--- a/javatools/src/test/java/org/xvm/asm/DirRepositoryConcurrentScanTest.java
+++ b/javatools/src/test/java/org/xvm/asm/DirRepositoryConcurrentScanTest.java
@@ -1,0 +1,113 @@
+package org.xvm.asm;
+
+
+import java.io.File;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+
+/**
+ * Regression / red-on-master proof for the DirRepository scan-cache race.
+ *
+ * <p>{@code DirRepository} caches its directory scan in a plain {@code HashMap modulesByFile} (a
+ * non-final field reassigned by {@code rebuildCache}) and a plain {@code TreeMap modulesByName}
+ * (rebuilt with {@code clear()} + {@code put()}). On master none of {@code loadModule}/
+ * {@code getModuleNames}/{@code ensureCache}/{@code rebuildCache} is synchronized, so concurrent
+ * callers race {@code clear()}/{@code put()} against {@code get()}/iteration. A fresh repository
+ * starts with {@code lastScan == 0}, so the first concurrent access has every thread run
+ * {@code rebuildCache} on the same maps at once. Two concurrent container-0 compiles reach exactly
+ * this path.</p>
+ *
+ * <p><b>Proven red on master</b> {@code 82683bcd2}: this exact test throws
+ * {@code java.util.ConcurrentModificationException} (verified in a master worktree with
+ * master-built modules parsed into the cache). It passes here because
+ * {@code DirRepository.loadModule}/{@code getModuleNames}/{@code storeModule} are {@code
+ * synchronized} on this branch (the coarse per-repository lock is the correct granularity for a
+ * lookup cache).</p>
+ */
+public class DirRepositoryConcurrentScanTest {
+    private static final File LIB =
+            new File("xdk/build/install/xdk/lib").isDirectory()
+                    ? new File("xdk/build/install/xdk/lib")
+                    : new File("../xdk/build/install/xdk/lib");
+
+    @Test
+    public void concurrentScanDoesNotCorruptTheCache() throws Exception {
+        assumeTrue(LIB.isDirectory(), "need built .xtc modules to feed the repository");
+        File[] xtc = LIB.listFiles((d, n) -> n.endsWith(".xtc"));
+        assumeTrue(xtc != null && xtc.length >= 4, "need several .xtc modules");
+
+        Path dir    = Files.createTempDirectory("dirrepo-race");
+        int  copied = 0;
+        for (File f : xtc) {
+            if (f.getName().equals("ecstasy.xtc")) {
+                continue;   // skip the big one to keep per-scan parse cost low
+            }
+            Files.copy(f.toPath(), dir.resolve(f.getName()));
+            if (++copied >= 6) {
+                break;
+            }
+        }
+        assumeTrue(copied >= 4, "need several small .xtc modules");
+
+        int threads = 8;
+        var pool    = Executors.newFixedThreadPool(threads);
+        var failure = new AtomicReference<Throwable>();
+
+        try {
+            for (int iter = 0; iter < 80 && failure.get() == null; iter++) {
+                var repo    = new DirRepository(dir.toFile(), true);
+                var start   = new CountDownLatch(1);
+                var futures = new ArrayList<Future<?>>();
+                for (int t = 0; t < threads; t++) {
+                    futures.add(pool.submit(() -> {
+                        start.await();
+                        // First concurrent call -> every thread runs rebuildCache (clear()+put())
+                        // on the shared modulesByName TreeMap; iterating the keySet view races it.
+                        int seen = 0;
+                        for (int i = 0; i < 8; i++) {
+                            for (String name : repo.getModuleNames()) {
+                                seen += name.length();
+                            }
+                        }
+                        return seen;
+                    }));
+                }
+                start.countDown();
+                for (Future<?> f : futures) {
+                    try {
+                        f.get(20, TimeUnit.SECONDS);
+                    } catch (ExecutionException e) {
+                        failure.compareAndSet(null, e.getCause());
+                    } catch (TimeoutException e) {
+                        failure.compareAndSet(null, new AssertionError(
+                                "a scan thread hung (corrupted HashMap infinite loop?)", e));
+                    }
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Throwable t = failure.get();
+        if (t != null) {
+            fail("concurrent DirRepository scan corrupted the cache: " + t, t);
+        }
+    }
+}


### PR DESCRIPTION
Fixes a data race in `DirRepository`'s directory-scan cache. Two files: the fix, and a test that is **red on `master` without it**.

## The bug

The scan cache is a plain `HashMap` (`modulesByFile` — a non-final field reassigned wholesale by `rebuildCache`) and a plain `TreeMap` (`modulesByName` — rebuilt with `clear()` followed by a `put()` loop). None of `loadModule`, `getModuleNames`, `ensureCache` or `rebuildCache` is synchronized.

A fresh repository has `lastScan == 0`, so `isCacheValid()` returns false and the **first** concurrent access has *every* thread run `rebuildCache` over the same maps simultaneously. On top of that, `getModuleNames()` returns `Collections.unmodifiableSet(modulesByName.keySet())` — a **live, fail-fast view** of the map being rebuilt.

Two parallel compiles resolving library modules from one repository hit this immediately:

```
java.util.ConcurrentModificationException
  at DirRepository.loadModule(DirRepository.java:91)
  at LinkedRepository.loadModule(LinkedRepository.java:101)
  at FileStructure.linkModules(FileStructure.java:825)
  at NativeContainer.loadNativeTemplates(NativeContainer.java:158)
```

and in principle a spinning corrupted `HashMap` or silently dropped entries ("module not found").

## The fix

Synchronize the three public entry points on the repository.

A coarse per-repository lock is the **right** granularity here rather than a pessimisation: this is a directory-scan cache consulted once per module lookup, not a hot inner loop.

Worth stating explicitly, because it looks like a place to reach for concurrent collections — **that would not be sufficient**. `ModuleInfo.ensureModule()` *also* lazily deserializes:

```java
if (module == null || module.isModified()) {
    module = tryLoad();
}
```

so with concurrent maps (or a copy-on-write volatile swap) two threads would still duplicate that deserialization and could publish a half-built module. The lock covers both the cache rebuild and the lazy materialization reached through it.

## The proof

`DirRepositoryConcurrentScanTest` — 8 threads × 80 iterations over a fresh repository. Verified **in this branch**:

- **without** the fix: fails with `ConcurrentModificationException`
- **with** the fix: passes

One note on the test: it feeds the repository modules the running JVM can actually parse (the freshly built XDK), because a module from a different `.xtc` format version fails to parse and never enters the cache — which would make the test vacuously green.

## Why now

This is the **last remaining blocker for parallel compilation**. The other blocker previously identified — the static compiler counters in `ConditionalStatement`, `ElseExpression`, `ElvisExpression` and `MethodDeclarationStatement` — is already fixed on master by #538 (all four are `AtomicInteger`). With both closed, two compiles of different modules are isolated: each clones library modules into its own build repository, so interning happens per-compile.

Gate: `./gradlew xdk:installDist`, then `./gradlew :javatools:test :javatools_utils:test` — green. (Separate invocations; in one invocation the test's module reads race `installDist`'s writes.)
