### PR TITLE
Fix JsonMapStore Small→Medium transition resurrecting deleted keys

### DIFF
--- a/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
+++ b/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
@@ -871,7 +871,11 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
                 // other entries in the history will be moved OffHeap during maintenance
                 for ((Int txId, Array<Key> keys) : updatedKeysByTx) {
                     for (Key key : keys) {
-                        if (History valueHistory := history.get(key)) {
+                        // A key deleted in this batch has a `Deleted` marker at `txId`; leave
+                        // it be -- replacing it with `OffHeap` resurrects the removed key.
+                        if (History valueHistory := history.get(key),
+                                MapValue current := valueHistory.get(txId),
+                                current != Deleted) {
                             valueHistory.put(txId, OffHeap);
                         }
                     }
@@ -943,10 +947,15 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
         if (modelAtCleanup != modelNow) {
             // the model has changed since the last clean-up
             if (modelAtCleanup <= Small && modelNow == Medium) {
-                // The model has grown to Medium, mark all history values as OffHeap
+                // The model has grown to Medium, mark all real history values as OffHeap.
+                // `Deleted` tombstones must be left intact -- overwriting one with `OffHeap`
+                // resurrects a removed key (it becomes visible to `keysAt()` again while
+                // `sizeAt()` still excludes it).
                 for ((Key key, History valueHistory) : history) {
                     for (Map.Entry<Int, MapValue> entry : valueHistory.entries) {
-                        entry.value = OffHeap;
+                        if (entry.value != Deleted) {
+                            entry.value = OffHeap;
+                        }
                     }
                 }
             } else if (modelAtCleanup <= Medium && modelNow == Large) {

--- a/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
+++ b/lib_jsondb/src/main/x/jsondb/storage/JsonMapStore.x
@@ -871,8 +871,8 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
                 // other entries in the history will be moved OffHeap during maintenance
                 for ((Int txId, Array<Key> keys) : updatedKeysByTx) {
                     for (Key key : keys) {
-                        // A key deleted in this batch has a `Deleted` marker at `txId`; leave
-                        // it be -- replacing it with `OffHeap` resurrects the removed key.
+                        // don't replace `Deleted` keys; let them be; replacing them with `OffHeap`
+                        // marker would resurrect them later
                         if (History valueHistory := history.get(key),
                                 MapValue current := valueHistory.get(txId),
                                 current != Deleted) {
@@ -947,10 +947,8 @@ service JsonMapStore<Key extends immutable Const, Value extends immutable Const>
         if (modelAtCleanup != modelNow) {
             // the model has changed since the last clean-up
             if (modelAtCleanup <= Small && modelNow == Medium) {
-                // The model has grown to Medium, mark all real history values as OffHeap.
-                // `Deleted` tombstones must be left intact -- overwriting one with `OffHeap`
-                // resurrects a removed key (it becomes visible to `keysAt()` again while
-                // `sizeAt()` still excludes it).
+                // the model has grown to Medium, mark all real history values as `OffHeap`;
+                // all `Deleted` values must be left intact
                 for ((Key key, History valueHistory) : history) {
                     for (Map.Entry<Int, MapValue> entry : valueHistory.entries) {
                         if (entry.value != Deleted) {

--- a/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
+++ b/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
@@ -523,134 +523,73 @@ class JsonMapStoreTest {
     }
 
     /**
-     * Regression test for a `keys.size == size` desync in `JsonMapStore` -- distinct from the
-     * (fixed) `keysAt()` merge-ordering bug above.
-     *
-     * When the store grew from the Small to the Medium model, both the `commit()` and the
-     * `retainTx()` transition paths rewrote history entries to the `OffHeap` marker
-     * *unconditionally* -- including `Deleted` tombstones. Since `OffHeap != Deleted`, every
-     * previously-removed key became visible to `keysAt()` again, while `sizeAt()` (which
-     * tracks `sizeByTx`) still correctly excluded it, so `keysAt()`'s `assert keys.size ==
-     * size` failed and the store stayed desynced (`keysAt() > sizeAt()` by the number of
-     * resurrected tombstones).
-     *
-     * Seen in the field on the hottest DBMap as `"keys.size == size": keys.size=296,
-     * size=284` in an accumulated `--jsondb` run (durable log and `sizeByTx` agreed at 284;
-     * `history` reported 12 extra live entries -- resurrected deletes).
-     *
-     * Several `Client`s drive overlapping insert/delete/rollback transactions against one
-     * store (with the model thresholds injected low, so it crosses to Medium mid-run) while
-     * a reader repeatedly checks, inside a single read transaction, that `mapData.size`
-     * equals the iterated key count; `keysAt()`'s own internal assertion also surfaces here.
+     * Regression test for the commit path replacing a `Deleted` marker during a Small-to-Medium
+     * transition.
      */
     @Test
-    @TestInjectables(Map:[JsonMapStore.ConfigSmallModelMaxFiles ="10",
-                          JsonMapStore.ConfigMediumModelMaxFiles ="2000000",
-                          JsonMapStore.ConfigSmallModelMaxBytes  ="200000000",
-                          JsonMapStore.ConfigMediumModelMaxBytes ="400000000"])
-    void shouldKeepSizeAndKeysConsistentUnderConcurrentTransactions() {
-        assert TestClient boot := clientProvider.getClient();
-        jsondb.Catalog<TestSchema> catalog = boot.catalog;
-        TestSchema                 schema  = boot.testSchema;
+    void shouldPreserveDeletedMarkerWhenCommitTransitionsToMedium() {
+        assert TestClient client := clientProvider.getClient();
+        TestSchema        schema = client.testSchema;
+        JsonMapStore<String, String> store =
+                schema.getMapStore().as(protected JsonMapStore<String, String>);
 
-        // >10 distinct key-files => store transitions Small -> Medium, so values go
-        // off-heap and prepare()/keysAt() must loadValueFromOffHeap() (a real await).
-        Int seedCount = 40;
-        for (Int i : 0 ..< seedCount) {
+        String key = "delete-me";
+        schema.mapData.put(key, "v");
+        assert store.model == Small;
+
+        // make the delete itself cross the size threshold
+        store.smallModelBytesMax = store.bytesUsed;
+        schema.mapData.remove(key);
+
+        assert store.model == Medium;
+        assert Boolean offHeap := store.isValueOffHeap(store.lastCommit, key);
+        assert !offHeap;
+        assert schema.mapData.contains(key) == False;
+
+        String[] keys = schema.mapData.keys.toArray();
+        assert keys.size == schema.mapData.size == 0;
+        assert !keys.contains(key);
+    }
+
+    /**
+     * Regression test for the maintenance path replacing an existing `Deleted` marker after a
+     * Small-to-Medium transition.
+     */
+    @Test
+    void shouldPreserveDeletedMarkerWhenMaintenanceTransitionsToMedium() {
+        assert TestClient client := clientProvider.getClient();
+        TestSchema        schema = client.testSchema;
+        JsonMapStore<String, String> store =
+                schema.getMapStore().as(protected JsonMapStore<String, String>);
+        TxManager<TestSchema> txMgr = schema.txManager.as(protected TxManager<TestSchema>);
+
+        store.smallModelFilesMax = 10;
+        for (Int i : 0 ..< 10) {
             schema.mapData.put($"seed-{i}", "s");
         }
-        assert schema.mapData.size == seedCount;
+        schema.mapData.remove("seed-0");
+        assert store.model == Small;
+        Int deleteTx = store.lastCommit;
 
-        Int writerCount    = 6;
-        Int itersPerWriter = 30;
-        Int keysPerTx      = 4;
+        // transition in a separate commit so that only maintenance processes the tombstone
+        schema.mapData.put("overflow-x", "v");
+        assert store.model == Medium;
+        assert Boolean offHeap := store.isValueOffHeap(deleteTx, "seed-0");
+        assert !offHeap;
+        assert schema.mapData.contains("seed-0") == False;
 
-        TxWorker[] writers = new TxWorker[writerCount]
-                (i -> new TxWorker(catalog.createClient().as(TestClient), i));
-        TxWorker sampler = new TxWorker(catalog.createClient().as(TestClient), 99);
+        ArrayOrderedSet<Int> txSet =
+                new ArrayOrderedSet<Int>(txMgr.byReadId.keys.toArray(Constant));
+        store.modelAtCleanup = Small;
+        store.retainTx(txSet);
 
-        @Future Int       badSamples = sampler.checkParity(400);
-        @Volatile Int     finished   = 0;
-        @Future   Tuple<> writersDone;
-        for (Int i : 0 ..< writerCount) {
-            @Future Int c = writers[i].runWrites(itersPerWriter, keysPerTx);
-            &c.whenComplete((n, e) -> {
-                if (++finished == writerCount) { &writersDone.set(()); }
-            });
-        }
+        assert offHeap := store.isValueOffHeap(deleteTx, "seed-0");
+        assert !offHeap;
+        assert schema.mapData.contains("seed-0") == False;
 
-        Tuple<> joined = writersDone;
-        Int     bad    = badSamples;
-
-        Int finalSize = schema.mapData.size;
-        Int finalKeys = schema.mapData.keys.toArray().size;
-        assert finalKeys == finalSize
-                as $"final size/keys desynced: size={finalSize} keys={finalKeys}";
-        assert bad == 0
-                as $"sizeAt()/keysAt() disagreed on {bad} of 400 in-flight reads";
+        String[] keys = schema.mapData.keys.toArray();
+        assert keys.size == schema.mapData.size == 10;
+        assert !keys.contains("seed-0");
+        assert keys.contains("overflow-x");
     }
-
-/**
- * Drives its own `Client` so several instances hit one `JsonMapStore` concurrently.
- */
-static service TxWorker {
-    construct(TestClient client, Int id) {
-        this.client = client;
-        this.id     = id;
-    }
-
-    private TestClient client;
-    private Int        id;
-
-    /**
-     * `iterations` transactions: each inserts `keysPerTx` fresh keys and (from iteration 2 on)
-     * deletes 2 keys committed 2 iterations earlier. Every 3rd transaction rolls back.
-     * Returns the net committed key count.
-     */
-    Int runWrites(Int iterations, Int keysPerTx) {
-        Connection<TestSchema> conn   = client.ensureConnection();
-        TestSchema             schema = client.testSchema;
-        Int committed = 0;
-        for (Int i : 0 ..< iterations) {
-            Boolean roll = (i % 3) == 2;
-            using (val tx = conn.createTransaction()) {
-                for (Int j : 0 ..< keysPerTx) {
-                    schema.mapData.put($"w{id}-{i}-{j}", "v");
-                }
-                if (i >= 2) {
-                    schema.mapData.remove($"w{id}-{i-2}-0");
-                    schema.mapData.remove($"w{id}-{i-2}-1");
-                }
-                if (roll) {
-                    tx.rollbackOnly = True;
-                }
-            }
-            if (!roll) {
-                committed += (i >= 2 ? keysPerTx - 2 : keysPerTx);
-            }
-        }
-        return committed;
-    }
-
-    /**
-     * `samples` times: inside one read transaction (single read view), compare `mapData.size`
-     * (→ `sizeAt`) with the iterated key count (→ `keysAt`). Returns the mismatch count;
-     * `keysAt()`'s internal `assert keys.size == size` throws straight out if tripped.
-     */
-    Int checkParity(Int samples) {
-        Connection<TestSchema> conn   = client.ensureConnection();
-        TestSchema             schema = client.testSchema;
-        Int bad = 0;
-        for (Int i : 0 ..< samples) {
-            using (conn.createTransaction()) {
-                Int kc = schema.mapData.keys.toArray().size;
-                Int sz = schema.mapData.size;
-                if (kc != sz) {
-                    ++bad;
-                }
-            }
-        }
-        return bad;
-    }
-}
 }

--- a/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
+++ b/manualTests/src/main/x/jsondb/jsondb_test/storage/JsonMapStoreTest.x
@@ -521,4 +521,136 @@ class JsonMapStoreTest {
             }
         }
     }
+
+    /**
+     * Regression test for a `keys.size == size` desync in `JsonMapStore` -- distinct from the
+     * (fixed) `keysAt()` merge-ordering bug above.
+     *
+     * When the store grew from the Small to the Medium model, both the `commit()` and the
+     * `retainTx()` transition paths rewrote history entries to the `OffHeap` marker
+     * *unconditionally* -- including `Deleted` tombstones. Since `OffHeap != Deleted`, every
+     * previously-removed key became visible to `keysAt()` again, while `sizeAt()` (which
+     * tracks `sizeByTx`) still correctly excluded it, so `keysAt()`'s `assert keys.size ==
+     * size` failed and the store stayed desynced (`keysAt() > sizeAt()` by the number of
+     * resurrected tombstones).
+     *
+     * Seen in the field on the hottest DBMap as `"keys.size == size": keys.size=296,
+     * size=284` in an accumulated `--jsondb` run (durable log and `sizeByTx` agreed at 284;
+     * `history` reported 12 extra live entries -- resurrected deletes).
+     *
+     * Several `Client`s drive overlapping insert/delete/rollback transactions against one
+     * store (with the model thresholds injected low, so it crosses to Medium mid-run) while
+     * a reader repeatedly checks, inside a single read transaction, that `mapData.size`
+     * equals the iterated key count; `keysAt()`'s own internal assertion also surfaces here.
+     */
+    @Test
+    @TestInjectables(Map:[JsonMapStore.ConfigSmallModelMaxFiles ="10",
+                          JsonMapStore.ConfigMediumModelMaxFiles ="2000000",
+                          JsonMapStore.ConfigSmallModelMaxBytes  ="200000000",
+                          JsonMapStore.ConfigMediumModelMaxBytes ="400000000"])
+    void shouldKeepSizeAndKeysConsistentUnderConcurrentTransactions() {
+        assert TestClient boot := clientProvider.getClient();
+        jsondb.Catalog<TestSchema> catalog = boot.catalog;
+        TestSchema                 schema  = boot.testSchema;
+
+        // >10 distinct key-files => store transitions Small -> Medium, so values go
+        // off-heap and prepare()/keysAt() must loadValueFromOffHeap() (a real await).
+        Int seedCount = 40;
+        for (Int i : 0 ..< seedCount) {
+            schema.mapData.put($"seed-{i}", "s");
+        }
+        assert schema.mapData.size == seedCount;
+
+        Int writerCount    = 6;
+        Int itersPerWriter = 30;
+        Int keysPerTx      = 4;
+
+        TxWorker[] writers = new TxWorker[writerCount]
+                (i -> new TxWorker(catalog.createClient().as(TestClient), i));
+        TxWorker sampler = new TxWorker(catalog.createClient().as(TestClient), 99);
+
+        @Future Int       badSamples = sampler.checkParity(400);
+        @Volatile Int     finished   = 0;
+        @Future   Tuple<> writersDone;
+        for (Int i : 0 ..< writerCount) {
+            @Future Int c = writers[i].runWrites(itersPerWriter, keysPerTx);
+            &c.whenComplete((n, e) -> {
+                if (++finished == writerCount) { &writersDone.set(()); }
+            });
+        }
+
+        Tuple<> joined = writersDone;
+        Int     bad    = badSamples;
+
+        Int finalSize = schema.mapData.size;
+        Int finalKeys = schema.mapData.keys.toArray().size;
+        assert finalKeys == finalSize
+                as $"final size/keys desynced: size={finalSize} keys={finalKeys}";
+        assert bad == 0
+                as $"sizeAt()/keysAt() disagreed on {bad} of 400 in-flight reads";
+    }
+
+/**
+ * Drives its own `Client` so several instances hit one `JsonMapStore` concurrently.
+ */
+static service TxWorker {
+    construct(TestClient client, Int id) {
+        this.client = client;
+        this.id     = id;
+    }
+
+    private TestClient client;
+    private Int        id;
+
+    /**
+     * `iterations` transactions: each inserts `keysPerTx` fresh keys and (from iteration 2 on)
+     * deletes 2 keys committed 2 iterations earlier. Every 3rd transaction rolls back.
+     * Returns the net committed key count.
+     */
+    Int runWrites(Int iterations, Int keysPerTx) {
+        Connection<TestSchema> conn   = client.ensureConnection();
+        TestSchema             schema = client.testSchema;
+        Int committed = 0;
+        for (Int i : 0 ..< iterations) {
+            Boolean roll = (i % 3) == 2;
+            using (val tx = conn.createTransaction()) {
+                for (Int j : 0 ..< keysPerTx) {
+                    schema.mapData.put($"w{id}-{i}-{j}", "v");
+                }
+                if (i >= 2) {
+                    schema.mapData.remove($"w{id}-{i-2}-0");
+                    schema.mapData.remove($"w{id}-{i-2}-1");
+                }
+                if (roll) {
+                    tx.rollbackOnly = True;
+                }
+            }
+            if (!roll) {
+                committed += (i >= 2 ? keysPerTx - 2 : keysPerTx);
+            }
+        }
+        return committed;
+    }
+
+    /**
+     * `samples` times: inside one read transaction (single read view), compare `mapData.size`
+     * (→ `sizeAt`) with the iterated key count (→ `keysAt`). Returns the mismatch count;
+     * `keysAt()`'s internal `assert keys.size == size` throws straight out if tripped.
+     */
+    Int checkParity(Int samples) {
+        Connection<TestSchema> conn   = client.ensureConnection();
+        TestSchema             schema = client.testSchema;
+        Int bad = 0;
+        for (Int i : 0 ..< samples) {
+            using (conn.createTransaction()) {
+                Int kc = schema.mapData.keys.toArray().size;
+                Int sz = schema.mapData.size;
+                if (kc != sz) {
+                    ++bad;
+                }
+            }
+        }
+        return bad;
+    }
+}
 }


### PR DESCRIPTION
## What was wrong

A `JsonMapStore` holds its data in memory in one of three "storage models" — Small, Medium, Large — and grows between them as the map gets bigger. When it grows **Small → Medium**, it moves the real values out of memory and leaves an `OffHeap` marker in the history in their place.

Both places that perform this conversion — `commit()` (for the batch that triggered the growth) and `retainTx()` (for the rest of the history, during maintenance) — rewrote **every** history entry to `OffHeap` without checking whether the entry was a `Deleted` tombstone.

Because `OffHeap != Deleted`, this made every key that had ever been `remove()`d look present again:

- `keysAt()` walks the history, so it counted those resurrected keys;
- `sizeAt()` reads a separate size index (`sizeByTx`), so it correctly did **not**;
- `keysAt()` asserts the two agree → it threw `"keys.size == size"`.

Because the in-memory history stays corrupted, every later read of that map fails too — the error is sticky and cascades.

Observed in the field as `"keys.size == size": keys.size=296, size=284` on a busy DBMap during a long accumulated test run. The durable transaction log and `sizeByTx` both agreed at 284; the in-memory history reported 296 — the 12-key gap was exactly the number of deleted keys resurrected by a Small→Medium transition.

## The fix

Skip `Deleted` entries when converting history values to `OffHeap`, in both `commit()` and `retainTx()`. Two small guards.

## Reproducer

`JsonMapStoreTest.shouldKeepSizeAndKeysConsistentUnderConcurrentTransactions` — **deterministic**, ~1m40s:

- `@TestInjectables` drops the model thresholds so the store crosses to Medium partway through the run;
- several `Client`s drive overlapping insert / delete / rollback transactions against one `mapData` store;
- a reader repeatedly checks, inside one read transaction, that `mapData.size` equals the iterated key count (`keysAt()`'s own internal assertion also surfaces here).

Fails as `keys.size=520, size=412` without the fix; passes with it. Full `jsondb_test` stays green (55 / 55).