### PR TITLE
Fix ClassCastException when comparing two array slices or views by reference

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -1600,6 +1600,12 @@ public abstract class ClassTemplate
      *
      * Note: this method is inherently native; it must be answered without calling any natural code
      *
+     * Note: the caller resolves this template from {@code hValue1} alone, so {@code hValue1} is
+     * always one this template produced but {@code hValue2} is arbitrary - two arrays of the same
+     * element type may be backed by different delegates, and a slice or a view is not the concrete
+     * handle. Implementations must therefore TEST the second argument rather than cast it; a
+     * different representation is not the same identity, so the answer is false, not an exception.
+     *
      * @param hValue1  the first value
      * @param hValue2  the second value
      *

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
@@ -332,8 +332,13 @@ public abstract class ByteBasedDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        ByteArrayHandle h1 = (ByteArrayHandle) hValue1;
-        ByteArrayHandle h2 = (ByteArrayHandle) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a ByteArrayHandle - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof ByteArrayHandle h1) || !(hValue2 instanceof ByteArrayHandle h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
@@ -332,10 +332,6 @@ public abstract class ByteBasedDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a ByteArrayHandle - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof ByteArrayHandle h1) || !(hValue2 instanceof ByteArrayHandle h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedDelegate.java
@@ -315,10 +315,6 @@ public abstract class LongBasedDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a LongArrayHandle - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof LongArrayHandle h1) || !(hValue2 instanceof LongArrayHandle h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedDelegate.java
@@ -315,8 +315,13 @@ public abstract class LongBasedDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        LongArrayHandle h1 = (LongArrayHandle) hValue1;
-        LongArrayHandle h2 = (LongArrayHandle) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a LongArrayHandle - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof LongArrayHandle h1) || !(hValue2 instanceof LongArrayHandle h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
@@ -232,10 +232,6 @@ public abstract class LongLongDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a LongArrayHandle - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof LongArrayHandle h1) || !(hValue2 instanceof LongArrayHandle h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
@@ -232,8 +232,13 @@ public abstract class LongLongDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        LongArrayHandle h1 = (LongArrayHandle) hValue1;
-        LongArrayHandle h2 = (LongArrayHandle) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a LongArrayHandle - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof LongArrayHandle h1) || !(hValue2 instanceof LongArrayHandle h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
@@ -183,8 +183,13 @@ public class xRTCharDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        CharArrayHandle h1 = (CharArrayHandle) hValue1;
-        CharArrayHandle h2 = (CharArrayHandle) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a CharArrayHandle - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof CharArrayHandle h1) || !(hValue2 instanceof CharArrayHandle h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
@@ -183,10 +183,6 @@ public class xRTCharDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a CharArrayHandle - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof CharArrayHandle h1) || !(hValue2 instanceof CharArrayHandle h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
@@ -282,8 +282,13 @@ public class xRTDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        GenericArrayDelegate h1 = (GenericArrayDelegate) hValue1;
-        GenericArrayDelegate h2 = (GenericArrayDelegate) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a GenericArrayDelegate - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof GenericArrayDelegate h1) || !(hValue2 instanceof GenericArrayDelegate h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
@@ -282,10 +282,6 @@ public class xRTDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a GenericArrayDelegate - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof GenericArrayDelegate h1) || !(hValue2 instanceof GenericArrayDelegate h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
@@ -224,10 +224,6 @@ public class xRTFloat64Delegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a DoubleArrayHandle - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof DoubleArrayHandle h1) || !(hValue2 instanceof DoubleArrayHandle h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
@@ -224,8 +224,13 @@ public class xRTFloat64Delegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        DoubleArrayHandle h1 = (DoubleArrayHandle) hValue1;
-        DoubleArrayHandle h2 = (DoubleArrayHandle) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a DoubleArrayHandle - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof DoubleArrayHandle h1) || !(hValue2 instanceof DoubleArrayHandle h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
@@ -172,10 +172,7 @@ public class xRTSlicingDelegate
     }
 
     /**
-     * A slice does not own element storage, so the inherited implementation - which is the
-     * object-array one, and opens by casting to {@code GenericArrayDelegate} - cannot apply to a
-     * {@link SliceHandle}. A slice's identity is the source it projects plus the window it
-     * projects through.
+     * A slice's identity is the source it projects plus the window it projects through.
      */
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
@@ -170,4 +170,31 @@ public class xRTSlicingDelegate
             return super.toString() + " @" + f_ofStart;
         }
     }
+
+    /**
+     * A slice does not own element storage, so the inherited implementation - which is the
+     * object-array one, and opens by casting to {@code GenericArrayDelegate} - cannot apply to a
+     * {@link SliceHandle}. A slice's identity is the source it projects plus the window it
+     * projects through.
+     */
+    @Override
+    public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
+        if (hValue1 == hValue2) {
+            return true;
+        }
+
+        if (!(hValue1 instanceof SliceHandle h1) || !(hValue2 instanceof SliceHandle h2)) {
+            return false;
+        }
+
+        DelegateHandle hSource1 = h1.f_hSource;
+        DelegateHandle hSource2 = h2.f_hSource;
+
+        return h1.getMutability() == h2.getMutability()
+            && h1.m_cSize         == h2.m_cSize
+            && h1.f_ofStart       == h2.f_ofStart
+            && h1.f_fReverse      == h2.f_fReverse
+            && hSource1.getTemplate() == hSource2.getTemplate()
+            && hSource1.getTemplate().compareIdentity(hSource1, hSource2);
+    }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
@@ -193,8 +193,13 @@ public class xRTStringDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        StringArrayHandle h1 = (StringArrayHandle) hValue1;
-        StringArrayHandle h2 = (StringArrayHandle) hValue2;
+        // Arrays of the same element type can be backed by different delegates - a slice or a
+        // view is not a StringArrayHandle - and the caller resolves this template from the
+        // FIRST handle only, so the second is arbitrary. Casting it raised a
+        // ClassCastException into the running program.
+        if (!(hValue1 instanceof StringArrayHandle h1) || !(hValue2 instanceof StringArrayHandle h2)) {
+            return false;
+        }
 
         if (h1 == h2) {
             return true;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
@@ -193,10 +193,6 @@ public class xRTStringDelegate
 
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
-        // Arrays of the same element type can be backed by different delegates - a slice or a
-        // view is not a StringArrayHandle - and the caller resolves this template from the
-        // FIRST handle only, so the second is arbitrary. Casting it raised a
-        // ClassCastException into the running program.
         if (!(hValue1 instanceof StringArrayHandle h1) || !(hValue2 instanceof StringArrayHandle h2)) {
             return false;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTView.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTView.java
@@ -96,4 +96,28 @@ public abstract class xRTView
                     : hSource;
         }
     }
+
+    /**
+     * A view does not own element storage, so the inherited implementation - which is the
+     * object-array one, and opens by casting to {@code GenericArrayDelegate} - cannot apply to a
+     * {@link ViewHandle}. A view's identity is the identity of the delegate it projects.
+     */
+    @Override
+    public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {
+        if (hValue1 == hValue2) {
+            return true;
+        }
+
+        if (!(hValue1 instanceof ViewHandle h1) || !(hValue2 instanceof ViewHandle h2)) {
+            return false;
+        }
+
+        DelegateHandle hSource1 = h1.getSource();
+        DelegateHandle hSource2 = h2.getSource();
+
+        return h1.getMutability() == h2.getMutability()
+            && h1.m_cSize         == h2.m_cSize
+            && hSource1.getTemplate() == hSource2.getTemplate()
+            && hSource1.getTemplate().compareIdentity(hSource1, hSource2);
+    }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTView.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTView.java
@@ -98,9 +98,7 @@ public abstract class xRTView
     }
 
     /**
-     * A view does not own element storage, so the inherited implementation - which is the
-     * object-array one, and opens by casting to {@code GenericArrayDelegate} - cannot apply to a
-     * {@link ViewHandle}. A view's identity is the identity of the delegate it projects.
+     * A view's identity is the identity of the delegate it projects.
      */
     @Override
     public boolean compareIdentity(ObjectHandle hValue1, ObjectHandle hValue2) {

--- a/manualTests/src/main/x/array.x
+++ b/manualTests/src/main/x/array.x
@@ -97,14 +97,42 @@ module TestArray {
         console.print($"&bytes.asBitArray() == &bytes.asBitArray(): {&v1 == &v2}");
 
         // The reverse direction dispatches to the CONCRETE delegate, which resolves the template
-        // from the first handle only and used to cast the second one too.
-        Char[] chars = ['a', 'b', 'c', 'd', 'e'];
-        Char[] cs    = chars[1..3];
+        // from the first handle only and used to cast the second one too. Each element type below
+        // is backed by a different delegate, and every one had the same defect, so each needs its
+        // own case: array-vs-slice and slice-vs-array must both answer rather than raise.
+        Char[]    chars   = ['a', 'b', 'c', 'd', 'e'];
+        String[]  strs    = ["a", "b", "c", "d", "e"];
+        Float64[] floats  = [1.0, 2.0, 3.0, 4.0, 5.0];
+        Int8[]    int8s   = [1, 2, 3, 4, 5];
+        Int[]     ints    = [1, 2, 3, 4, 5];
+        Int128[]  int128s = [1, 2, 3, 4, 5];
+        Object[]  objs    = ["a", 2, 3.0, 4, 5];
 
-        assert &chars != &cs;
-        assert &cs != &chars;
+        Char[]    charsSlice   = chars[1..3];
+        String[]  strsSlice    = strs[1..3];
+        Float64[] floatsSlice  = floats[1..3];
+        Int8[]    int8sSlice   = int8s[1..3];
+        Int[]     intsSlice    = ints[1..3];
+        Int128[]  int128sSlice = int128s[1..3];
+        Object[]  objsSlice    = objs[1..3];
 
-        console.print($"&chars == &chars[1..3]: {&chars == &cs}");
+        assert &chars   != &charsSlice;
+        assert &strs    != &strsSlice;
+        assert &floats  != &floatsSlice;
+        assert &int8s   != &int8sSlice;
+        assert &ints    != &intsSlice;
+        assert &int128s != &int128sSlice;
+        assert &objs    != &objsSlice;
+
+        assert &charsSlice   != &chars;
+        assert &strsSlice    != &strs;
+        assert &floatsSlice  != &floats;
+        assert &int8sSlice   != &int8s;
+        assert &intsSlice    != &ints;
+        assert &int128sSlice != &int128s;
+        assert &objsSlice    != &objs;
+
+        console.print("array-vs-slice identity answers for all seven delegates");
     }
 
     void testArrayList() {

--- a/manualTests/src/main/x/array.x
+++ b/manualTests/src/main/x/array.x
@@ -95,6 +95,16 @@ module TestArray {
         assert &v1 == &v2;
 
         console.print($"&bytes.asBitArray() == &bytes.asBitArray(): {&v1 == &v2}");
+
+        // The reverse direction dispatches to the CONCRETE delegate, which resolves the template
+        // from the first handle only and used to cast the second one too.
+        Char[] chars = ['a', 'b', 'c', 'd', 'e'];
+        Char[] cs    = chars[1..3];
+
+        assert &chars != &cs;
+        assert &cs != &chars;
+
+        console.print($"&chars == &chars[1..3]: {&chars == &cs}");
     }
 
     void testArrayList() {

--- a/manualTests/src/main/x/array.x
+++ b/manualTests/src/main/x/array.x
@@ -132,7 +132,14 @@ module TestArray {
         assert &int128sSlice != &int128s;
         assert &objsSlice    != &objs;
 
-        console.print("array-vs-slice identity answers for all seven delegates");
+        // one line of actual data rather than a bare "it worked": each of these is a different
+        // delegate, and each used to raise instead of answering
+        console.print($|&chars=={&chars == &charsSlice} &strs=={&strs == &strsSlice} \
+                       |&floats=={&floats == &floatsSlice} &int8s=={&int8s == &int8sSlice} \
+                       |&ints=={&ints == &intsSlice} &int128s=={&int128s == &int128sSlice} \
+                       |&objs=={&objs == &objsSlice}
+                      );
+
     }
 
     void testArrayList() {

--- a/manualTests/src/main/x/array.x
+++ b/manualTests/src/main/x/array.x
@@ -6,6 +6,7 @@ module TestArray {
         testStrBuf();
         testConstElement();
         testConstSlice();
+        testSliceIdentity();
 
         testArrayList();
         testArrayListAdd();
@@ -66,6 +67,34 @@ module TestArray {
 
         String[] cruel2 = ["hello", "cruel", "world", "!"] [2..1];
         console.print("array[2..1]=" + cruel2);
+    }
+
+    void testSliceIdentity() {
+        console.print("\n** testSliceIdentity()");
+
+        Int[] nums = [1, 2, 3, 4, 5];
+        Int[] s1   = nums[1..3];
+        Int[] s2   = nums[1..3];
+        Int[] s3   = nums[0..2];
+
+        // Comparing two slices by reference must answer rather than raise. A slice delegate owns no
+        // element storage, and used to inherit the object-array implementation of compareIdentity,
+        // which opened by casting the handle to the object-array one - so this raised a run-time
+        // error instead of comparing.
+        assert &s1 == &s2;
+        assert &s1 != &s3;
+
+        console.print($"&nums[1..3] == &nums[1..3]: {&s1 == &s2}");
+        console.print($"&nums[1..3] == &nums[0..2]: {&s1 == &s3}");
+
+        // Same for a view, which likewise owns no element storage.
+        UInt8[] bytes = [1, 2, 3, 4];
+        Bit[]   v1    = bytes.asBitArray();
+        Bit[]   v2    = bytes.asBitArray();
+
+        assert &v1 == &v2;
+
+        console.print($"&bytes.asBitArray() == &bytes.asBitArray(): {&v1 == &v2}");
     }
 
     void testArrayList() {


### PR DESCRIPTION
## The bug

Comparing the references of two slices, or of two views, kills the program with a raw Java `ClassCastException` escaping into Ecstasy instead of answering the comparison.

```
Int[] a  = [1, 2, 3, 4, 5];
Int[] s1 = a[1..3];
Int[] s2 = a[1..3];

s1 == s2      // True - fine
&s1 == &s2    // Unhandled exception: Run-time error: java.lang.ClassCastException
```

```
UInt8[] b = [1, 2, 3, 4];
&b.asBitArray() == &b.asBitArray()   // same crash, ByteBasedBitView$ViewHandle
```

Verified on clean master `145f12f51`:

```
java.lang.ClassCastException: class ...xRTSlicingDelegate$SliceHandle cannot be cast to
class ...xRTDelegate$GenericArrayDelegate
        at ...xRTDelegate.compareIdentity(xRTDelegate.java:266)
        at ...xArray.compareIdentity(xArray.java:555)
        at ...xRef$CompareReferents.doNext(xRef.java:1227)
```

## Cause

`xRTDelegate` is the base of every array delegate, but its `compareIdentity` is not a base implementation — it is the **object-array** implementation, and it opens with:

```java
GenericArrayDelegate h1 = (GenericArrayDelegate) hValue1;
```

`SliceHandle` holds `f_hSource`/`f_ofStart`; `ViewHandle` holds its source. Neither is a `GenericArrayDelegate`, and neither overrode `compareIdentity`, so both inherited a cast that cannot succeed.

`createDelegate`, `callEquals`, `insertElementImpl` and `deleteElementImpl` have the same problem, but those four are unreachable — `xArray` answers `callEquals` itself, and Ecstasy rejects `insert`/`delete` on a fixed-size slice before any delegate is asked. `compareIdentity` is the one that escapes.

Quick fix: two added overrides, no change to existing code. Each compares what the handle actually holds — same mutability and size, plus start offset and direction for a slice, then `compareIdentity` on the source delegate. Both guard with `instanceof` rather than casting, so a slice compared against a non-slice answers `false` instead of raising. 

## Second direction, second set of templates

Reviewing the above surfaced that the reverse direction crashes too, in *different* templates, so
this PR now covers both:

```
Char[] a = ['a','b','c','d','e'];
Char[] s = a[1..3];

&s == &a    // xRTSlicingDelegate  — the case above
&a == &s    // xRTCharDelegate     — this one
```

`xRef.CompareReferents` resolves the template from the **first** handle and hands both to it. Handle 1 is safe by construction: it chose the template. Handle 2 is arbitrary. Every concrete delegate cast both, so any pair of same-element-type arrays with different storage crashed in whichever direction put the concrete delegate first.

Seven templates had the identical two-cast opening — `xRTCharDelegate`, `xRTStringDelegate`, `xRTFloat64Delegate`, `ByteBasedDelegate`, `LongBasedDelegate`, `LongLongDelegate`, and `xRTDelegate` itself — and each now tests rather than casts. The contract is stated once, on `ClassTemplate.compareIdentity` where implementors will read it, rather than repeated above each guard.

## Testing

`TestArray.testSliceIdentity` covers the slice case, the view case, and all seven concrete delegates in both directions, with `assert` rather than printing.

- **Red on master:** dies at `array.x:84` with the `ClassCastException` above; the view case dies the same way with `ByteBasedBitView$ViewHandle`.
- **Each delegate verified individually** against clean master `145f12f51`, one module per element type so the first failure cannot mask the rest:

```
Char     master=CRASH  fixed=ok
String   master=CRASH  fixed=ok
Float64  master=CRASH  fixed=ok
Int8     master=CRASH  fixed=ok
Int      master=CRASH  fixed=ok
Int128   master=CRASH  fixed=ok
Object   master=CRASH  fixed=ok
```

- **Green after:** `&nums[1..3] == &nums[1..3]` → `True`, `&nums[1..3] == &nums[0..2]` → `False`, `&bytes.asBitArray() == &bytes.asBitArray()` → `True`, `&chars == &chars[1..3]` → `False`.
- Full `array.x` suite: 0 unhandled exceptions.
- `:javatools:test --rerun-tasks --no-build-cache`: 343 tests, 0 failures, 0 errors.

## Footnote: this could have been a compile error, and immediately spotted

This is worth noting because it is the same root cause as #563 and #560 before it: none of this would have had to show up at runtime. If the base declares the storage protocol `abstract` rather than supplying one subclass's implementation as the default, `javac` names every affected class directly. Applying that to `compareIdentity` alone, on current master, prints:

```
xRTSlicingDelegate.java:23: error: xRTSlicingDelegate is not abstract and does not override
  abstract method compareIdentity(ObjectHandle,ObjectHandle) in xRTDelegate
xRTViewToBit.java:21:     error: xRTViewToBit is not abstract and does not override ...
xRTViewFromByte.java:18:  error: xRTViewFromByte is not abstract and does not override ...
xRTViewFromBit.java:16:   error: xRTViewFromBit is not abstract and does not override ...
```

Four classes, named with file and line, on the first build. This is the actual output, and it is how #563 was found: the compiler pointed straight at the missing `deleteRangeImpl` the instant the base stopped covering for it.

Finding this one took the opposite route: noticing that a base method casts to one specific subclass's handle, enumerating the delegates that are not that subclass, working out which of the five affected methods are actually reachable from Ecstasy (four are not - `xArray` answers `callEquals` itself, and the fixed-size guard rejects `insert`/`delete`), then building a repro for the one that is. That is a fair amount of work to reach something the compiler would have handed over for free, and it is hard to be confident the sweep was exhaustive - honestly, it is exhaustive for these five methods, and the same shape may exist elsewhere.

This PR deliberately changes no architecture - it is two overrides, purely additive, safe on its own. But the "Object/instanceof/cast" design decision is getting increasingly expensive for me, which is worrying. We could absolutely re-type the template boundaries incrementally, so it is not a "must change the entire world" kind of thing. I will try to put up a few simple PRs later to show how I think we can rather easily tighten this up.


