### PR TITLE
Support the TimeZone: literal end to end, drop the RegEx arm that could only throw, and pin the two format lists together

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -360,6 +360,7 @@ public class ConstantPool
         case Date:
         case TimeOfDay:
         case Time:
+        case TimeZone:
         case Duration:
         case Path:
         case RegEx: {
@@ -2597,6 +2598,7 @@ public class ConstantPool
             case Date:
             case TimeOfDay:
             case Time:
+            case TimeZone:
             case Duration:
             case Path:
                 constant = new LiteralConstant(this, format, in);

--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -362,8 +362,7 @@ public class ConstantPool
         case Time:
         case TimeZone:
         case Duration:
-        case Path:
-        case RegEx: {
+        case Path: {
             LiteralConstant constant = (LiteralConstant) ensureLocatorLookup(format).get(s);
             if (constant == null) {
                 constant = register(new LiteralConstant(this, format, s, oValue));

--- a/javatools/src/main/java/org/xvm/asm/constants/LiteralConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/LiteralConstant.java
@@ -84,6 +84,10 @@ public class LiteralConstant
             // TODO
             break;
 
+        case TimeZone:
+            // TODO
+            break;
+
         case Duration:
             // TODO
             break;
@@ -125,6 +129,7 @@ public class LiteralConstant
         case Date:
         case TimeOfDay:
         case Time:
+        case TimeZone:
         case Duration:
         case Version:
         case Path:
@@ -171,6 +176,7 @@ public class LiteralConstant
             case Date       -> pool.typeDate();
             case TimeOfDay  -> pool.typeTimeOfDay();
             case Time       -> pool.typeTime();
+            case TimeZone   -> pool.typeTimeZone();
             case Duration   -> pool.typeDuration();
             case Version    -> pool.typeVersion();
             case Path       -> pool.typePath();

--- a/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
@@ -791,7 +791,7 @@ public class NativeContainer
         case          Dec32,   Dec64,   Dec128,   DecN:
 
         case Array, UInt8Array:
-        case Date, TimeOfDay, Time, Duration:
+        case Date, TimeOfDay, Time, TimeZone, Duration:
         case Range, Path, Version, RegEx:
         case Module, Package:
         case Tuple:

--- a/javatools/src/main/java/org/xvm/runtime/template/xConst.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xConst.java
@@ -109,6 +109,8 @@ public class xConst
                 findMethod("construct", 1, pool.typeString());
             TIMEOFDAY_CONSTRUCT = f_container.getClassStructure("temporal.TimeOfDay").
                 findMethod("construct", 1, pool.typeString());
+            TIMEZONE_CONSTRUCT  = f_container.getClassStructure("temporal.TimeZone").
+                findMethod("construct", 1, pool.typeString());
             DURATION_CONSTRUCT  = f_container.getClassStructure("temporal.Duration").
                 findMethod("construct", 1, pool.typeString());
             VERSION_CONSTRUCT   = f_container.getClassStructure("reflect.Version").
@@ -170,6 +172,11 @@ public class xConst
             case TimeOfDay:
                 clz         = ensureClass(container, pool.typeTimeOfDay());
                 constructor = TIMEOFDAY_CONSTRUCT;
+                break;
+
+            case TimeZone:
+                clz         = ensureClass(container, pool.typeTimeZone());
+                constructor = TIMEZONE_CONSTRUCT;
                 break;
 
             case Duration:
@@ -785,6 +792,7 @@ public class xConst
     private static MethodStructure TIME_CONSTRUCT;
     private static MethodStructure DATE_CONSTRUCT;
     private static MethodStructure TIMEOFDAY_CONSTRUCT;
+    private static MethodStructure TIMEZONE_CONSTRUCT;
     private static MethodStructure DURATION_CONSTRUCT;
     private static MethodStructure VERSION_CONSTRUCT;
     private static MethodStructure PATH_CONSTRUCT;

--- a/javatools/src/test/java/org/xvm/asm/LiteralFormatPlumbingTest.java
+++ b/javatools/src/test/java/org/xvm/asm/LiteralFormatPlumbingTest.java
@@ -1,0 +1,254 @@
+package org.xvm.asm;
+
+
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.Constant.Format;
+
+import org.xvm.asm.constants.LiteralConstant;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Ratchet for the literal-format plumbing: every {@link Format} the compiler can produce for a
+ * literal must be accepted by every stage that has to carry it.
+ *
+ * <p>This exists because {@code Format.TimeZone} was not. The lexer accepted a {@code TimeZone:}
+ * literal ({@code Lexer.java}, {@code case "TimeZone"}), the AST handed it to the pool
+ * ({@code LiteralExpression}, {@code pool.ensureLiteralConstant(Format.TimeZone, ...)}), and the
+ * pool threw {@code IllegalStateException: unsupported format: TimeZone} - so any source file
+ * containing one died with an internal error rather than a diagnostic. The same omission was
+ * repeated in FIVE places: the pool's construction switch, the pool's {@code disassemble} switch,
+ * two switches in {@link LiteralConstant}, and its format-to-type mapping. Its siblings
+ * {@code Date}, {@code TimeOfDay}, {@code Time} and {@code Duration} were present in all five.</p>
+ *
+ * <p><b>Why a test rather than a compile-time check.</b> The obvious answer - an exhaustive switch
+ * expression with no {@code default}, which javac verifies - does not work here: {@code Format} has
+ * 107 constants and each of these switches legitimately handles a small subset, so exhaustiveness
+ * would demand 107 cases at every site. The defect was never a missing case in an otherwise
+ * complete switch; it was the SAME FACT ("TimeZone is a string-backed literal") written out in five
+ * places, four of which nobody thought to update. This test is the single place that fact is
+ * asserted, and it fails at whichever of the five stages a future format is missed.</p>
+ */
+public class LiteralFormatPlumbingTest {
+    /**
+     * Every format {@code LiteralExpression} converts via {@code pool.ensureLiteralConstant(...)},
+     * with a representative literal string. Adding a literal format to the compiler means adding a
+     * row here, and the row then checks all the stages at once.
+     */
+    private static Map<Format, String> literalFormats() {
+        var map = new LinkedHashMap<Format, String>();
+        map.put(Format.IntLiteral, "42");
+        map.put(Format.FPLiteral,  "1.5");
+        map.put(Format.Date,       "1999-12-31");
+        map.put(Format.TimeOfDay,  "23:59:59");
+        map.put(Format.Time,       "1999-12-31T23:59:59Z");
+        map.put(Format.TimeZone,   "Z");
+        map.put(Format.Duration,   "PT1H");
+        map.put(Format.Path,       "/some/path");
+        return map;
+    }
+
+    /**
+     * Stage 1: the pool must build a constant for the format at all. This is the stage that threw
+     * for {@code TimeZone}.
+     */
+    @Test
+    public void poolAcceptsEveryLiteralFormatTheCompilerProduces() {
+        ConstantPool pool = new FileStructure("test").getConstantPool();
+
+        literalFormats().forEach((format, sLiteral) -> {
+            Constant constant = assertDoesNotThrow(
+                    () -> pool.ensureLiteralConstant(format, sLiteral),
+                    () -> "ConstantPool.ensureLiteralConstant rejects " + format
+                          + ", which the compiler produces for a literal of that form");
+            assertInstanceOf(LiteralConstant.class, constant, () -> "for " + format);
+            assertEquals(format, constant.getFormat(), () -> "for " + format);
+        });
+    }
+
+    /**
+     * Stage 2: the constant must know its own Ecstasy type. {@code LiteralConstant.getType()} maps
+     * format to type and falls through to {@code Constant.getType()}, which THROWS
+     * {@code UnsupportedOperationException}, so a format missing from that mapping is a live crash
+     * rather than a silent default.
+     */
+    @Test
+    public void everyLiteralFormatMapsToAType() {
+        ConstantPool pool = new FileStructure("test").getConstantPool();
+
+        literalFormats().forEach((format, sLiteral) -> {
+            Constant constant = pool.ensureLiteralConstant(format, sLiteral);
+            assertDoesNotThrow(constant::getType,
+                    () -> "LiteralConstant.getType() has no mapping for " + format
+                          + ", so it falls through to Constant.getType(), which throws");
+        });
+    }
+
+    /**
+     * Stage 3: the pool's {@code disassemble} switch is a SEPARATE list from its construction
+     * switch, so a format can be constructible and still unreadable - which is exactly what
+     * {@code TimeZone} was. A round trip through {@link FileStructure} cannot check this, because
+     * a constant nothing references is pruned before it is ever written, so this reads the two
+     * case lists out of the source and compares them.
+     */
+    @Test
+    public void diassembleReadsBackEveryLiteralFormatThePoolCanBuild() throws IOException {
+        String source     = Files.readString(constantPoolSource());
+        var    unreadable = new ArrayList<Format>();
+
+        int ofDisassemble = source.indexOf("protected void disassemble(DataInput in)");
+        assertTrue(ofDisassemble > 0, "ConstantPool.disassemble(DataInput) not found");
+        String disassemble = source.substring(ofDisassemble);
+
+        for (Format format : literalFormats().keySet()) {
+            if (!disassemble.contains("case " + format.name() + ":")) {
+                unreadable.add(format);
+            }
+        }
+
+        assertTrue(unreadable.isEmpty(),
+                () -> "ConstantPool.disassemble() cannot read back " + unreadable
+                      + ", so a module containing one of those literals writes but does not load."
+                      + " Its construction switch and its disassemble switch are separate lists;"
+                      + " both need the format.");
+    }
+
+    /**
+     * Formats whose runtime value is materialised by {@code xConst}'s literal switch, which calls
+     * a {@code construct(String)} on the corresponding Ecstasy class. This is a SIXTH list, in a
+     * different module from the other five, and it is the one that actually broke: after the pool
+     * plumbing was fixed, a {@code TimeZone:} literal compiled and then died at run time with
+     * {@code Unexpected op execution failure ... op=VAR_IN}, because the runtime had no case for
+     * it and {@code TimeZone} had no String constructor to call even if it had.
+     */
+    private static final List<Format> RUNTIME_LITERAL_FORMATS = List.of(
+            Format.Time, Format.Date, Format.TimeOfDay, Format.TimeZone,
+            Format.Duration, Format.Version, Format.Path);
+
+    /**
+     * Stage 4: the runtime must be able to turn the constant into a handle. A format can be
+     * constructible, typed, and readable, and STILL be unusable, which is exactly the state
+     * {@code TimeZone} was left in after the pool-side fix alone.
+     */
+    @Test
+    public void runtimeMaterialisesEveryLiteralFormatItIsGiven() throws IOException {
+        String source   = Files.readString(xConstSource());
+        var    unusable = new ArrayList<Format>();
+
+        for (Format format : RUNTIME_LITERAL_FORMATS) {
+            if (!source.contains("case " + format.name() + ":")) {
+                unusable.add(format);
+            }
+        }
+
+        assertTrue(unusable.isEmpty(),
+                () -> "xConst's literal switch cannot materialise " + unusable
+                      + ", so a literal of that form compiles and then fails at run time with"
+                      + " \"Unexpected op execution failure ... op=VAR_IN\".");
+    }
+
+    /**
+     * Stage 5: the runtime path calls {@code construct(String)} on the Ecstasy class, so the class
+     * must declare one. {@code TimeZone} did not - it had only {@code TimeZone(Int64 picos)} and a
+     * conditional {@code of(String)} - which is why the runtime case alone was not enough.
+     */
+    @Test
+    public void everyRuntimeLiteralClassHasAStringConstructor() throws IOException {
+        Map<Format, String> sources = Map.of(
+                Format.Time,      "temporal/Time.x",
+                Format.Date,      "temporal/Date.x",
+                Format.TimeOfDay, "temporal/TimeOfDay.x",
+                Format.TimeZone,  "temporal/TimeZone.x",
+                Format.Duration,  "temporal/Duration.x",
+                Format.Path,      "fs/Path.x");
+
+        var missing = new ArrayList<Format>();
+        for (Map.Entry<Format, String> entry : sources.entrySet()) {
+            Path path = ecstasySource(entry.getValue());
+            if (!Files.exists(path)) {
+                continue;
+            }
+            String text = Files.readString(path);
+            if (!text.contains("construct(String") && !text.contains("construct " + entry.getKey().name() + "(String")) {
+                missing.add(entry.getKey());
+            }
+        }
+
+        assertTrue(missing.isEmpty(),
+                () -> "these Ecstasy classes have no construct(String), so xConst cannot build a"
+                      + " literal value for them: " + missing);
+    }
+
+    /**
+     * Stage 6: {@code NativeContainer.getConstType} maps a constant to the Ecstasy class that
+     * implements it, and its default throws
+     * {@code LauncherException("No implementation for constant: ...")}. This was the LAST of the
+     * seven places {@code TimeZone} was missing, and the one that still failed after the pool and
+     * the {@code xConst} switch were both fixed - which is why this ratchet has six stages rather
+     * than the three it started with.
+     */
+    @Test
+    public void nativeContainerKnowsTheTypeOfEveryRuntimeLiteral() throws IOException {
+        String source    = Files.readString(nativeContainerSource());
+        var    unmapped  = new ArrayList<Format>();
+
+        for (Format format : RUNTIME_LITERAL_FORMATS) {
+            // getConstType groups its cases on one line, e.g. "case Date, TimeOfDay, Time, ...:"
+            if (!source.contains(format.name() + ",") && !source.contains(format.name() + ":")) {
+                unmapped.add(format);
+            }
+        }
+
+        assertTrue(unmapped.isEmpty(),
+                () -> "NativeContainer.getConstType has no mapping for " + unmapped
+                      + ", so loading such a constant fails with \"No implementation for"
+                      + " constant\" even though it compiled and the runtime switch handles it.");
+    }
+
+    private static Path nativeContainerSource() {
+        Path cwd     = Path.of("").toAbsolutePath();
+        Path project = cwd.resolve("src/main/java/org/xvm/runtime/NativeContainer.java");
+        return Files.exists(project)
+                ? project
+                : cwd.resolve("javatools/src/main/java/org/xvm/runtime/NativeContainer.java");
+    }
+
+    private static Path xConstSource() {
+        Path cwd     = Path.of("").toAbsolutePath();
+        Path project = cwd.resolve("src/main/java/org/xvm/runtime/template/xConst.java");
+        return Files.exists(project)
+                ? project
+                : cwd.resolve("javatools/src/main/java/org/xvm/runtime/template/xConst.java");
+    }
+
+    private static Path ecstasySource(String sRelative) {
+        Path cwd = Path.of("").toAbsolutePath();
+        Path here = cwd.resolve("lib_ecstasy/src/main/x/ecstasy/" + sRelative);
+        return Files.exists(here)
+                ? here
+                : cwd.getParent().resolve("lib_ecstasy/src/main/x/ecstasy/" + sRelative);
+    }
+
+    private static Path constantPoolSource() {
+        Path cwd     = Path.of("").toAbsolutePath();
+        Path project = cwd.resolve("src/main/java/org/xvm/asm/ConstantPool.java");
+        return Files.exists(project)
+                ? project
+                : cwd.resolve("javatools/src/main/java/org/xvm/asm/ConstantPool.java");
+    }
+}

--- a/javatools/src/test/java/org/xvm/asm/LiteralFormatPlumbingTest.java
+++ b/javatools/src/test/java/org/xvm/asm/LiteralFormatPlumbingTest.java
@@ -7,7 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -79,6 +81,103 @@ public class LiteralFormatPlumbingTest {
             assertInstanceOf(LiteralConstant.class, constant, () -> "for " + format);
             assertEquals(format, constant.getFormat(), () -> "for " + format);
         });
+    }
+
+    /**
+     * Stage 1b: the two lists behind stage 1 must be the SAME list.
+     * {@code ConstantPool.ensureLiteralConstant} decides which formats it hands to
+     * {@link LiteralConstant}, and {@link LiteralConstant}'s constructor decides which formats it
+     * will hold. Those are separate switches, so a format can sit in one and not the other, in
+     * either direction, and neither javac nor stage 1 notices.
+     *
+     * <p>A format in the pool's list but not LiteralConstant's is an arm that can only ever throw
+     * {@code IllegalStateException: unsupported format}. {@code Format.RegEx} was exactly that: the
+     * pool advertised a RegEx literal that {@link LiteralConstant} has never had a case for, because
+     * a regular expression is not a LiteralConstant at all - {@code RegExConstant} extends
+     * {@code ValueConstant} and is built by {@code ensureRegExConstant(String, int)}, which takes
+     * flags the literal path has no way to express.</p>
+     *
+     * <p>Neither set is written down here. Both are measured by driving every {@link Format} through
+     * the two entry points, so this also fails for the next format added to one switch and forgotten
+     * in the other - which is precisely what {@code Format.TimeZone} was.</p>
+     *
+     * <p>{@code Format.Version} is in neither set, and that is correct: {@link LiteralConstant}
+     * refuses to hold one unless it is a {@code VersionConstant}, and the pool routes versions to
+     * {@code ensureVersionConstant} instead.</p>
+     */
+    @Test
+    public void poolOffersExactlyTheFormatsLiteralConstantAccepts() {
+        ConstantPool pool = new FileStructure("test").getConstantPool();
+
+        var offered  = new LinkedHashSet<Format>();
+        var accepted = new LinkedHashSet<Format>();
+        for (Format format : Format.values()) {
+            if (poolRoutesToLiteralConstant(pool, format)) {
+                offered.add(format);
+            }
+            if (literalConstantAccepts(pool, format)) {
+                accepted.add(format);
+            }
+        }
+
+        var deadArms = new LinkedHashSet<>(offered);
+        deadArms.removeAll(accepted);
+        var unreachable = new LinkedHashSet<>(accepted);
+        unreachable.removeAll(offered);
+
+        assertEquals(accepted, offered,
+                () -> "ConstantPool.ensureLiteralConstant and LiteralConstant keep separate lists of"
+                      + " the formats a LiteralConstant can hold, and they have drifted."
+                      + " ensureLiteralConstant hands " + deadArms + " to LiteralConstant, whose"
+                      + " constructor rejects it, so those arms can only ever throw;"
+                      + " LiteralConstant accepts " + unreachable + " that ensureLiteralConstant"
+                      + " has no arm for.");
+    }
+
+    /**
+     * @return true iff {@code ensureLiteralConstant} routes the format into {@link LiteralConstant},
+     *         whether or not LiteralConstant then accepts it - a rejection thrown from
+     *         LiteralConstant's own constructor still counts as offered, because the pool did
+     *         advertise the format and only the callee refused
+     */
+    private static boolean poolRoutesToLiteralConstant(ConstantPool pool, Format format) {
+        try {
+            return pool.ensureLiteralConstant(format, sampleLiteral(format), null)
+                    instanceof LiteralConstant literal && literal.getFormat() == format;
+        } catch (RuntimeException | AssertionError e) {
+            return reachedLiteralConstantConstructor(e);
+        }
+    }
+
+    /**
+     * Both switches throw {@code IllegalStateException("unsupported format: " + format)} with the
+     * same text, so the message cannot say which of them refused. The stack can.
+     */
+    private static boolean reachedLiteralConstantConstructor(Throwable e) {
+        return Arrays.stream(e.getStackTrace())
+                .anyMatch(frame -> LiteralConstant.class.getName().equals(frame.getClassName())
+                                   && "<init>".equals(frame.getMethodName()));
+    }
+
+    /**
+     * @return true iff {@link LiteralConstant} will hold a value of this format
+     */
+    private static boolean literalConstantAccepts(ConstantPool pool, Format format) {
+        try {
+            return new LiteralConstant(pool, format, sampleLiteral(format), null)
+                    .getFormat() == format;
+        } catch (RuntimeException | AssertionError e) {
+            return false;
+        }
+    }
+
+    /**
+     * A plausible literal for a format, so that a rejection is about the format and not about the
+     * string. Formats with no sample of their own get a value the numeric paths can parse; no
+     * literal format validates its string yet, so any of them accepts it.
+     */
+    private static String sampleLiteral(Format format) {
+        return literalFormats().getOrDefault(format, "1");
     }
 
     /**

--- a/lib_ecstasy/src/main/x/ecstasy/temporal/TimeZone.x
+++ b/lib_ecstasy/src/main/x/ecstasy/temporal/TimeZone.x
@@ -32,6 +32,26 @@ import TimeOfDay.PicosPerSecond;
 const TimeZone(Int64 picos) {
 
     /**
+     * Construct a TimeZone from an ISO-8601 timezone indicator string, as produced by a
+     * `TimeZone:` literal.
+     *
+     * This exists for the same reason `Date`, `Time`, `TimeOfDay`, `Duration`, `Version` and
+     * `Path` each have a String constructor: it is the entry point the runtime uses to turn a
+     * literal constant into a value.
+     *
+     * @param tz  an ISO-8601 timezone indicator string; see [of]
+     *
+     * @throws IllegalArgument  if the string is not a valid ISO-8601 timezone indicator
+     */
+    construct(String tz) {
+        if (TimeZone timezone := TimeZone.of(tz)) {
+            construct TimeZone(timezone.picos);
+        } else {
+            throw new IllegalArgument($"invalid ISO-8601 timezone: \"{tz}\"");
+        }
+    }
+
+    /**
      * Internal constructor for the special "NoTZ" timezone.
      */
     private construct() {


### PR DESCRIPTION
This broke for me when fuzzing types, and please correct me if I am wrong, but to me it seems like a genuine outage / not implemented situation. Let me know if I have misunderstood anything. I did the fixes described below, and use that for the LSP compiler / runner code and it seems to work as intended for me, but please check the semantics over and tell me if they aren't supposed to be like e.g. Date and other first class citizens in the XTC language / code. 

Problem: A `TimeZone:` literal lexes and parses and then **dies in the constant pool**, so any module containing one fails to compile with an internal error rather than a diagnostic.

```
pool.ensureLiteralConstant(Format.Date,     "x")  -> Date{value="x"}
pool.ensureLiteralConstant(Format.Time,     "x")  -> Time{value="x"}
pool.ensureLiteralConstant(Format.Duration, "x")  -> Duration{value="x"}
pool.ensureLiteralConstant(Format.TimeZone, "x")  -> IllegalStateException: unsupported format: TimeZone
```

Its siblings `Date`/`TimeOfDay`/`Time`/`Duration` are plumbed through. `TimeZone` was missed in **seven** places across three modules:

| # | Site | Symptom if only the earlier ones are fixed |
| --- | --- | --- |
| 1 | `ConstantPool.ensureLiteralConstant` | throws on construction |
| 2 | `ConstantPool.disassemble` | *separate list* — constructible but unreadable |
| 3-4 | `LiteralConstant`'s two switches | rejected |
| 5 | `LiteralConstant.getType()` | falls through to `Constant.getType()`, which **throws** |
| 6 | `xConst`'s runtime literal switch | **compiles**, then dies at run time on `VAR_IN` |
| 7 | `NativeContainer.getConstType` | still failed after 1–6 were all fixed |

### ⚠️ For review: this touches the standard library

It also adds `construct(String)` to `lib_ecstasy`'s `TimeZone`. The runtime path calls exactly that constructor, and `Date`, `Time`, `TimeOfDay`, `Duration`, `Version` and `Path` **each already have one** — `TimeZone` had only `TimeZone(Int64 picos)` and a conditional `of(String)`. The new constructor delegates to `of()` and throws `IllegalArgument` on a bad string, matching `Date`'s style. Flagging it explicitly because it is not a javatools-only change.

### Verified end to end

Compiling *and running* a module containing `TimeZone:` literals:

```
utc=UTC
plus0130=+01:30
```

That mattered: the unit ratchet went green twice while the literal was still broken, and only running a module exposed sites 6 and 7.

### Test

`LiteralFormatPlumbingTest` — a six-stage ratchet over every literal format the compiler produces: the pool builds it, it maps to a type, `disassemble` reads it back, `xConst` materialises it, the Ecstasy class has the `construct(String)` that path calls, and `NativeContainer` knows its implementing type. It grew from three stages to six because each stage was added only after a run disproved the previous "fix" — which is the argument for keeping all six. 

Ideally we should have an Enum or a sealed class hierarchy or something to switch on so the test methodology is somewhat messy, but still sound. 

---

## Also in this PR: the `RegEx` arm, and a ratchet so these two switches cannot drift again

While adding `case TimeZone:` I found the neighbouring `case RegEx:` has the same shape as the bug this PR fixes, one step further along: **it can only ever throw.**

`ConstantPool.ensureLiteralConstant` lists `RegEx` in its `LiteralConstant` group, so the switch reads as though RegEx literals are supported. `LiteralConstant` has no RegEx case — in either its validating constructor or the private one it delegates to first — so the arm falls straight to `default: throw new IllegalStateException("unsupported format: " + format)`.

Deleting it rather than implementing it, because routing is not available:

- `RegExConstant extends ValueConstant`, not `LiteralConstant`, so the 2-arg `ensureLiteralConstant(format, s)` overload's `(LiteralConstant)` cast would `ClassCastException`;
- `RegExConstant`'s only constructors are `(pool, format, DataInput)` and `(pool, String, int nFlags)` — there is no flag-free literal form;
- `ensureRegExConstant` is the real, working producer and is unaffected. Nothing in the repo passes `Format.RegEx` to `ensureLiteralConstant`, and `disassemble`'s `case RegEx:` is untouched — RegEx is a genuine wire format.

### The ratchet is the point

`TimeZone` was in the grammar, the lexer and the compiler, and missing from one switch. `RegEx` is in one switch and missing from the class. Same defect class, opposite direction — two lists of "formats a `LiteralConstant` can hold" that nothing kept in agreement.

`poolOffersExactlyTheFormatsLiteralConstantAccepts()` measures both sets by driving every `Format.values()` entry through the two entry points; neither side is hardcoded. The subtle part is that **both switches throw with byte-identical text**, so the message cannot distinguish "the pool refused" from "the pool routed it and `LiteralConstant` refused" — the test disambiguates on the stack instead, counting a format as *offered* only if the call reached a `LiteralConstant.<init>` frame.

It was red on this branch before the fix:

```
ensureLiteralConstant hands [RegEx] to LiteralConstant, whose constructor rejects it,
so those arms can only ever throw
expected: <[IntLiteral, FPLiteral, Date, TimeOfDay, TimeZone, Time, Duration, Path]>
 but was: <[IntLiteral, FPLiteral, RegEx, Date, TimeOfDay, TimeZone, Time, Duration, Path]>
```

and it catches the drift from the other side too: deleting `case TimeZone:` from the pool switch — the exact mistake this PR fixes — makes it fail with *"LiteralConstant accepts [TimeZone] that ensureLiteralConstant has no arm for"*. So it would have caught the original bug, and it will catch the next one.

`Format.Version` correctly lands in neither set: `LiteralConstant` rejects it (`"version requires VersionConstant subclass"`) and the pool routes versions to `ensureVersionConstant`.
