### PR TITLE
Make the implicit-identity cache concurrent: it is written from service threads

### DIFF
--- a/javatools/src/main/java/org/xvm/asm/ConstantPool.java
+++ b/javatools/src/main/java/org/xvm/asm/ConstantPool.java
@@ -3983,7 +3983,7 @@ public class ConstantPool
     /**
      * Cache of implicitly imported identities.
      */
-    private final Map<String, IdentityConstant> f_implicits = new HashMap<>();
+    private final Map<String, IdentityConstant> f_implicits = new ConcurrentHashMap<>();
 
     /**
      * A special "chicken and egg" list of TypeConstants that need to have their TypeInfos rebuilt.

--- a/javatools/src/test/java/org/xvm/asm/ConstantPoolDiagnosticsTest.java
+++ b/javatools/src/test/java/org/xvm/asm/ConstantPoolDiagnosticsTest.java
@@ -1,0 +1,63 @@
+package org.xvm.asm;
+
+
+import java.util.List;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+
+/**
+ * Tests for {@link ConstantPool} thread-safety diagnostics.
+ */
+public class ConstantPoolDiagnosticsTest {
+    /**
+     * The implicit-identity cache is lazily written from concurrent service threads at runtime
+     * (e.g. {@code xService} resolving "Timeout" through the owner pool while sibling services run
+     * on the shared executor; TypeInfo builds resolving "Object"/"String"). All ServiceContexts of
+     * one container share one pool, so no parallel containers are needed to reach this.
+     *
+     * <p>Master's shape was a plain {@code HashMap}, so a {@code put} resize racing another
+     * thread's {@code get} could structurally corrupt the map - lost unrelated entries, broken
+     * bins - not merely duplicate work. The cached values themselves converge (identities are
+     * interned), so the map implementation is the entire defect.</p>
+     *
+     * <p><b>Proven red on master</b> {@code fd7eb58f7}: the instance-type pin below fails
+     * deterministically against the {@code new HashMap<>()} field initializer. The parallel
+     * exercise is the behavioral companion - it cannot be relied on to fail deterministically,
+     * because {@code HashMap} corruption under a race is scheduling-dependent.</p>
+     */
+    @Test
+    public void implicitIdentityCacheIsConcurrentSafe() throws Exception {
+        var pool = new FileStructure("test").getConstantPool();
+
+        var field = ConstantPool.class.getDeclaredField("f_implicits");
+        field.setAccessible(true);
+        assertInstanceOf(ConcurrentMap.class, field.get(pool),
+                "f_implicits is written from service threads and must be a concurrent map");
+
+        var names = List.of("String", "Boolean", "Object", "Exception",
+                "Map", "Array", "Int64", "Char");
+        try (var executor = Executors.newFixedThreadPool(8)) {
+            var start   = new CountDownLatch(1);
+            var futures = names.stream().map(name -> executor.submit(() -> {
+                start.await();
+                return pool.getImplicitlyImportedIdentity(name);
+            })).toList();
+            start.countDown();
+
+            for (int i = 0; i < names.size(); i++) {
+                assertSame(pool.getImplicitlyImportedIdentity(names.get(i)),
+                        futures.get(i).get(10, TimeUnit.SECONDS),
+                        "racing implicit lookups must resolve to the interned identity");
+            }
+        }
+    }
+}

--- a/javatools/src/test/java/org/xvm/asm/ConstantPoolDiagnosticsTest.java
+++ b/javatools/src/test/java/org/xvm/asm/ConstantPoolDiagnosticsTest.java
@@ -19,20 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  */
 public class ConstantPoolDiagnosticsTest {
     /**
-     * The implicit-identity cache is lazily written from concurrent service threads at runtime
-     * (e.g. {@code xService} resolving "Timeout" through the owner pool while sibling services run
-     * on the shared executor; TypeInfo builds resolving "Object"/"String"). All ServiceContexts of
-     * one container share one pool, so no parallel containers are needed to reach this.
+     * {@code f_implicits} backs the pool's memoized {@code clzXxx()} accessors, each of whose
+     * first call does a {@code get} then a {@code put}. That is reachable from service threads -
+     * {@code clzObject()} via {@code TypeConstant.isRootObject()} on the lazy TypeInfo path - and
+     * all ServiceContexts of a container share one pool. The values converge, so the map itself is
+     * the whole defect: a resizing {@code put} racing a {@code get} can lose unrelated keys.
      *
-     * <p>Master's shape was a plain {@code HashMap}, so a {@code put} resize racing another
-     * thread's {@code get} could structurally corrupt the map - lost unrelated entries, broken
-     * bins - not merely duplicate work. The cached values themselves converge (identities are
-     * interned), so the map implementation is the entire defect.</p>
-     *
-     * <p><b>Proven red on master</b> {@code fd7eb58f7}: the instance-type pin below fails
-     * deterministically against the {@code new HashMap<>()} field initializer. The parallel
-     * exercise is the behavioral companion - it cannot be relied on to fail deterministically,
-     * because {@code HashMap} corruption under a race is scheduling-dependent.</p>
+     * <p>The type pin is the assertion and is deterministic. The parallel exercise is a companion
+     * and cannot be relied on to fail, as {@code HashMap} corruption is scheduling-dependent.</p>
      */
     @Test
     public void implicitIdentityCacheIsConcurrentSafe() throws Exception {


### PR DESCRIPTION
`ConstantPool.f_implicits` is a plain `HashMap` that can be read and written from more than one thread. One line fixes it: `ConcurrentHashMap`, already imported in this file.

**Why it is reachable from service threads.** `f_implicits` backs the pool's ~112 memoized `clzXxx()` accessors, and each one's *first* call per pool does a `get` then a `put`. Those first calls are not compiler-only — `clzObject()` is reached from `TypeConstant.isRootObject()`, on the lazy `TypeInfo` path the runtime drives on demand. Every `ServiceContext` in a container shares one `ConstantPool`, and `Runtime` schedules them on an executor sized to `availableProcessors()`, so two services can be inside that first call at the same time.

**Why the map, not the values.** The values converge — identities are interned, so two racing writers publish the same object and losing the race costs nothing. The corruption is in the *map*: a `put` that resizes while another thread reads can leave entries in the wrong bins or drop unrelated keys, and those then misresolve for the life of the pool. So the map implementation is the entire defect and `ConcurrentHashMap` is the entire fix.

**Test.** `ConstantPoolDiagnosticsTest.implicitIdentityCacheIsConcurrentSafe()`. The type pin is the assertion and is deterministic — red against the `HashMap` field initializer, green after. The eight-thread exercise is a companion and is *not* claimed to fail deterministically, since `HashMap` corruption under a race is scheduling-dependent; the javadoc says so.
