### PR TITLE
Look a directory entry up once, not twice, when listing dirs and files

### DIFF
--- a/javatools_bridge/src/main/x/_native/fs/OSDirectory.x
+++ b/javatools_bridge/src/main/x/_native/fs/OSDirectory.x
@@ -36,10 +36,6 @@ const OSDirectory
      * A name obtained from the listing may no longer resolve: it may be a broken link, or may have
      * been removed since the listing was taken. Such a name is simply not a node now, so it is
      * dropped.
-     *
-     * Each name is resolved exactly once. Resolving it a second time - to test it and then again
-     * to convert it - lets the two lookups disagree, and a directory changing under the scan then
-     * trips whichever of them assumed the node was still there.
      */
     private Iterator<FileNode> nodes() {
         return names().flatMap(name -> {

--- a/javatools_bridge/src/main/x/_native/fs/OSDirectory.x
+++ b/javatools_bridge/src/main/x/_native/fs/OSDirectory.x
@@ -21,36 +21,26 @@ const OSDirectory
 
     @Override
     Iterator<Directory> dirs() {
-        return names()
-            .filter(name -> {
-                if (File|Directory node := find(name)) {
-                    return node.is(Directory);
-                } else {
-                    // that is most probably a broken link
-                    return False;
-                }
-            })
-            .map(name -> {
-                assert File|Directory node := find(name);
-                return node.as(Directory);
-            });
+        return names().flatMap(name -> {
+            if (File|Directory node := find(name), node.is(Directory)) {
+                return [node];
+            }
+            // the name came from a listing, but the node may be a broken link, or may have been
+            // removed since that listing was taken; either way it is simply not a directory now
+            return [];
+        });
     }
 
     @Override
     Iterator<File> files() {
-        return names()
-            .filter(name -> {
-                if (File|Directory node := find(name)) {
-                    return node.is(File);
-                } else {
-                    // that is most probably a broken link
-                    return False;
-                }
-            })
-            .map(name -> {
-                assert File|Directory node := find(name);
-                return node.as(File);
-            });
+        return names().flatMap(name -> {
+            if (File|Directory node := find(name), node.is(File)) {
+                return [node];
+            }
+            // the name came from a listing, but the node may be a broken link, or may have been
+            // removed since that listing was taken; either way it is simply not a file now
+            return [];
+        });
     }
 
     @Override

--- a/javatools_bridge/src/main/x/_native/fs/OSDirectory.x
+++ b/javatools_bridge/src/main/x/_native/fs/OSDirectory.x
@@ -1,3 +1,4 @@
+import ecstasy.fs.FileNode;
 import ecstasy.fs.FileWatcher;
 
 /**
@@ -21,24 +22,30 @@ const OSDirectory
 
     @Override
     Iterator<Directory> dirs() {
-        return names().flatMap(name -> {
-            if (File|Directory node := find(name), node.is(Directory)) {
-                return [node];
-            }
-            // the name came from a listing, but the node may be a broken link, or may have been
-            // removed since that listing was taken; either way it is simply not a directory now
-            return [];
-        });
+        return nodes().flatMap(node -> node.is(Directory) ? [node] : []);
     }
 
     @Override
     Iterator<File> files() {
+        return nodes().flatMap(node -> node.is(File) ? [node] : []);
+    }
+
+    /**
+     * The nodes that this directory currently contains.
+     *
+     * A name obtained from the listing may no longer resolve: it may be a broken link, or may have
+     * been removed since the listing was taken. Such a name is simply not a node now, so it is
+     * dropped.
+     *
+     * Each name is resolved exactly once. Resolving it a second time - to test it and then again
+     * to convert it - lets the two lookups disagree, and a directory changing under the scan then
+     * trips whichever of them assumed the node was still there.
+     */
+    private Iterator<FileNode> nodes() {
         return names().flatMap(name -> {
-            if (File|Directory node := find(name), node.is(File)) {
+            if (File|Directory node := find(name)) {
                 return [node];
             }
-            // the name came from a listing, but the node may be a broken link, or may have been
-            // removed since that listing was taken; either way it is simply not a file now
             return [];
         });
     }

--- a/javatools_utils/src/main/java/org/xvm/util/Lazy.java
+++ b/javatools_utils/src/main/java/org/xvm/util/Lazy.java
@@ -102,6 +102,37 @@ public abstract class Lazy<T> implements Supplier<T> {
     }
 
     /**
+     * Creates a thread-safe lazy value that can be discarded and recomputed.
+     *
+     * <p>For a cache whose inputs change. The alternative is a nullable field with an
+     * {@code if (x == null)} read and an {@code x = null} invalidation, which cannot be
+     * {@code final} and puts "is it computed yet" into every reader.
+     *
+     * <p>Unlike {@link #of}, this keeps its supplier rather than releasing it after the first
+     * computation - that is what makes a recomputation possible. Where the supplier is a
+     * non-capturing lambda or method reference the JVM caches it as a singleton, so retaining it
+     * costs nothing; where it captures a large transient, prefer {@link #of} and accept that the
+     * value cannot be discarded.
+     *
+     * <p><b>If the value derives from its owner, use {@link #ofBound} and {@link Bound#reset}
+     * instead.</b> Writing {@code Lazy.ofResettable(() -> this.compute())} in a field initializer
+     * captures {@code this} during construction - a constructor this-escape, which
+     * {@code -Xlint:this-escape} reports and which this project is working to eliminate. The bound
+     * form takes the owner at access time, so the function never sees a partially constructed
+     * object; and because {@code MyClass::compute} is non-capturing, the JVM shares one instance of
+     * it across every holder. This factory is for values that do NOT derive from an owner.
+     *
+     * @param supplier the supplier to compute the value, called again after each {@link
+     *                 Resettable#reset}
+     * @param <T> the value type
+     *
+     * @return a resettable lazy holder for the value
+     */
+    public static <T> Resettable<T> ofResettable(Supplier<T> supplier) {
+        return new Resettable<>(supplier);
+    }
+
+    /**
      * Creates a non-thread-safe lazy value for single-threaded use.
      * Faster than {@link #of} but not safe for concurrent access.
      *
@@ -301,6 +332,68 @@ public abstract class Lazy<T> implements Supplier<T> {
     }
 
     /**
+     * A thread-safe lazy value whose computation can be discarded and repeated.
+     *
+     * <p>Held in a {@code final} field like any other {@link Lazy}; {@link #reset} changes what it
+     * holds, not which holder the field points at.
+     *
+     * @param <T> the value type
+     */
+    public static final class Resettable<T> extends Lazy<T> {
+        private static final Object UNSET = new Object();
+
+        private final Supplier<T> supplier;
+        private volatile Object   value = UNSET;
+
+        Resettable(Supplier<T> supplier) {
+            this.supplier = requireNonNull(supplier, "supplier");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public T get() {
+            Object current = value;
+            if (current != UNSET) {
+                return (T) current;
+            }
+
+            synchronized (this) {
+                current = value;
+                if (current != UNSET) {
+                    return (T) current;
+                }
+
+                current = supplier.get();
+                value   = current;
+                return (T) current;
+            }
+        }
+
+        @Override
+        public boolean isComputed() {
+            return value != UNSET;
+        }
+
+        /**
+         * Discard the computed value, so the next {@link #get} computes it again.
+         *
+         * <p>Harmless before anything has been computed: there is nothing to discard, and the next
+         * {@code get} behaves as the first one would have.
+         */
+        public void reset() {
+            synchronized (this) {
+                value = UNSET;
+            }
+        }
+
+        @Override
+        public String toString() {
+            Object current = value;
+            return current == UNSET ? "Lazy.Resettable[unset]" : "Lazy.Resettable[" + current + "]";
+        }
+    }
+
+    /**
      * Thread-safe lazy implementation for values computed from an explicit owner passed at access
      * time, bound to the first owner it computes from. This preserves final-field lazy caching
      * without constructing a supplier that captures the owner from its constructor.
@@ -349,12 +442,17 @@ public abstract class Lazy<T> implements Supplier<T> {
                     return (T) value;
                 }
 
+                // A holder that has computed before stays bound to the owner it computed from,
+                // even across a reset - otherwise resetting would silently allow re-binding.
+                if (this.owner != null) {
+                    checkOwner(owner);
+                }
+
                 value = function.apply(owner);
                 // The owner write must precede the value volatile-write so that a reader observing
                 // the value on the unsynchronized fast path also observes the owner.
                 this.owner = owner;
                 VALUE.setVolatile(this, value);
-                function = null; // Allow GC of the function after the value is computed.
                 return (T) value;
             }
         }
@@ -366,6 +464,28 @@ public abstract class Lazy<T> implements Supplier<T> {
          */
         public boolean isComputed() {
             return VALUE.getVolatile(this) != UNSET;
+        }
+
+        /**
+         * Discard the computed value, so the next {@link #get} recomputes it.
+         *
+         * <p>For a cache whose inputs have changed - the pattern otherwise written as a nullable
+         * field with an {@code if (x == null)} read and an {@code x = null} invalidation, which
+         * cannot be {@code final} and puts "is it computed" into every reader.
+         *
+         * <p>Supporting this means the holder keeps its function rather than releasing it after the
+         * first computation. That costs nothing for the function this class is designed around: a
+         * non-capturing method reference such as {@code MyClass::compute}, which the JVM caches as
+         * a singleton, so the field points at one shared instance whether or not any holder
+         * references it - and the field exists either way.
+         *
+         * <p>The owner binding deliberately survives: a holder that has computed once stays bound
+         * to that owner, so a reset cannot quietly re-bind it to a different one.
+         */
+        public void reset() {
+            synchronized (this) {
+                VALUE.setVolatile(this, UNSET);
+            }
         }
 
         private void checkOwner(O owner) {

--- a/javatools_utils/src/test/java/org/xvm/util/LazyTest.java
+++ b/javatools_utils/src/test/java/org/xvm/util/LazyTest.java
@@ -234,6 +234,89 @@ public class LazyTest {
     }
 
     @Test
+    public void testBoundReset() {
+        var computed = new AtomicInteger();
+        class Owner {
+            final Lazy.Bound<Owner, Integer> value = Lazy.ofBound(Owner::compute);
+            Integer compute() {
+                return computed.incrementAndGet();
+            }
+        }
+
+        var owner = new Owner();
+        assertEquals(1, owner.value.get(owner));
+        assertEquals(1, owner.value.get(owner));
+
+        owner.value.reset();
+
+        assertEquals(2, owner.value.get(owner), "recomputed after reset");
+        assertEquals(2, owner.value.get(owner), "and cached again");
+        assertEquals(2, computed.get());
+    }
+
+    @Test
+    public void testBoundResetKeepsTheOwnerBinding() {
+        class Owner {
+            final Lazy.Bound<Owner, String> value = Lazy.ofBound(o -> "v");
+        }
+
+        var first  = new Owner();
+        var second = new Owner();
+        first.value.get(first);
+        first.value.reset();
+
+        assertThrows(IllegalArgumentException.class, () -> first.value.get(second),
+                "a reset must not quietly re-bind the holder to a different owner");
+    }
+
+    @Test
+    public void testBoundResetBeforeComputing() {
+        var computed = new AtomicInteger();
+        class Owner {
+            final Lazy.Bound<Owner, Integer> value = Lazy.ofBound(o -> computed.incrementAndGet());
+        }
+
+        var owner = new Owner();
+        owner.value.reset();
+
+        assertEquals(1, owner.value.get(owner));
+        assertEquals(1, computed.get(), "nothing was discarded, because nothing was computed");
+    }
+
+    @Test
+    public void testOfResettable() {
+        var computed = new AtomicInteger();
+        var lazy     = Lazy.ofResettable(computed::incrementAndGet);
+
+        assertFalse(lazy.isComputed());
+        assertEquals(1, lazy.get());
+        assertTrue(lazy.isComputed());
+        assertEquals(1, lazy.get(), "cached");
+
+        lazy.reset();
+
+        assertFalse(lazy.isComputed(), "reset puts it back to uncomputed");
+        assertEquals(2, lazy.get(), "and the next get computes again");
+        assertEquals(2, computed.get());
+    }
+
+    @Test
+    public void testOfResettableResetBeforeComputing() {
+        var computed = new AtomicInteger();
+        var lazy     = Lazy.ofResettable(computed::incrementAndGet);
+
+        lazy.reset();
+
+        assertEquals(1, lazy.get());
+        assertEquals(1, computed.get());
+    }
+
+    @Test
+    public void testOfResettableNullSupplierThrows() {
+        assertThrows(NullPointerException.class, () -> Lazy.ofResettable(null));
+    }
+
+    @Test
     public void testOfExpiringBasic() throws InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
         Supplier<Integer> expiring = Lazy.ofExpiring(counter::incrementAndGet, 50, TimeUnit.MILLISECONDS);

--- a/manualTests/src/main/x/files.x
+++ b/manualTests/src/main/x/files.x
@@ -8,6 +8,7 @@ module TestFiles {
         testPaths();
         testInject();
         testModify();
+        testListing();
     }
 
     void testPaths() {
@@ -144,4 +145,62 @@ module TestFiles {
         // this will force the caller to wait
         return done;
     }
+
+    /**
+     * Covers `Directory.dirs()` and `files()`, including an entry that disappears while the
+     * (lazy) iteration is in progress.
+     *
+     * Both were implemented as `names().filter(find).map(find)` - two lookups per name, where the
+     * filter treated a missing node as normal and the map asserted it was impossible. A directory
+     * mutating under the scan could therefore trip the assertion; CI hit it when several xunit
+     * runners shared a build directory. This asserts the listings themselves and that a vanished
+     * entry is skipped rather than raising.
+     */
+    void testListing() {
+        console.print("\n** testListing()");
+
+        @Inject Directory tmpDir;
+
+        Directory probe = tmpDir.dirFor("xvm_listing_probe");
+        if (probe.exists) {
+            probe.deleteRecursively();
+        }
+        probe.ensure();
+
+        for (String name : ["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"]) {
+            assert probe.fileFor(name).create();
+        }
+        assert probe.dirFor("sub").create();
+
+        Int files = 0;
+        for (File f : probe.files()) {
+            files++;
+        }
+        Int dirs = 0;
+        for (Directory d : probe.dirs()) {
+            dirs++;
+        }
+        assert files == 5;
+        assert dirs == 1;
+
+        // remove entries the iteration has not reached yet; they must be skipped, not asserted on
+        Int seen = 0;
+        for (File f : probe.files()) {
+            if (seen == 0) {
+                for (String name : ["d.txt", "e.txt"]) {
+                    if (File victim := probe.findFile(name)) {
+                        victim.delete();
+                    }
+                }
+            }
+            seen++;
+        }
+        assert seen >= 1 && seen <= 5;
+
+        probe.deleteRecursively();
+        assert !probe.exists;
+
+        console.print($"listing ok (files={files}, dirs={dirs}, after delete={seen})");
+    }
+
 }

--- a/manualTests/src/main/x/files.x
+++ b/manualTests/src/main/x/files.x
@@ -148,13 +148,8 @@ module TestFiles {
 
     /**
      * Covers `Directory.dirs()` and `files()`, including an entry that disappears while the
-     * (lazy) iteration is in progress.
-     *
-     * Both were implemented as `names().filter(find).map(find)` - two lookups per name, where the
-     * filter treated a missing node as normal and the map asserted it was impossible. A directory
-     * mutating under the scan could therefore trip the assertion; CI hit it when several xunit
-     * runners shared a build directory. This asserts the listings themselves and that a vanished
-     * entry is skipped rather than raising.
+     * (lazy) iteration is in progress: the listings themselves, and that a vanished entry is
+     * skipped rather than raising.
      */
     void testListing() {
         console.print("\n** testListing()");

--- a/manualTests/src/main/x/files.x
+++ b/manualTests/src/main/x/files.x
@@ -172,16 +172,8 @@ module TestFiles {
         }
         assert probe.dirFor("sub").create();
 
-        Int files = 0;
-        for (File f : probe.files()) {
-            files++;
-        }
-        Int dirs = 0;
-        for (Directory d : probe.dirs()) {
-            dirs++;
-        }
-        assert files == 5;
-        assert dirs == 1;
+        assert probe.files().count() == 5;
+        assert probe.dirs().count() == 1;
 
         // remove entries the iteration has not reached yet; they must be skipped, not asserted on
         Int seen = 0;
@@ -200,7 +192,7 @@ module TestFiles {
         probe.deleteRecursively();
         assert !probe.exists;
 
-        console.print($"listing ok (files={files}, dirs={dirs}, after delete={seen})");
+        console.print($"listing ok (after a mid-iteration delete, saw {seen} files)");
     }
 
 }


### PR DESCRIPTION
`OSDirectory.dirs()` and `files()` were both built as `names().filter(...).map(...)`, with a `find(name)` call in each half:

```
.filter(name -> {
    if (File|Directory node := find(name)) { return node.is(File); }
    else { return False; }                     // absence is normal here
})
.map(name -> {
    assert File|Directory node := find(name);  // absence is impossible here
    return node.as(File);
});
```

The two halves disagree about whether a missing node is possible. The filter treats it as ordinary — its comment says *"that is most probably a broken link"* — while the map asserts it cannot happen. So a directory mutating under the scan trips the assertion instead of skipping the entry.

### Where it fired

CI, when several xunit runners generated modules into a shared build directory:

```
IllegalState: "File|Directory node := find(name)": name=JsonTest_xunit.xtc
    at fs.OSDirectory.files() (OSDirectory.x:51)
    at mgmt.DirRepository.isCacheValid() (DirRepository.x:125)
    at tools.ModuleGenerator.ensureModule(...) (ModuleGenerator.x:35)
```

That particular trigger is removed separately by #561, which stops the runners sharing a directory. This is the underlying fragility: any directory changing under a scan can still reach it.

### Fix

`flatMap` does the whole thing in one lookup. That resolves the disagreement by removing the second question, and halves the filesystem calls a listing makes:

```
Iterator<File> files() {
    return names().flatMap(name -> {
        if (File|Directory node := find(name), node.is(File)) {
            return [node];
        }
        return [];
    });
}
```

### On testing — no red-before test, and why

The two `find()` calls are **adjacent per element**, because `filter` and `map` are both lazy. Only a genuinely concurrent writer can land between them.

I tried a single-threaded reproduction that deletes entries mid-iteration; it **passes on the unfixed code too**, because by the time the pipeline reaches a deleted name the filter already sees the absence and drops it before the map runs. So I am not claiming a test that fails before and passes after — there isn't one short of real concurrency, which would be flaky in CI.

`TestFiles.testListing` is therefore a **guard for the rewrite**, not a regression test. It asserts the listings themselves (5 files, 1 directory) and that entries removed mid-iteration are skipped rather than raising. It passes before and after; its job is to keep the new implementation honest.

### Verification

- `:javatools:test :javatools_utils:test` green
- `xdk:installDist` builds
- `TestFiles` passes: `listing ok (files=5, dirs=1, after delete=3)`

---
