### PR TITLE
Fix NPE in FileStructure.getErrorListener() when no ambient pool is bound

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/FileStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/FileStructure.java
@@ -1392,8 +1392,13 @@ public class FileStructure
     public ErrorListener getErrorListener() {
         ErrorListener errs = m_errs;
         if (errs == null) {
+            // getCurrentPool() is an AMBIENT thread-local: it is null on any thread that has not had
+            // a pool pushed onto it, which is every thread driving the compiler or runtime from
+            // ordinary Java code. Dereferencing it unconditionally turned this diagnostic accessor
+            // into an NPE source. Ownership belongs in a parameter, not a thread-local - see the PR
+            // discussion - but the null guard is the minimal, behaviour-preserving fix.
             ConstantPool poolCurrent = ConstantPool.getCurrentPool();
-            if (poolCurrent != m_pool) {
+            if (poolCurrent != null && poolCurrent != m_pool) {
                 errs = poolCurrent.getErrorListener();
             }
         }

--- a/javatools/src/test/java/org/xvm/asm/FileStructureErrorListenerTest.java
+++ b/javatools/src/test/java/org/xvm/asm/FileStructureErrorListenerTest.java
@@ -1,0 +1,45 @@
+package org.xvm.asm;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+
+/**
+ * {@link FileStructure#getErrorListener()} must not depend on an ambient "current pool" being bound
+ * to the calling thread.
+ *
+ * <p>It consulted {@code ConstantPool.getCurrentPool()} - a thread-local - and dereferenced the
+ * result unconditionally. That thread-local is simply {@code null} on any thread that has not had a
+ * pool pushed onto it, which is every thread that drives the compiler or runtime from ordinary Java
+ * code (an embedding host, a build tool, a test). The accessor is a DIAGNOSTIC accessor, so the
+ * failure mode was a {@code NullPointerException} thrown from the very code meant to report
+ * problems.</p>
+ */
+public class FileStructureErrorListenerTest {
+    @Test
+    public void getErrorListenerWorksWithNoAmbientPoolBound() {
+        // a plain FileStructure with no explicit ErrorListener set; this test thread has never had a
+        // pool bound, so getCurrentPool() returns null
+        var file = new FileStructure("test");
+
+        ErrorListener errs = file.getErrorListener();
+
+        assertNotNull(errs, "a diagnostic accessor must never return null");
+        assertSame(ErrorListener.RUNTIME, errs,
+                "with no explicit listener and no ambient pool, the runtime listener is the answer");
+    }
+
+    @Test
+    public void getErrorListenerPrefersAnExplicitlySetListener() {
+        var file = new FileStructure("test");
+        var mine = new ErrorList(10);
+
+        file.setErrorListener(mine);
+
+        assertSame(mine, file.getErrorListener(),
+                "an explicitly supplied listener must win over any fallback");
+    }
+}


### PR DESCRIPTION
Fixes an NPE in `FileStructure.getErrorListener()`. Two files: a one-line guard, and a test that is red on `master` without it.

## The bug

```java
ConstantPool poolCurrent = ConstantPool.getCurrentPool();
if (poolCurrent != m_pool) {
    errs = poolCurrent.getErrorListener();     // NPE when nothing is bound
}
```

`getCurrentPool()` is an **ambient thread-local**. It is `null` on any thread that has not had a pool pushed onto it — which is *every* thread driving the compiler or runtime from ordinary Java code: an embedding host, a build tool, a test harness.

Because this is a **diagnostic accessor**, the failure mode is an NPE thrown from the very code meant to *report* problems, and it surfaces far from its cause:

```
NullPointerException: Cannot invoke "ConstantPool.getErrorListener()" because "poolCurrent" is null
  at FileStructure.getErrorListener(FileStructure.java:1397)
  at XvmStructure.getErrorListener(XvmStructure.java:417)
  at TypeConstant.ensureTypeInfo(TypeConstant.java:1659)
  at Container.findModuleMethod(Container.java:252)
```

## The fix

A null guard. When no pool is bound, fall through to `ErrorListener.RUNTIME` — exactly what the method already does when nothing else is available. When a pool **is** bound, behaviour is unchanged.

## The proof

`FileStructureErrorListenerTest` — the repro is two lines of setup: construct a `FileStructure` and ask it for its `ErrorListener` from an ordinary thread. Verified **in this branch** to fail on `master` with the NPE above and to pass with the guard. A second case pins that an explicitly supplied listener still wins.

---

## Why the ambient pool is the real problem (context, not part of this PR)

The null guard makes the symptom go away. It is worth saying plainly what the shape underneath is, because this is the third or fourth bug of the same family.

`getCurrentPool()` expresses **ownership** — *which* `ConstantPool` this work belongs to — as a **thread-local** rather than a parameter. That has three consequences, and this NPE is only the mildest:

1. **It can be absent.** Any thread that did not go through the code that pushes a pool sees `null`. Nothing in the type system says so, so every reader must remember a null check — and this one did not. That is this bug.

2. **It can be *wrong*, which is worse than absent.** A null fails loudly; a *stale or unrelated* pool fails silently and produces a plausible-looking answer. We hit exactly that in display code: an op's `toString()` read the ambient service context to resolve a constant index, and under a debugger that is whatever fiber happens to be current on the **observing** thread — usually not the frame the op belongs to. It indexed an unrelated method's constant array and printed a misleading value, with the resulting `ArrayIndexOutOfBoundsException` swallowed by a `catch (Throwable)`. Nobody would have noticed.

3. **The compiler cannot help.** With ownership in a parameter, "which pool?" is answered at every call site and checked at compile time. With a thread-local it is answered at runtime by whatever happened to run first, so a wrong answer is indistinguishable from a right one and only shows up as a puzzling crash — or worse, as quiet corruption under concurrency, when two containers or two compiles share a process.

The alternative is unexciting and it works: **pass the pool.** Where a caller genuinely knows the owner — and it almost always does — it can say so:

```java
// instead of the accessor guessing from a thread-local
public ErrorListener getErrorListener(ConstantPool poolCaller) { ... }

// the caller states what it owns
return ensureTypeInfo(getErrorListener(getConstantPool()));
```

That keeps the routing this code was reaching for (a foreign pool's work still reported through that pool's listener) while making the ownership explicit and checkable, instead of hoping the right value happens to be bound to the right thread at the right moment.

I am **not** proposing that change here — this PR is deliberately the minimal fix, and threading a parameter touches call sites that deserve their own review. But if the ambient accessor were removed and the pool passed explicitly, this class of bug would be unrepresentable rather than merely guarded against, and I would rather that were a considered decision than something that erodes one null check at a time.
