### PR TITLE
Fix Op.toName() so Op.toString() cannot throw

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/Op.java
+++ b/javatools/src/main/java/org/xvm/asm/Op.java
@@ -1699,6 +1699,15 @@ public abstract class Op {
         case OP_PIP_DECB:    return "PIP_DECB";
         case OP_PIP_ADD:     return "PIP_ADD";
         case OP_PIP_SUB:     return "PIP_SUB";
+        case OP_PIP_MUL:     return "PIP_MUL";
+        case OP_PIP_DIV:     return "PIP_DIV";
+        case OP_PIP_MOD:     return "PIP_MOD";
+        case OP_PIP_SHL:     return "PIP_SHL";
+        case OP_PIP_SHR:     return "PIP_SHR";
+        case OP_PIP_USHR:    return "PIP_USHR";
+        case OP_PIP_AND:     return "PIP_AND";
+        case OP_PIP_OR:      return "PIP_OR";
+        case OP_PIP_XOR:     return "PIP_XOR";
         case OP_I_GET:       return "I_GET";
         case OP_I_SET:       return "I_SET";
         case OP_IIP_INC:     return "IIP_INC";
@@ -1711,6 +1720,13 @@ public abstract class Op {
         case OP_IIP_SUB:     return "IIP_SUB";
         case OP_IIP_MUL:     return "IIP_MUL";
         case OP_IIP_DIV:     return "IIP_DIV";
+        case OP_IIP_MOD:     return "IIP_MOD";
+        case OP_IIP_SHL:     return "IIP_SHL";
+        case OP_IIP_SHR:     return "IIP_SHR";
+        case OP_IIP_USHR:    return "IIP_USHR";
+        case OP_IIP_AND:     return "IIP_AND";
+        case OP_IIP_OR:      return "IIP_OR";
+        case OP_IIP_XOR:     return "IIP_XOR";
         case OP_CALL_00:     return "CALL_00";
         case OP_CALL_01:     return "CALL_01";
         case OP_CALL_0N:     return "CALL_0N";
@@ -1886,10 +1902,13 @@ public abstract class Op {
     public static final int OP_NEWC_0       = 0x40;
     public static final int OP_NEWC_1       = 0x41;
     public static final int OP_NEWC_N       = 0x42;
+    /** Reserved: the tuple-argument variant of NEWC. Not implemented; the constant holds the
+     *  slot so the contiguous NEWC/NEWCG numbering is not disturbed. See also OP_NEWCG_T. */
     public static final int OP_NEWC_T       = 0x43;
     public static final int OP_NEWCG_0      = 0x44;
     public static final int OP_NEWCG_1      = 0x45;
     public static final int OP_NEWCG_N      = 0x46;
+    /** Reserved: the tuple-argument variant of NEWCG. Not implemented; see OP_NEWC_T. */
     public static final int OP_NEWCG_T      = 0x47;
     public static final int OP_NEWV_0       = 0x48;
     public static final int OP_NEWV_1       = 0x49;

--- a/javatools/src/main/java/org/xvm/asm/Op.java
+++ b/javatools/src/main/java/org/xvm/asm/Op.java
@@ -1902,18 +1902,15 @@ public abstract class Op {
     public static final int OP_NEWC_0       = 0x40;
     public static final int OP_NEWC_1       = 0x41;
     public static final int OP_NEWC_N       = 0x42;
-    /** Reserved: the tuple-argument variant of NEWC. Not implemented; the constant holds the
-     *  slot so the contiguous NEWC/NEWCG numbering is not disturbed. See also OP_NEWCG_T. */
-    public static final int OP_NEWC_T       = 0x43;
+    public static final int OP_NEWC_T       = 0x43; // not implemented
     public static final int OP_NEWCG_0      = 0x44;
     public static final int OP_NEWCG_1      = 0x45;
     public static final int OP_NEWCG_N      = 0x46;
-    /** Reserved: the tuple-argument variant of NEWCG. Not implemented; see OP_NEWC_T. */
-    public static final int OP_NEWCG_T      = 0x47;
+    public static final int OP_NEWCG_T      = 0x47; // not implemented
     public static final int OP_NEWV_0       = 0x48;
     public static final int OP_NEWV_1       = 0x49;
     public static final int OP_NEWV_N       = 0x4A;
-    public static final int OP_NEWV_T       = 0x4B;
+    public static final int OP_NEWV_T       = 0x4B; // not implemented
 
     public static final int OP_RETURN_0     = 0x4C;
     public static final int OP_RETURN_1     = 0x4D;

--- a/javatools/src/test/java/org/xvm/asm/OpNameCoverageTest.java
+++ b/javatools/src/test/java/org/xvm/asm/OpNameCoverageTest.java
@@ -1,0 +1,148 @@
+package org.xvm.asm;
+
+
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Ratchet: every opcode {@code Op.instantiate} can produce must have a name in {@code Op.toName}.
+ *
+ * <p>The two are parallel ~200-case switches over the same domain, and they had drifted by 16
+ * opcodes - the {@code IIP_*} and {@code PIP_*} bitwise, shift and mod forms. Since
+ * {@code Op.toString()} is {@code toName(getOpCode())} and {@code toName}'s default throws, those
+ * 16 opcodes threw {@code IllegalStateException} from {@code toString()}. That is worse than an
+ * ordinary missing case, for two reasons.</p>
+ *
+ * <p>First, {@code toString()} is called IMPLICITLY - by debuggers, by loggers, by string
+ * concatenation - so the failure appears in places that have nothing to do with the opcode.</p>
+ *
+ * <p>Second, and worse, fifteen sites build an error message with {@code toName(getOpCode())}, for
+ * example {@code OpInPlaceAssign}:</p>
+ *
+ * <pre>default -&gt; throw new UnsupportedOperationException(toName(getOpCode()));</pre>
+ *
+ * <p>{@code OpInPlaceAssign} IS the {@code IIP_*} family. So on exactly the opcodes that reach that
+ * line, constructing the intended {@code UnsupportedOperationException} threw
+ * {@code IllegalStateException} instead, destroying the real diagnostic at the moment it was
+ * needed.</p>
+ *
+ * <p>The relationship asserted is a SUBSET, not equality: {@code toName} may legitimately name an
+ * opcode {@code instantiate} does not produce. {@code OP_NEWC_T} and {@code OP_NEWCG_T} are exactly
+ * that - reserved slots holding their place in the contiguous {@code NEWC}/{@code NEWCG} numbering,
+ * unimplemented but deliberately not removed, because removing them invites a renumbering that
+ * would break the binary format.</p>
+ */
+public class OpNameCoverageTest {
+    /**
+     * The static check: no opcode may be instantiable without being nameable. This is the ratchet -
+     * it fails on the next divergence, not just on the sixteen that prompted it.
+     */
+    @Test
+    public void everyInstantiableOpcodeHasAName() throws IOException {
+        String source = Files.readString(opSource());
+
+        Set<String> instantiate = casesIn(source, "public static Op instantiate(",
+                                                  "public static String toName(");
+        Set<String> toName      = casesIn(source, "public static String toName(", null);
+
+        assertTrue(instantiate.size() > 200,
+                "sanity: expected to find the instantiate switch, found " + instantiate.size()
+                + " cases");
+
+        var unnamed = new TreeSet<>(instantiate);
+        unnamed.removeAll(toName);
+
+        assertTrue(unnamed.isEmpty(),
+                () -> "Op.instantiate can produce these opcodes but Op.toName cannot name them: "
+                      + unnamed + ". Op.toString() is toName(getOpCode()) and toName's default"
+                      + " throws, so toString() throws on each of them - including inside the"
+                      + " error messages that 15 sites build with toName(getOpCode()).");
+    }
+
+    /**
+     * The dynamic check: calling {@code toName} on every opcode {@code instantiate} accepts must
+     * actually return a name rather than throw. The static check reads source; this one runs the
+     * method, so a case that exists but falls through still fails here.
+     */
+    @Test
+    public void toNameDoesNotThrowForAnyInstantiableOpcode() throws Exception {
+        String source = Files.readString(opSource());
+
+        Set<String> instantiate = casesIn(source, "public static Op instantiate(",
+                                                  "public static String toName(");
+        var failures = new ArrayList<String>();
+
+        for (String sConstant : instantiate) {
+            int nOp = Op.class.getDeclaredField(sConstant).getInt(null);
+            try {
+                String sName = Op.toName(nOp);
+                if (sName == null || sName.isEmpty()) {
+                    failures.add(sConstant + " -> " + sName);
+                }
+            } catch (RuntimeException e) {
+                failures.add(sConstant + " -> " + e);
+            }
+        }
+
+        assertTrue(failures.isEmpty(),
+                () -> "Op.toName threw or returned nothing for: " + failures);
+    }
+
+    /**
+     * A spot check on the specific opcode that proved the bug, so the regression has a named,
+     * readable case rather than only appearing inside a set difference.
+     */
+    @Test
+    public void theOpcodeThatProvedTheBugIsNamed() {
+        assertEquals("IIP_AND", assertDoesNotThrow(() -> Op.toName(Op.OP_IIP_AND)));
+        assertEquals("PIP_XOR", assertDoesNotThrow(() -> Op.toName(Op.OP_PIP_XOR)));
+        assertEquals("LINE_1",  Op.toName(Op.OP_LINE_1));
+    }
+
+    /**
+     * Extract the {@code case OP_*} labels between two markers in the source.
+     *
+     * @param source  the source text
+     * @param sFrom   the marker the region starts at
+     * @param sTo     the marker the region ends at, or null for "to the end"
+     */
+    private static Set<String> casesIn(String source, String sFrom, String sTo) {
+        int of = source.indexOf(sFrom);
+        assertTrue(of >= 0, "marker not found: " + sFrom);
+
+        int ofEnd = sTo == null ? source.length() : source.indexOf(sTo, of);
+        assertTrue(ofEnd > of, "end marker not found after start: " + sTo);
+
+        var     names   = new TreeSet<String>();
+        Matcher matcher = CASE_LABEL.matcher(source.substring(of, ofEnd));
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    private static Path opSource() {
+        Path cwd     = Path.of("").toAbsolutePath();
+        Path project = cwd.resolve("src/main/java/org/xvm/asm/Op.java");
+        return Files.exists(project)
+                ? project
+                : cwd.resolve("javatools/src/main/java/org/xvm/asm/Op.java");
+    }
+
+    private static final Pattern CASE_LABEL = Pattern.compile("case\\s+(OP_\\w+)\\s*:");
+}


### PR DESCRIPTION
`Op.instantiate` switches **215** opcodes; `Op.toName` switches **201**. The 16 in the gap all have op classes and are instantiated:

```
IIP_AND IIP_MOD IIP_OR IIP_SHL IIP_SHR IIP_USHR IIP_XOR
PIP_AND PIP_DIV PIP_MOD PIP_MUL PIP_OR PIP_SHL PIP_SHR PIP_USHR PIP_XOR
```

`Op.toString()` is `toName(getOpCode())`, and `toName`'s default throws:

```
Op.toName(0xDD)  ->  java.lang.IllegalStateException: op=0xdd     (IIP_AND)
Op.toName(0x01)  ->  LINE_1
```

**Why this is worse than an ordinary missing case.** `toString()` is called *implicitly* — by debuggers, by loggers, by string concatenation — so the failure surfaces far from the opcode that caused it.

**And it destroys diagnostics.** Fifteen sites build an error message with `toName(getOpCode())`, for example `OpInPlaceAssign`:

```java
default -> throw new UnsupportedOperationException(toName(getOpCode()));
```

`OpInPlaceAssign` **is** the `IIP_*` family. So on exactly the opcodes that reach that line, constructing the intended `UnsupportedOperationException` throws `IllegalStateException` instead — the real diagnostic is lost at the moment it is needed.

**On `OP_NEWC_T` / `OP_NEWCG_T`** — the reverse drift: named by `toName`, never instantiated. They are **not** dead code and are deliberately kept. `_T` is a real family variant (`NEW_T` and `NEWG_T` are both implemented), and `0x43`/`0x47` sit inside the contiguous `NEWC`/`NEWCG` numbering — removing them invites a renumbering that would break the binary format. They are now documented as reserved.

**Test.** `OpNameCoverageTest` has three cases: a static check that `instantiate`'s case set is a **subset** of `toName`'s (subset, not equality, so the two reserved names stay legal); a dynamic check that actually calls `Op.toName` for every instantiable opcode, catching a case that exists but falls through; and a named spot check on `IIP_AND`/`PIP_XOR` with `LINE_1` as a control. All three verified red on unfixed master and green after.