### PR TITLE
Publish MethodStructure native/code state safely (volatile)

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/MethodStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/MethodStructure.java
@@ -3106,7 +3106,12 @@ public class MethodStructure
     /**
      * The method's code (for assembling new code).
      */
-    private transient Code m_code;
+    // volatile: ensureCode() lazily creates this while other threads may be reading it, and
+    // markNative()/resetRuntimeInfo() mutate the surrounding state. Without a happens-before edge a
+    // reader can observe a PARTIALLY CONSTRUCTED Code through this reference. See also m_fNative:
+    // the two are read together (ensureCode tests isNative() first), so they must be published
+    // together or a reader can pair a stale flag with a null/incomplete object.
+    private transient volatile Code m_code;
 
     /**
      * The method's AST.
@@ -3132,7 +3137,12 @@ public class MethodStructure
      * True iff the method has been marked as "native". This is not part of the persistent method
      * structure; it exists only to support the prototype interpreter implementation.
      */
-    private transient boolean m_fNative;
+    // volatile: markNative() flips this as part of a multi-step transition (setAbstract,
+    // resetRuntimeInfo, then two field writes) while another thread may be inside
+    // getOps() -> ensureCode(), which reads isNative() before touching m_code. With no edge, that
+    // reader can see the stale native=false together with a null m_code and take the wrong branch -
+    // surfacing as getOps()'s "has no code" IllegalStateException.
+    private transient volatile boolean m_fNative;
 
     /**
      * True iff the method has been marked as "transient". This is not part of the persistent method

--- a/javatools/src/main/java/org/xvm/asm/MethodStructure.java
+++ b/javatools/src/main/java/org/xvm/asm/MethodStructure.java
@@ -1162,9 +1162,6 @@ public class MethodStructure
         setAbstract(false);
         resetRuntimeInfo();
 
-        if (getName().equals("compare") && getIdentityConstant().getNamespace().getName().equals("Const")) {
-            int q= 0;
-        }
         m_fNative    = true;
         m_fTransient = true;
     }

--- a/javatools/src/test/java/org/xvm/asm/MethodStructureVisibilityTest.java
+++ b/javatools/src/test/java/org/xvm/asm/MethodStructureVisibilityTest.java
@@ -1,0 +1,38 @@
+package org.xvm.asm;
+
+
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Pins the memory-visibility contract of {@link MethodStructure}'s native/code state.
+ *
+ * <p>These two fields are written by one thread ({@code markNative()}, {@code ensureCode()}) and
+ * read by others ({@code getOps()} -> {@code ensureCode()} -> {@code isNative()}). They are read
+ * TOGETHER - {@code ensureCode()} tests {@code isNative()} before touching {@code m_code} - so
+ * without a happens-before edge a reader can pair a stale flag with a null or partially constructed
+ * object.</p>
+ *
+ * <p>This is a REGRESSION PIN, not a race reproduction: the data race is provable from the Java
+ * Memory Model but not deterministically reproducible, because the transition runs at link time and
+ * the window does not reliably overlap. What this test does guarantee is that the edge cannot be
+ * silently removed later by someone dropping the modifier.</p>
+ */
+public class MethodStructureVisibilityTest {
+    @Test
+    public void nativeAndCodeStateArePublishedSafely() throws Exception {
+        assertVolatile("m_fNative");
+        assertVolatile("m_code");
+    }
+
+    private static void assertVolatile(String sField) throws Exception {
+        var field = MethodStructure.class.getDeclaredField(sField);
+        assertTrue(Modifier.isVolatile(field.getModifiers()),
+                () -> "MethodStructure." + sField + " must be volatile: it is written by one thread"
+                    + " and read by others with no other happens-before edge");
+    }
+}


### PR DESCRIPTION
Makes `MethodStructure.m_fNative` and `m_code` `volatile`. Two modifiers, plus a test that pins them.

## Why this is needed

These two fields are **written by one thread and read by others**, with no happens-before edge between them — and, crucially, they are **read together**:

```java
public Code ensureCode() {
    if (isNative() || !hasCode()) {      // reads m_fNative
        return null;
    }
    Code code = m_code;                  // then reads m_code
    if (code == null) {
        m_code = code = new Code(this);  // ...and writes it, unsynchronized
    }
    return code;
}
```

Meanwhile `markNative()` performs a **multi-step transition** over that same state:

```java
public void markNative() {
    setAbstract(false);
    resetRuntimeInfo();      // clears cached runtime info
    m_fNative    = true;
    m_fTransient = true;
}
```

With both fields non-volatile there is nothing ordering those writes against those reads, so a racing reader can:

1. **Pair a stale flag with missing state** — observe `native == false` (not yet visible) together with a `m_code` that is still `null`, take the non-native branch, and fail. `getOps()` turns that into a hard `IllegalStateException("... has no code")`.
2. **Observe a partially constructed `Code`** — the plain write `m_code = new Code(this)` can become visible before the object's own initialisation does.
3. **Duplicate the construction** — two threads each build a `Code`. Benign today, but it means "one `Code` per method" is not actually guaranteed.

## Why it matters now rather than in principle

It is not reachable in a strictly single-threaded link-then-run sequence, which is why it has not bitten in the CLI. It becomes reachable the moment a **second thread touches a `MethodStructure`** while another marks it native or forces its code — concurrent compilation, a warm/resident runtime serving repeated work, an embedding host, or a JIT/interpreter mix. Those are all directions the project is actively moving in.

The failure mode is the expensive kind: **intermittent, timing-dependent, and non-reproducible** — an `IllegalStateException` from `getOps()` in a run that worked yesterday, with a stack that points at the reader and says nothing about the writer. Cheap to prevent, extremely tedious to diagnose.

## Why `volatile` and nothing more

This is deliberately the minimal fix:

- **Behaviour-neutral.** No locking is introduced, no hot path is altered, no API changes. Single-threaded behaviour is identical.
- **It fixes the two dangerous cases** (1) and (2) above, which are the ones that corrupt or crash.
- It does **not** close case (3), duplicate construction, which needs a double-checked or synchronized `ensureCode()`. That is a real change to a frequently-called method, so it is deliberately left out of this PR; the duplicate objects are each complete and correct, so the remaining exposure is waste rather than corruption.

## The test

`MethodStructureVisibilityTest` asserts by reflection that both fields are `volatile`.

It is a **regression pin, not a race reproduction**, and the PR should be read that way. The defect is provable from the Java Memory Model but not deterministically reproducible: `markNative()` runs at link time, so the racing window does not reliably overlap without instrumentation. What the test does guarantee is that the edge cannot be silently removed later by someone dropping a modifier — which is exactly how this kind of fix usually regresses. Verified that it fails if either `volatile` is removed.

## Related

Same family as #548 (a diagnostic accessor NPE'ing on an ambient thread-local) and #547 (an unsynchronized scan cache): shared mutable state whose ownership and publication were left implicit. All three were surfaced by driving the compiler and runtime from ordinary Java threads rather than from the CLI's single-threaded path.
