### PR TITLE
Fix deleteAll(range): wrong elements on byte-backed arrays, crash on String arrays

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
@@ -178,7 +178,7 @@ public abstract class ByteBasedDelegate
         int             nDelete   = (int) cDelete;
 
         if (nIndex < cSize - nDelete) {
-            System.arraycopy(abValue, nIndex + 1, abValue, nIndex, cSize - nIndex - nDelete);
+            System.arraycopy(abValue, nIndex + nDelete, abValue, nIndex, cSize - nIndex - nDelete);
         }
         Arrays.fill(abValue, cSize - nDelete, cSize, (byte) 0);
         hDelegate.m_cSize -= cDelete;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
@@ -178,6 +178,21 @@ public class xRTStringDelegate
         asValue[(int) --hDelegate.m_cSize] = null;
     }
 
+    @Override
+    protected void deleteRangeImpl(DelegateHandle hTarget, long lIndex, long cDelete) {
+        StringArrayHandle hDelegate = (StringArrayHandle) hTarget;
+        int               cSize     = (int) hDelegate.m_cSize;
+        String[]          asValue   = hDelegate.m_asValue;
+        int               nIndex    = (int) lIndex;
+        int               nDelete   = (int) cDelete;
+
+        if (nIndex < cSize - nDelete) {
+            System.arraycopy(asValue, nIndex + nDelete, asValue, nIndex, cSize - nIndex - nDelete);
+        }
+        Arrays.fill(asValue, cSize - nDelete, cSize, null);
+        hDelegate.m_cSize -= cDelete;
+    }
+
 
     // ----- ClassTemplate API ---------------------------------------------------------------------
 

--- a/manualTests/src/main/x/array.x
+++ b/manualTests/src/main/x/array.x
@@ -24,6 +24,7 @@ module TestArray {
 
         testComparable();
         testAggregation();
+        testDeleteRange();
 
         testIterators();
 
@@ -443,4 +444,45 @@ module TestArray {
         console.print($"col={col}");
         console.print($"bytes={col.contents}");
     }
+
+    /**
+     * `deleteAll(range)` across every element type that has its own storage.
+     *
+     * Array storage is chosen per element type - a byte-backed delegate for `Int8`, a `String[]`
+     * one for `String`, an `ObjectHandle[]` one for everything else - and each implements the
+     * delete itself. Two of them were wrong in ways a single-element delete could not show:
+     * the byte-backed one copied from the wrong offset and silently produced the wrong elements,
+     * and `String` had no implementation at all and inherited the one for object arrays, which
+     * failed with a cast error. So this deletes a MULTI-element range, and does it for every type,
+     * because each type is a different implementation.
+     */
+    void testDeleteRange() {
+        console.print("\n** testDeleteRange()");
+
+        // removing 1..2 from a five-element array must always leave the 1st, 4th and 5th
+        assert new Array<Int64>  (Mutable, [1, 2, 3, 4, 5]).deleteAll(1..2) == [1, 4, 5];
+        assert new Array<Int8>   (Mutable, [1, 2, 3, 4, 5]).deleteAll(1..2) == [1, 4, 5];
+        assert new Array<Int16>  (Mutable, [1, 2, 3, 4, 5]).deleteAll(1..2) == [1, 4, 5];
+        assert new Array<Int128> (Mutable, [1, 2, 3, 4, 5]).deleteAll(1..2) == [1, 4, 5];
+        assert new Array<UInt8>  (Mutable, [1, 2, 3, 4, 5]).deleteAll(1..2) == [1, 4, 5];
+        assert new Array<Float64>(Mutable, [1.0, 2.0, 3.0, 4.0, 5.0]).deleteAll(1..2) == [1.0, 4.0, 5.0];
+        assert new Array<Char>   (Mutable, ['a', 'b', 'c', 'd', 'e']).deleteAll(1..2) == ['a', 'd', 'e'];
+        assert new Array<String> (Mutable, ["a", "b", "c", "d", "e"]).deleteAll(1..2) == ["a", "d", "e"];
+        assert new Array<Boolean>(Mutable, [True, False, True, False, True]).deleteAll(1..2)
+                == [True, False, True];
+        assert new Array<Bit>    (Mutable, [0, 1, 0, 1, 0]).deleteAll(1..2) == [0, 1, 0];
+        assert new Array<Nibble> (Mutable, [0, 1, 2, 3, 4]).deleteAll(1..2) == [0, 3, 4];
+        assert new Array<Object> (Mutable, [1, 2, 3, 4, 5]).deleteAll(1..2).size == 3;
+
+        // a single-element delete took a different path and always worked; keep it covered
+        assert new Array<String>(Mutable, ["a", "b", "c", "d"]).deleteAll(1..1) == ["a", "c", "d"];
+        assert new Array<Int8>  (Mutable, [1, 2, 3, 4]).deleteAll(1..1) == [1, 3, 4];
+
+        // and a range reaching the end, where the copy is skipped entirely
+        assert new Array<Int8>  (Mutable, [1, 2, 3, 4, 5]).deleteAll(3..4) == [1, 2, 3];
+        assert new Array<String>(Mutable, ["a", "b", "c", "d", "e"]).deleteAll(3..4) == ["a", "b", "c"];
+
+        console.print("deleteAll(range) ok for every element type");
+    }
+
 }


### PR DESCRIPTION
Two defects in the same operation. They were found together, and they have the same cause.  (This issue also illustrates that it is actually quite problematic to bypass the Java type system, which would have facilitated this being a compile time error instead of two runtime issues, and we should really revisit that policy. It is not the first thing I ran into at runtime that could have been reduced to Java compile time during the LSP project.) 

## What breaks

Array storage is chosen per element type — a byte-backed delegate for `Int8`/`UInt8`, a `String[]` one for `String`, an `ObjectHandle[]` one for the rest — and each implements `deleteRangeImpl` itself.

**1. Byte-backed arrays silently return the wrong elements.**

```
Int8 [1,2,3,4,5].deleteAll(1..2)  ->  [1, 3, 4]      expected [1, 4, 5]
UInt8 likewise                    ->  0x010304       expected 0x010405
```

The copy starts at the wrong offset:

```java
System.arraycopy(abValue, nIndex + 1, abValue, nIndex, cSize - nIndex - nDelete);
//                        ^^^^^^^^^^ should be nIndex + nDelete
```

`+1` is correct in `deleteElementImpl` directly above, which is where this looks copied from. Deleting a *single* element agrees either way, which is why it survived. **No exception — just wrong data.**

**2. `String` arrays crash.**

```
ClassCastException: StringArrayHandle cannot be cast to GenericArrayDelegate
    at xRTDelegate.deleteRangeImpl(xRTDelegate.java:681)
    at xArray.invokeDeleteAll(xArray.java:765)
```

`xRTStringDelegate` has no `deleteRangeImpl`, so it inherits the one on `xRTDelegate` — which *is* the implementation for object arrays and starts by casting to `GenericArrayDelegate`. Again only for a multi-element range, since a single-element delete takes the `deleteElementImpl` branch, which `String` does implement.

Checked every element type with its own storage. `Int64`, `Int16`, `Int128`, `Float64`, `Char`, `Boolean`, `Bit`, `Nibble` and `Object` are correct; `Int8`, `UInt8` and `String` were not.

## Why both existed

Both are consequences of the storage protocol being declared in terms of a supertype that carries no information:

```java
protected void deleteRangeImpl(DelegateHandle hTarget, long lIndex, long cDelete)
```

Nine methods on `xRTDelegate` take a `DelegateHandle`, and twenty implementations across the hierarchy open by casting it back to the type they actually store. Two things follow directly, and both happened here:

- **A missing implementation is invisible.** `xRTStringDelegate` inherits an implementation written for a *different* storage type, and nothing objects, because `DelegateHandle` accepts it. Had the protocol been declared over the handle type each delegate stores, the inherited body would not have type-checked against `StringArrayHandle` and this would have been a compile error rather than a crash reported from user code.
- **Nothing relates one implementation to another.** The byte-backed and generic versions are the same algorithm over different storage, but the type system is told nothing that would let a reader — or a compiler — line them up. The `+1` sat next to a correct `+ nDelete` in a sibling file for as long as it took someone to delete two elements from an `Int8[]`.

This is the ordinary cost of routing a typed operation through an untyped parameter: the compiler is holding the information needed to catch both of these, and the signature throws it away. The fix here is the two lines; the reason there were two lines to fix is the signature.

`xRTDelegate` cannot be generified as it stands, because it is simultaneously the abstract base and the concrete object-array implementation, so its defaults construct a `GenericArrayDelegate`. Splitting that concrete role out is the prerequisite, and is a separate change.

## Tests

`TestArray.testDeleteRange` covers every element type that has its own storage, deleting a **multi-element** range because that is what neither defect survives. On the unfixed runtime it fails immediately:

```
IllegalState: "new Array<Int8>(Mutable, [1,2,3,4,5]).deleteAll(1..2) == [1, 4, 5]": ... = [1, 3, 4]
    at testDeleteRange() (array.x:390)
```

and the `String` case throws after it. It also keeps the single-element path, which always worked, and a range reaching the end of the array, where the copy is skipped entirely.

## Verification

- `:javatools:test :javatools_utils:test` green
- `xdk:installDist` builds
- the new test passes on this branch and fails on `master`, verified by running the same compiled module against both runtimes