### PR TITLE
Keep one failing alarm from killing every timer in the JVM

### DIFF
--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
@@ -264,7 +264,19 @@ public class xLocalClock
 
             @Override
             public void run() {
-                f_alarm.run();
+                try {
+                    f_alarm.run();
+                } catch (Throwable e) {
+                    // must not happen - and must not escape either. TIMER is a single
+                    // process-wide java.util.Timer with one thread, shared by every alarm in
+                    // every container, and java.util.Timer kills that thread and cancels the
+                    // Timer permanently if a TimerTask throws. Letting this out would silently
+                    // disable every alarm in the JVM, surfacing much later as an unrelated hang.
+                    // TODO: report this through a runtime failure channel once one exists,
+                    //       rather than to stderr
+                    System.err.println("Unexpected alarm failure on the shared LocalClock timer");
+                    e.printStackTrace(System.err);
+                }
             }
 
             private final Alarm f_alarm;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
@@ -452,14 +452,24 @@ public class xNanosTimer
 
                 @Override
                 public void run() {
-                    Alarm alarm       = m_alarm;
-                    long cExtraMillis = alarm.checkReadyMillis();
-                    if (cExtraMillis == 0) {
-                        m_alarm = null;
-                        alarm.run();
-                    } else {
-                        // reschedule
-                        xLocalClock.TIMER.schedule(alarm.createTrigger(), cExtraMillis);
+                    try {
+                        Alarm alarm       = m_alarm;
+                        long cExtraMillis = alarm.checkReadyMillis();
+                        if (cExtraMillis == 0) {
+                            m_alarm = null;
+                            alarm.run();
+                        } else {
+                            // reschedule
+                            xLocalClock.TIMER.schedule(alarm.createTrigger(), cExtraMillis);
+                        }
+                    } catch (Throwable e) {
+                        // see xLocalClock.Alarm.Trigger.run(): these triggers are scheduled onto
+                        // the very same process-wide timer, so an escaping exception would kill
+                        // that one shared thread and disable every alarm in the JVM
+                        // TODO: report this through a runtime failure channel once one exists,
+                        //       rather than to stderr
+                        System.err.println("Unexpected alarm failure on the shared NanoTimer trigger");
+                        e.printStackTrace(System.err);
                     }
                 }
 

--- a/javatools/src/test/java/org/xvm/runtime/AlarmTimerSurvivesCallbackFailureTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/AlarmTimerSurvivesCallbackFailureTest.java
@@ -1,0 +1,257 @@
+package org.xvm.runtime;
+
+
+import java.io.File;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.Constants;
+import org.xvm.asm.DirRepository;
+import org.xvm.asm.LinkedRepository;
+import org.xvm.asm.ModuleRepository;
+import org.xvm.asm.Op;
+
+import org.xvm.asm.op.Return_0;
+
+import org.xvm.runtime.ObjectHandle.GenericHandle;
+
+import org.xvm.runtime.template.xBoolean;
+
+import org.xvm.runtime.template.numbers.LongLong;
+import org.xvm.runtime.template.numbers.xInt128;
+
+import org.xvm.runtime.template._native.temporal.xLocalClock;
+import org.xvm.runtime.template._native.temporal.xNanosTimer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+
+/**
+ * The alarm triggers run on one process-wide {@link Timer} with a single thread, shared by every
+ * alarm in every container. {@link java.util.Timer} kills that thread and cancels the Timer
+ * permanently if a {@link TimerTask} throws, so an exception escaping a trigger would silently
+ * disable every alarm in the whole JVM - with the symptom appearing as an unrelated hang, much
+ * later and somewhere else entirely.
+ * <p/>
+ * Each test schedules a real alarm, arranges for it to fail when it matures, and then checks that
+ * the timer thread is still alive and the Timer still accepts work. Failure is injected by dropping
+ * the callback registry entry, which is a state the runtime can reach on its own: a service that
+ * has been collected, or an alarm cancelled concurrently with its own maturation.
+ */
+public class AlarmTimerSurvivesCallbackFailureTest {
+    /**
+     * A LocalClock alarm whose callback has gone missing must not take the shared timer with it.
+     */
+    @Test
+    public void localClockAlarmFailureDoesNotKillTheSharedTimer() throws InterruptedException {
+        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+
+        NativeContainer container = newContainer();
+        ServiceContext  context   = container.createServiceContext("clock");
+        Frame           frame     = entryFrame(context);
+
+        Timer timerLive  = xLocalClock.TIMER;
+        Timer timerProbe = new Timer("test-alarm-timer", true);
+
+        // run against a private timer, so that a thread this test deliberately kills can never be
+        // the one the rest of the suite depends on
+        xLocalClock.TIMER = timerProbe;
+        try {
+            int nResult = xLocalClock.INSTANCE.invokeNativeN(frame,
+                    xLocalClock.INSTANCE.getStructure().findMethod("schedule", 3),
+                    null, scheduleArgs(container), Op.A_IGNORE);
+            assertEquals(Op.R_NEXT, nResult, "the alarm must schedule successfully");
+
+            assertTimerSurvives(context, timerProbe);
+        } finally {
+            xLocalClock.TIMER = timerLive;
+            timerProbe.cancel();
+        }
+    }
+
+    /**
+     * NanoTimer alarms are scheduled onto the very same process-wide timer, through a trigger of
+     * their own, so they carry the same hazard and need the same guard.
+     */
+    @Test
+    public void nanosTimerAlarmFailureDoesNotKillTheSharedTimer() throws InterruptedException {
+        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+
+        NativeContainer container = newContainer();
+        ServiceContext  context   = container.createServiceContext("nanos");
+        Frame           frame     = entryFrame(context);
+
+        ObjectHandle hTimer = xNanosTimer.INSTANCE.ensureTimer(frame, null);
+        xNanosTimer.INSTANCE.invokeNativeN(frame,
+                xNanosTimer.INSTANCE.getStructure().findMethod("start", 0),
+                hTimer, Utils.OBJECTS_NONE, Op.A_IGNORE);
+
+        Timer timerLive  = xLocalClock.TIMER;
+        Timer timerProbe = new Timer("test-alarm-timer", true);
+
+        xLocalClock.TIMER = timerProbe;
+        try {
+            int nResult = xNanosTimer.INSTANCE.invokeNativeN(frame,
+                    xNanosTimer.INSTANCE.getStructure().findMethod("schedule", 3),
+                    hTimer, scheduleArgs(container), Op.A_IGNORE);
+            assertEquals(Op.R_NEXT, nResult, "the alarm must schedule successfully");
+
+            assertTimerSurvives(context, timerProbe);
+        } finally {
+            xLocalClock.TIMER = timerLive;
+            timerProbe.cancel();
+        }
+    }
+
+
+    // ----- helpers -------------------------------------------------------------------------------
+
+    /**
+     * Drop the scheduled alarm's callback so that it fails when it matures, then prove the timer
+     * survived it.
+     * <p/>
+     * A {@link Timer} runs every task on one thread, so a marker task queued behind the alarm can
+     * only run if that thread outlived the alarm's failure.
+     */
+    private static void assertTimerSurvives(ServiceContext context, Timer timer)
+            throws InterruptedException {
+        // the alarm has ALARM_DELAY_MILLIS still to run, so this always lands first
+        context.getCallbackMap().clear();
+
+        var fired = new CountDownLatch(1);
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                fired.countDown();
+            }
+        }, MARKER_DELAY_MILLIS);
+
+        assertTrue(fired.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "a failing alarm must not kill the shared timer thread");
+
+        assertDoesNotThrow(() -> timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+            }
+        }, 0L), "the shared timer must still accept new alarms");
+    }
+
+    /**
+     * @return the argument list for a "schedule(Duration, Alarm, Boolean)" native call
+     */
+    private static ObjectHandle[] scheduleArgs(NativeContainer container) {
+        GenericHandle hDelay = new GenericHandle(
+                container.getTemplate("temporal.Duration").getCanonicalClass());
+        hDelay.setField(null, "picoseconds",
+                xInt128.INSTANCE.makeHandle(new LongLong(ALARM_DELAY_MILLIS * PICOS_PER_MILLI)));
+
+        return new ObjectHandle[]{hDelay, null, xBoolean.FALSE};
+    }
+
+    private static NativeContainer newContainer() {
+        return new NativeContainer(new Runtime(), systemRepository());
+    }
+
+    /**
+     * Create a native entry frame for the specified service, of the shape a native method receives.
+     */
+    private static Frame entryFrame(ServiceContext context) {
+        var message = new ServiceContext.Message(null) {
+            @Override
+            public boolean isAsync() {
+                return true;
+            }
+
+            @Override
+            public int getCallDepth() {
+                return 0;
+            }
+
+            @Override
+            public ObjectHandle getTimeoutHandle() {
+                return null;
+            }
+
+            @Override
+            public long getTimeoutStamp() {
+                return 0L;
+            }
+
+            @Override
+            Frame createFrame(ServiceContext ctx) {
+                return ctx.createServiceEntryFrame(this, 0, NATIVE_OPS);
+            }
+        };
+        return context.createServiceEntryFrame(message, 0, NATIVE_OPS);
+    }
+
+    private static boolean systemModulesAvailable() {
+        ModuleRepository repository = systemRepository();
+        return repository != null
+            && repository.loadModule(Constants.ECSTASY_MODULE) != null
+            && repository.loadModule(Constants.TURTLE_MODULE)  != null
+            && repository.loadModule(Constants.NATIVE_MODULE)  != null;
+    }
+
+    /**
+     * Test-only locator for the gradle build outputs that hold the compiled system modules.
+     */
+    private static ModuleRepository systemRepository() {
+        var repositories = SYSTEM_MODULE_PATHS.stream()
+                .map(AlarmTimerSurvivesCallbackFailureTest::repositoryFor)
+                .filter(Objects::nonNull)
+                .toList();
+        return repositories.isEmpty()
+                ? null
+                : new LinkedRepository(repositories.toArray(ModuleRepository.NO_REPOS));
+    }
+
+    private static ModuleRepository repositoryFor(String path) {
+        File directory = checkoutFile(path);
+        return directory.isDirectory() ? new DirRepository(directory, true) : null;
+    }
+
+    private static File checkoutFile(String path) {
+        Path root = Path.of("").toAbsolutePath();
+        while (root != null && !Files.isDirectory(root.resolve("javatools"))) {
+            root = root.getParent();
+        }
+        return Objects.requireNonNull(root, "checkout root").resolve(path).toFile();
+    }
+
+
+    // ----- constants -----------------------------------------------------------------------------
+
+    private static final List<String> SYSTEM_MODULE_PATHS = List.of(
+            "lib_ecstasy/build/xtc/main/lib",
+            "javatools_bridge/build/xtc/main/lib",
+            "xdk/build/install/xdk/lib",
+            "xdk/build/install/xdk/javatools");
+
+    private static final Op[] NATIVE_OPS = new Op[]{Return_0.INSTANCE};
+
+    private static final long PICOS_PER_MILLI = 1_000_000_000L;
+
+    /** Long enough that the callback is always dropped before the alarm matures. */
+    private static final long ALARM_DELAY_MILLIS = 500L;
+
+    /** Queued behind the alarm, so it only runs if the timer thread outlived the failure. */
+    private static final long MARKER_DELAY_MILLIS = 1_500L;
+
+    private static final long AWAIT_TIMEOUT_SECONDS = 10L;
+}


### PR DESCRIPTION
`xLocalClock.TIMER` is a **single process-wide `java.util.Timer`** — one thread, shared by every alarm in every container in the JVM:

```java
public static Timer TIMER = new Timer("ecstasy:LocalClock", true);   // xLocalClock.java:282
```

The only thing scheduled on it is `Alarm.Trigger`, and its `run()` had no guard:

```java
protected static class Trigger extends TimerTask {
    @Override
    public void run() {
        f_alarm.run();          // nothing catches anything
    }
}
```

`java.util.Timer`'s own thread catches nothing. **An exception escaping `TimerTask.run()` terminates that thread and cancels the Timer permanently**, so every later `TIMER.schedule(...)` — at `:128`, `:226` and `:239` — throws `IllegalStateException: Timer already cancelled`.

So one bad alarm silently disables **every alarm in the whole process**.

## Why this is nasty rather than merely wrong

The failure does not surface where it happens. A dead `Timer` means alarms simply never fire, so what you observe is a **hang** — in a different container, arbitrarily later, with nothing in the log connecting it to the alarm that died. There is no error, no degraded mode, no signal at all.

It is reachable today. `Alarm.run()` calls `WeakCallback.extractCallback()`, which on master ends in a bare `throw new IllegalStateException()` whenever the context is gone or the callback id was already removed — precisely the shutdown/cancel race a timer thread is most likely to hit.

## The fix

Guard at the `TimerTask` boundary so the timer thread survives, and **record** the failure rather than discarding it.

Deliberately **not** a blanket `catch` around `context.callLater(...)`: that would swallow real errors at the one place a diagnostic is useful. The guard belongs at the boundary that must not die, not around the call that might legitimately fail.

**Both triggers are guarded, not just `xLocalClock`'s.** `xNanosTimer`'s `Trigger` schedules onto the same static `TIMER` and calls the same throwing method, so fixing one would leave the identical JVM-wide kill switch armed. Its test is red on master too.

31 lines added, 9 removed, across 2 files. Nothing changes for a program that works today — this only adds a guard where there was none.

## Proof

`AlarmTimerSurvivesCallbackFailureTest` — **8 failures / 8 runs** on master, **0 / 8** after. The test log shows the thread dying:

```
Exception in thread "test-alarm-timer" java.lang.IllegalStateException
  at org.xvm.runtime.WeakCallback.extractCallback(WeakCallback.java:37)
  at ...xLocalClock$Alarm.run(xLocalClock.java:232)
  at ...xLocalClock$Alarm$Trigger.run(xLocalClock.java:267)
  at java.base/java.util.TimerThread.mainLoop(Timer.java:572)
```

It is not timing-luck. `java.util.Timer` runs everything on one thread, so the test schedules a real alarm on a **private** Timer at 500 ms, drops the callback at ~1 ms (a 500× margin), queues a marker task at 1500 ms and awaits 10 s — the marker can only fire if that thread outlived the failure. The timer thread is a daemon with a bounded join, so a failure ends the test cleanly rather than hanging CI.

`:javatools:test` 348 → 350, same 40 pre-existing environment-gated skips.

## Relationship to the other clock PR

This is independent of the callback-registry work in the companion PR, in both directions, and either can land first — they conflict textually in `xLocalClock.java` and `xNanosTimer.java`, so whichever goes second wants a rebase.

The distinction is worth stating: that PR removes the throwers we currently know about. This one says the timer thread must survive one we do not. If a future thrower appears on this path — from `callLater`, from the fiber machinery — the kill switch is still armed without this change.
