### PR TITLE
Build generated xunit test modules under the output dir, not a shared /tmp/xunit

### DIFF
--- a/lib_xunit_engine/src/main/x/xunit_engine.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine.x
@@ -64,6 +64,11 @@ module xunit_engine.xtclang.org {
     static String DefaultXUnitDir = "xunit";
 
     /**
+     * The directory, under the output directory, that the generated test module is built into.
+     */
+    static String GeneratedModuleDir = "modules";
+
+    /**
      * The root test output directory located under the build directory.
      */
     static String TestOutputRootDir = "test-output";
@@ -108,14 +113,18 @@ module xunit_engine.xtclang.org {
         @Inject(ConfigTestOutputDir) String?          outDirName;
         @Inject("repository")        ModuleRepository coreRepo;
         @Inject                      Directory        curDir;
-        @Inject                      Directory        tmpDir;
         @Inject                      Console          console;
 
         Directory outDir   = outDirName.is(String)
                                     ? curDir.dirFor(outDirName)
                                     : curDir.dirFor(DefaultXUnitDir);
 
-        Directory buildDir = tmpDir.dirFor("xunit");
+        // The generated module is built under the output directory rather than in a shared
+        // /tmp/xunit. Every runner used the same /tmp/xunit, and each one generates a module into
+        // it, scans it with a DirRepository, and deletes the module when finished - so one runner
+        // could delete a module while another was mid-scan. The output directory is already
+        // private to this project, this checkout and this user, which the /tmp path was not.
+        Directory buildDir = outDir.dirFor(GeneratedModuleDir);
 
         outDir.ensure();
         buildDir.ensure();


### PR DESCRIPTION
Every xunit runner generated its test module into the same directory:

```
Directory buildDir = tmpDir.dirFor("xunit");     // /tmp/xunit, for every runner
```

Each runner then scans that directory with a `DirRepository`, and deletes its module when finished. With several `testXtc` tasks running concurrently, one runner deletes a module while another is mid-scan:

```
IllegalState: "File|Directory node := find(name)": name=JsonTest_xunit.xtc
    at fs.OSDirectory.files() (OSDirectory.x:51)
    at mgmt.DirRepository.isCacheValid() (DirRepository.x:125)
    at tools.ModuleGenerator.ensureModule(...) (ModuleGenerator.x:35)
```

Seen on CI in `:manualTests:testXtc`, where the module being deleted (`JsonTest_xunit.xtc`) belonged to `:xdk:lib-json:testXtc`.

### Why a shared `/tmp` path is the wrong shape

Three collision domains, only the first of which CI happened to hit:

| | example |
| --- | --- |
| concurrent tasks in one build | `lib-json` and `manualTests` |
| concurrent builds by one user | two terminals, or a daemon plus a CLI run |
| **different users on one machine** | shared runner or dev box — the second user cannot write a directory the first one owns |

### Fix

The engine is already handed an output directory (`xvm.xunit.outputDir`, which the plugin sets from `--xunit-out` to the project's `build/xunit`). That directory is already private to the project, the checkout and the user. The generated module now goes under it:

```
Directory buildDir = outDir.dirFor(GeneratedModuleDir);   // <project>/build/xunit/modules
```

No new option and no plugin change — the isolation already existed and simply was not used for this one path. The `tmpDir` injection is no longer needed.

### Verification

Ran the four runners that were sharing the directory, after `rm -rf /tmp/xunit`:

```
manualTests   -> .../manualTests/build/xunit/modules
lib_metrics   -> .../lib_metrics/build/xunit/modules
lib_json      -> .../lib_json/build/xunit/modules

/tmp/xunit    -> never created
```

All pass, each in its own directory.

### Related, not fixed here

This removes the collision but not the underlying fragility. `OSDirectory.files()` calls `find(name)` twice per name, and the two calls disagree about whether absence is possible:

```
names()
  .filter(name -> { if (node := find(name)) { ... } else { return False; } })   // absence is normal
  .map(name    -> { assert node := find(name); ... })                          // absence is impossible
```

Any directory changing under a scan can still trip that assertion. Filed separately.