### PR TITLE
Fix Version.isSameAs() indexing the wrong array (oneliner)

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/Version.java
+++ b/javatools/src/main/java/org/xvm/asm/Version.java
@@ -489,7 +489,7 @@ public class Version
         if (cThis != cThat) {
             int[] remaining = cThis > cThat ? thisInts : thatInts;
             for (int i = cShared, c = remaining.length; i < c; ++i) {
-                if (thatInts[i] != 0) {
+                if (remaining[i] != 0) {
                     return false;
                 }
             }

--- a/javatools/src/test/java/org/xvm/asm/VersionTest.java
+++ b/javatools/src/test/java/org/xvm/asm/VersionTest.java
@@ -309,6 +309,40 @@ public class VersionTest {
         assertThrows(IllegalStateException.class, () -> new Version(new int[] {1, -7}, null));
     }
 
+    /**
+     * {@code isSameAs} compares the shared version parts and then requires every part beyond the
+     * shared prefix to be zero, so "1.2.0" and "1.2" are the same version.
+     *
+     * <p>The remainder loop selected the longer array into {@code remaining}, iterated to ITS
+     * length, and then indexed {@code thatInts} anyway. Whenever the receiver was the longer of
+     * the two, that read ran past the end of {@code thatInts}: "1.2.3".isSameAs("1.2") threw
+     * {@link ArrayIndexOutOfBoundsException} rather than returning false, and
+     * "1.2.0".isSameAs("1.2") threw rather than returning true. The reversed direction worked by
+     * accident, because there {@code remaining} IS {@code thatInts}.</p>
+     */
+    @Test
+    public void testIsSameAsAcrossDifferingPartCounts() {
+        // the receiver is longer - the direction that used to throw
+        assertTrue(new Version("1.2.0").isSameAs(new Version("1.2")));
+        assertFalse(new Version("1.2.3").isSameAs(new Version("1.2")));
+
+        // the argument is longer - the direction that always worked
+        assertTrue(new Version("1.2").isSameAs(new Version("1.2.0")));
+        assertFalse(new Version("1.2").isSameAs(new Version("1.2.3")));
+
+        // trailing zeros are ignorable however many there are, in both directions
+        assertTrue(new Version("1.2.0.0").isSameAs(new Version("1.2")));
+        assertTrue(new Version("1.2").isSameAs(new Version("1.2.0.0")));
+
+        // a non-zero part anywhere past the shared prefix still differs
+        assertFalse(new Version("1.2.0.1").isSameAs(new Version("1.2")));
+        assertFalse(new Version("1.2").isSameAs(new Version("1.2.0.1")));
+
+        // equal-length versions are unaffected by the remainder loop
+        assertTrue(new Version("1.2.3").isSameAs(new Version("1.2.3")));
+        assertFalse(new Version("1.2.3").isSameAs(new Version("1.2.4")));
+    }
+
     static VersionTree<String> genTree() {
         VersionTree<String> tree = new VersionTree<>();
         tree.put(new Version("1.0"), "one-oh");


### PR DESCRIPTION
One-liner: `Version.isSameAs()` indexes `thatInts[i]` where it means `remaining[i]`.

```java
int[] remaining = cThis > cThat ? thisInts : thatInts;
for (int i = cShared, c = remaining.length; i < c; ++i) {
    if (thatInts[i] != 0) {          // <-- remaining[i]
```

`remaining` is computed and then never used. The loop bound comes from the longer
array while the indexed array is always `thatInts`, so when the receiver is the
longer of the two the read runs off the end.

The method compares the shared version-part prefix and then requires every part
beyond it to be zero, so `1.2.0` and `1.2` are meant to be the same version. Two
observed consequences:

```java
new Version("1.2.3").isSameAs(new Version("1.2"))
    // ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
    // (expected: false)

new Version("1.2.0").isSameAs(new Version("1.2"))
    // ArrayIndexOutOfBoundsException
    // (expected: true)
```

So the trailing-zeros semantic the method exists to provide never works in that
direction. The reversed direction works only by accident, because there
`remaining` and `thatInts` are the same array — which is why this survived.

**Fix:** index `remaining[i]`. No signature, semantic, or performance change; the
already-correct direction is untouched.

**Test:** `VersionTest.testIsSameAsAcrossDifferingPartCounts` covers both
directions, multiple trailing zeros, a non-zero part past the shared prefix, and
equal-length pairs as a control. Verified red on master before the fix
(`ArrayIndexOutOfBoundsException` at `Version.java:492`) and green after.