### PR TITLE
Resolve native templates per container instead of through mutable statics

### DIFF
--- a/javatools/src/main/java/org/xvm/api/InterpreterConnector.java
+++ b/javatools/src/main/java/org/xvm/api/InterpreterConnector.java
@@ -95,7 +95,7 @@ public class InterpreterConnector
                 TypeConstant typeArg = method.getParam(0).getType();
 
                 assert typeStrings.isA(typeArg);
-                ahArg = new ObjectHandle[]{xString.makeArrayHandle(asArg)};
+                ahArg = new ObjectHandle[]{xString.makeArrayHandle(m_containerMain, asArg)};
             }
             break;
 
@@ -103,7 +103,7 @@ public class InterpreterConnector
             TypeConstant typeArg = method.getParam(0).getType();
             assert typeStrings.isA(typeArg);
             // the method requires an array that we can supply
-            ahArg = new ObjectHandle[]{xString.makeArrayHandle(asArg)};
+            ahArg = new ObjectHandle[]{xString.makeArrayHandle(m_containerMain, asArg)};
             break;
         }
         }

--- a/javatools/src/main/java/org/xvm/asm/OpVar.java
+++ b/javatools/src/main/java/org/xvm/asm/OpVar.java
@@ -147,7 +147,8 @@ public abstract class OpVar
         if (clzArray == null || !typeList.equals(typePrev)) {
             TypeConstant typeEl = typeList.resolveGenericType("Element");
 
-            clzArray = xArray.INSTANCE.ensureParameterizedClass(context.f_container, typeEl);
+            clzArray = context.f_container.nativeTemplates().get(xArray.class).
+                    ensureParameterizedClass(context.f_container, typeEl);
 
             context.setOpInfo(this, Category.Composition, clzArray);
             context.setOpInfo(this, Category.Type, typeList);

--- a/javatools/src/main/java/org/xvm/asm/OpVar.java
+++ b/javatools/src/main/java/org/xvm/asm/OpVar.java
@@ -147,7 +147,7 @@ public abstract class OpVar
         if (clzArray == null || !typeList.equals(typePrev)) {
             TypeConstant typeEl = typeList.resolveGenericType("Element");
 
-            clzArray = context.f_container.nativeTemplates().get(xArray.class).
+            clzArray = context.f_container.nativeTemplate(xArray.class).
                     ensureParameterizedClass(context.f_container, typeEl);
 
             context.setOpInfo(this, Category.Composition, clzArray);

--- a/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
+++ b/javatools/src/main/java/org/xvm/asm/constants/TypeConstant.java
@@ -7812,7 +7812,7 @@ public abstract class TypeConstant
         }
 
         // don't cache a "foreign" handle
-        return xRTType.makeForeignHandle(this);
+        return xRTType.makeForeignHandle(container, this);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/asm/op/Assert.java
+++ b/javatools/src/main/java/org/xvm/asm/op/Assert.java
@@ -126,7 +126,7 @@ public class Assert
         ClassConstant    constClz    = (ClassConstant) idConstruct.getNamespace();
         ClassTemplate    template    = frame.ensureTemplate(constClz);
         ClassComposition clzTarget   = template.getCanonicalClass(frame.f_context.f_container);
-        StringHandle     hMsg        = xString.makeHandle(sMsg);
+        StringHandle     hMsg        = xString.makeHandle(frame, sMsg);
         ObjectHandle[]   ahArg       = new ObjectHandle[construct.getMaxVars()];
 
         ahArg[0] = hMsg;

--- a/javatools/src/main/java/org/xvm/asm/op/MoveRef.java
+++ b/javatools/src/main/java/org/xvm/asm/op/MoveRef.java
@@ -18,6 +18,7 @@ import org.xvm.javajit.RegisterInfo;
 
 import org.xvm.javajit.registers.Ref;
 
+import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.TypeComposition;
@@ -71,8 +72,9 @@ public class MoveRef
                     typeReg = infoSrc.getType();
                 }
             } else {
-                TypeComposition clzRef = xRef.INSTANCE.ensureParameterizedClass(
-                        frame.f_context.f_container, infoSrc.getType());
+                Container       container = frame.f_context.f_container;
+                TypeComposition clzRef    = container.nativeTemplates().get(xRef.class).
+                        ensureParameterizedClass(container, infoSrc.getType());
                 hRef    = new RefHandle(clzRef, frame, m_nFromValue);
                 typeReg = hRef.getType();
             }

--- a/javatools/src/main/java/org/xvm/asm/op/MoveRef.java
+++ b/javatools/src/main/java/org/xvm/asm/op/MoveRef.java
@@ -72,8 +72,8 @@ public class MoveRef
                     typeReg = infoSrc.getType();
                 }
             } else {
-                Container       container = frame.f_context.f_container;
-                TypeComposition clzRef    = container.nativeTemplates().get(xRef.class).
+                Container       container = frame.container();
+                TypeComposition clzRef    = container.nativeTemplate(xRef.class).
                         ensureParameterizedClass(container, infoSrc.getType());
                 hRef    = new RefHandle(clzRef, frame, m_nFromValue);
                 typeReg = hRef.getType();

--- a/javatools/src/main/java/org/xvm/asm/op/MoveVar.java
+++ b/javatools/src/main/java/org/xvm/asm/op/MoveVar.java
@@ -104,8 +104,8 @@ public class MoveVar
                         ? frame.poolContext().typeObject()
                         : frame.getVarInfo(nFrom).getType();
             }
-            Container       container = frame.f_context.f_container;
-            TypeComposition clzRef    = container.nativeTemplates().get(xVar.class).
+            Container       container = frame.container();
+            TypeComposition clzRef    = container.nativeTemplate(xVar.class).
                     ensureParameterizedClass(container, typeReferent);
             hRef = new RefHandle(clzRef, frame, nFrom);
             if (fNextReg) {

--- a/javatools/src/main/java/org/xvm/asm/op/MoveVar.java
+++ b/javatools/src/main/java/org/xvm/asm/op/MoveVar.java
@@ -18,6 +18,7 @@ import org.xvm.javajit.RegisterInfo;
 
 import org.xvm.javajit.registers.Ref;
 
+import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.ExceptionHandle;
@@ -103,8 +104,9 @@ public class MoveVar
                         ? frame.poolContext().typeObject()
                         : frame.getVarInfo(nFrom).getType();
             }
-            TypeComposition clzRef = xVar.INSTANCE.
-                    ensureParameterizedClass(frame.f_context.f_container, typeReferent);
+            Container       container = frame.f_context.f_container;
+            TypeComposition clzRef    = container.nativeTemplates().get(xVar.class).
+                    ensureParameterizedClass(container, typeReferent);
             hRef = new RefHandle(clzRef, frame, nFrom);
             if (fNextReg) {
                 frame.introduceResolvedVar(nTo, hRef.getType());

--- a/javatools/src/main/java/org/xvm/asm/op/Var_M.java
+++ b/javatools/src/main/java/org/xvm/asm/op/Var_M.java
@@ -108,7 +108,7 @@ public class Var_M
 
             frame.introduceResolvedVar(m_nVar, typeMap, null, Frame.VAR_STANDARD, null);
 
-            return frame.f_context.f_container.nativeTemplates().get(xListMap.class).
+            return frame.nativeTemplate(xListMap.class).
                     constructMap(frame, typeMap, ahKey, ahValue,
                             anyDeferred(ahKey), anyDeferred(ahValue), m_nVar);
         } catch (ExceptionHandle.WrapperException e) {

--- a/javatools/src/main/java/org/xvm/asm/op/Var_M.java
+++ b/javatools/src/main/java/org/xvm/asm/op/Var_M.java
@@ -108,8 +108,9 @@ public class Var_M
 
             frame.introduceResolvedVar(m_nVar, typeMap, null, Frame.VAR_STANDARD, null);
 
-            return xListMap.INSTANCE.constructMap(frame, typeMap, ahKey, ahValue,
-                    anyDeferred(ahKey), anyDeferred(ahValue), m_nVar);
+            return frame.f_context.f_container.nativeTemplates().get(xListMap.class).
+                    constructMap(frame, typeMap, ahKey, ahValue,
+                            anyDeferred(ahKey), anyDeferred(ahValue), m_nVar);
         } catch (ExceptionHandle.WrapperException e) {
             return frame.raiseException(e);
         }

--- a/javatools/src/main/java/org/xvm/asm/op/Var_MN.java
+++ b/javatools/src/main/java/org/xvm/asm/op/Var_MN.java
@@ -117,7 +117,7 @@ public class Var_MN
             frame.introduceResolvedVar(m_nVar, typeMap,
                     frame.getString(m_nNameId), Frame.VAR_STANDARD, null);
 
-            return frame.f_context.f_container.nativeTemplates().get(xListMap.class).
+            return frame.nativeTemplate(xListMap.class).
                     constructMap(frame, typeMap, ahKey, ahValue,
                             anyDeferred(ahKey), anyDeferred(ahValue), m_nVar);
         } catch (ExceptionHandle.WrapperException e) {

--- a/javatools/src/main/java/org/xvm/asm/op/Var_MN.java
+++ b/javatools/src/main/java/org/xvm/asm/op/Var_MN.java
@@ -117,8 +117,9 @@ public class Var_MN
             frame.introduceResolvedVar(m_nVar, typeMap,
                     frame.getString(m_nNameId), Frame.VAR_STANDARD, null);
 
-            return xListMap.INSTANCE.constructMap(frame, typeMap, ahKey, ahValue,
-                    anyDeferred(ahKey), anyDeferred(ahValue), m_nVar);
+            return frame.f_context.f_container.nativeTemplates().get(xListMap.class).
+                    constructMap(frame, typeMap, ahKey, ahValue,
+                            anyDeferred(ahKey), anyDeferred(ahValue), m_nVar);
         } catch (ExceptionHandle.WrapperException e) {
             return frame.raiseException(e);
         }

--- a/javatools/src/main/java/org/xvm/runtime/ClassComposition.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassComposition.java
@@ -429,7 +429,7 @@ public class ClassComposition
                 FieldInfo field = entry.getValue();
 
                 if (!(enid instanceof NestedIdentity) && field.isRegular()) {
-                    ashNames[i++] = xString.makeHandle(field.getName());
+                    ashNames[i++] = xString.makeHandle(f_container, field.getName());
                 }
             }
             assert i == m_cRegularFields;

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -127,7 +127,38 @@ public abstract class ClassTemplate
      * @param template  the new template
      */
     protected void registerNativeTemplate(ClassTemplate template) {
+        registerAuxiliaryTemplate(template);
+
+        // this template implements a composite type declared by "this" one, so it has no name of
+        // its own to be found under; publish it into the container's native template table
+        nativeTemplates().register(template);
+    }
+
+    /**
+     * Register a native template that serves an additional structure using a template class that
+     * is already spoken for. Unlike {@link #registerNativeTemplate}, this does not make the
+     * template its class's native instance - {@link NativeTemplates#get} must keep answering with
+     * the template registered for the class's own structure.
+     *
+     * @param template  the new template
+     */
+    protected void registerAuxiliaryTemplate(ClassTemplate template) {
         ((NativeContainer) f_container).registerNativeTemplate(template.getCanonicalType(), template);
+    }
+
+    /**
+     * @return this template's container's table of native templates
+     */
+    protected NativeTemplates nativeTemplates() {
+        return NativeTemplates.of(f_container);
+    }
+
+    /**
+     * @return true iff this is the container's native template for its class, rather than one of
+     *         the per-structure templates that the same class also backs
+     */
+    protected boolean isNativeInstance() {
+        return nativeTemplates().isNativeInstance(this);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -154,11 +154,18 @@ public abstract class ClassTemplate
     }
 
     /**
-     * @return true iff this is the container's native template for its class, rather than one of
-     *         the per-structure templates that the same class also backs
+     * Note: the class has to be named explicitly, because it is the class that <i>declares</i> the
+     * calling method that matters, not this template's own class. A template that inherits such a
+     * method - {@code xVar} extends {@code xRef} - is the native instance of its own class while
+     * still not being the one the inherited method is asking about.
+     *
+     * @param clzTemplate  the native template class being asked about
+     *
+     * @return true iff this is the container's native template for the specified class, rather
+     *         than one of the per-structure templates that the same class also backs
      */
-    protected boolean isNativeInstance() {
-        return nativeTemplates().isNativeInstance(this);
+    protected boolean isNativeInstance(Class<? extends ClassTemplate> clzTemplate) {
+        return this == nativeTemplates().get(clzTemplate);
     }
 
     /**
@@ -211,7 +218,7 @@ public abstract class ClassTemplate
                 if ("Object".equals(f_sName)) {
                     return null;
                 }
-                templateSuper = m_templateSuper = xObject.INSTANCE;
+                templateSuper = m_templateSuper = nativeTemplates().get(xObject.class);
             } else {
                 templateSuper = m_templateSuper =
                     f_container.getTemplate(f_structSuper.getIdentityConstant());
@@ -2001,7 +2008,7 @@ public abstract class ClassTemplate
      * @return one of the {@link Op#R_NEXT}, {@link Op#R_CALL} or {@link Op#R_EXCEPTION} values
      */
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
-        return frame.assignValue(iReturn, xString.makeHandle(hTarget.toString()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, hTarget.toString()));
     }
 
 
@@ -2458,7 +2465,7 @@ public abstract class ClassTemplate
             if (hfn == null) {
                 // in case super constructors have their own finalizers, we need a non-null anchor
                 // that may be replaced by Frame.chainFinalizers()
-                hfn = FullyBoundHandle.NO_OP;
+                hfn = FullyBoundHandle.ensureNoOp(frame.f_context.f_container);
             }
 
             frame.m_hfnFinally = hfn;

--- a/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/ClassTemplate.java
@@ -147,10 +147,14 @@ public abstract class ClassTemplate
     }
 
     /**
+     * Obtain this template's container's table of native templates - for registering a template,
+     * or anything else that works on the table itself. To just look one up, prefer the shorthand
+     * {@link Container#nativeTemplate} on {@link #f_container}.
+     *
      * @return this template's container's table of native templates
      */
     protected NativeTemplates nativeTemplates() {
-        return NativeTemplates.of(f_container);
+        return f_container.nativeTemplates();
     }
 
     /**
@@ -165,7 +169,7 @@ public abstract class ClassTemplate
      *         than one of the per-structure templates that the same class also backs
      */
     protected boolean isNativeInstance(Class<? extends ClassTemplate> clzTemplate) {
-        return this == nativeTemplates().get(clzTemplate);
+        return this == f_container.nativeTemplate(clzTemplate);
     }
 
     /**
@@ -218,7 +222,7 @@ public abstract class ClassTemplate
                 if ("Object".equals(f_sName)) {
                     return null;
                 }
-                templateSuper = m_templateSuper = nativeTemplates().get(xObject.class);
+                templateSuper = m_templateSuper = f_container.nativeTemplate(xObject.class);
             } else {
                 templateSuper = m_templateSuper =
                     f_container.getTemplate(f_structSuper.getIdentityConstant());
@@ -2465,7 +2469,7 @@ public abstract class ClassTemplate
             if (hfn == null) {
                 // in case super constructors have their own finalizers, we need a non-null anchor
                 // that may be replaced by Frame.chainFinalizers()
-                hfn = FullyBoundHandle.ensureNoOp(frame.f_context.f_container);
+                hfn = FullyBoundHandle.ensureNoOp(frame.container());
             }
 
             frame.m_hfnFinally = hfn;

--- a/javatools/src/main/java/org/xvm/runtime/Container.java
+++ b/javatools/src/main/java/org/xvm/runtime/Container.java
@@ -400,6 +400,13 @@ public abstract class Container
     }
 
     /**
+     * @return this container's table of native templates
+     */
+    public NativeTemplates nativeTemplates() {
+        return getNativeContainer().f_templates;
+    }
+
+    /**
      * @return a ClassTemplate for a type associated with the specified name (core classes only)
      */
     public ClassTemplate getTemplate(String sName) {

--- a/javatools/src/main/java/org/xvm/runtime/Container.java
+++ b/javatools/src/main/java/org/xvm/runtime/Container.java
@@ -99,7 +99,7 @@ public abstract class Container
         ServiceContext ctx = m_contextMain;
         if (ctx == null) {
             try (var ignore = ConstantPool.withPool(getConstantPool())) {
-                xService templateService = nativeTemplates().get(xService.class);
+                xService templateService = nativeTemplate(xService.class);
 
                 m_contextMain = ctx = createServiceContext(getModule().getName());
                 templateService.createServiceHandle(ctx,
@@ -402,10 +402,29 @@ public abstract class Container
     }
 
     /**
+     * Obtain this container's table of native templates.
+     *
+     * <p>One of three ways in. This one is the table itself, for bulk work - registering a
+     * template, or anything else that is not a single lookup. To look one template up, use
+     * {@link #nativeTemplate}. To get the table from something that is not a container -
+     * a frame, a template, a composition - use {@link NativeTemplates#of}.</p>
+     *
      * @return this container's table of native templates
      */
     public NativeTemplates nativeTemplates() {
         return getNativeContainer().f_templates;
+    }
+
+    /**
+     * Look one native template up - the shorthand for the common case, over
+     * {@link #nativeTemplates()}.
+     *
+     * @param clzTemplate  the native template class
+     *
+     * @return this container's native template of that class
+     */
+    public <T extends ClassTemplate> T nativeTemplate(Class<T> clzTemplate) {
+        return nativeTemplates().get(clzTemplate);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/Container.java
+++ b/javatools/src/main/java/org/xvm/runtime/Container.java
@@ -99,10 +99,12 @@ public abstract class Container
         ServiceContext ctx = m_contextMain;
         if (ctx == null) {
             try (var ignore = ConstantPool.withPool(getConstantPool())) {
+                xService templateService = nativeTemplates().get(xService.class);
+
                 m_contextMain = ctx = createServiceContext(getModule().getName());
-                xService.INSTANCE.createServiceHandle(ctx,
-                    xService.INSTANCE.getCanonicalClass(),
-                    xService.INSTANCE.getCanonicalType());
+                templateService.createServiceHandle(ctx,
+                    templateService.getCanonicalClass(),
+                    templateService.getCanonicalType());
             }
         }
         return ctx;

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -236,7 +236,7 @@ public class Frame
      * @return a new frame
      */
     public Frame createWaitFrame(CompletableFuture<ObjectHandle> cfResult, int iReturn) {
-        return createWaitFrame(xFuture.makeHandle(cfResult), iReturn);
+        return createWaitFrame(xFuture.makeHandle(f_context.f_container, cfResult), iReturn);
     }
 
     /**
@@ -280,7 +280,7 @@ public class Frame
             CompletableFuture<ObjectHandle> cfReturn =
                     cfResult.thenApply(ahResult -> ahResult[iResult]);
 
-            ahFuture[i] = xFuture.makeHandle(cfReturn);
+            ahFuture[i] = xFuture.makeHandle(f_context.f_container, cfReturn);
 
             frameNext.f_aInfo[i] = new VarInfo(xFuture.TYPE, VAR_DYNAMIC_REF);
         }
@@ -1047,7 +1047,7 @@ public class Frame
         }
 
         if (isFuture(iReturn)) {
-            return assignValue(iReturn, xFuture.makeHandle(cfResult));
+            return assignValue(iReturn, xFuture.makeHandle(f_context.f_container, cfResult));
         }
 
         // the wait frame will deal with exceptions

--- a/javatools/src/main/java/org/xvm/runtime/Frame.java
+++ b/javatools/src/main/java/org/xvm/runtime/Frame.java
@@ -236,7 +236,7 @@ public class Frame
      * @return a new frame
      */
     public Frame createWaitFrame(CompletableFuture<ObjectHandle> cfResult, int iReturn) {
-        return createWaitFrame(xFuture.makeHandle(f_context.f_container, cfResult), iReturn);
+        return createWaitFrame(xFuture.makeHandle(container(), cfResult), iReturn);
     }
 
     /**
@@ -280,7 +280,7 @@ public class Frame
             CompletableFuture<ObjectHandle> cfReturn =
                     cfResult.thenApply(ahResult -> ahResult[iResult]);
 
-            ahFuture[i] = xFuture.makeHandle(f_context.f_container, cfReturn);
+            ahFuture[i] = xFuture.makeHandle(container(), cfReturn);
 
             frameNext.f_aInfo[i] = new VarInfo(xFuture.TYPE, VAR_DYNAMIC_REF);
         }
@@ -1047,7 +1047,7 @@ public class Frame
         }
 
         if (isFuture(iReturn)) {
-            return assignValue(iReturn, xFuture.makeHandle(f_context.f_container, cfResult));
+            return assignValue(iReturn, xFuture.makeHandle(container(), cfResult));
         }
 
         // the wait frame will deal with exceptions
@@ -1329,6 +1329,25 @@ public class Frame
      */
     public ConstantPool poolContext() {
         return f_context.f_pool;
+    }
+
+    /**
+     * @return the container that owns the service this frame is running on
+     */
+    public Container container() {
+        return f_context.f_container;
+    }
+
+    /**
+     * Look one native template up - the shorthand for the common case, over
+     * {@code container().nativeTemplates()}.
+     *
+     * @param clzTemplate  the native template class
+     *
+     * @return this frame's container's native template of that class
+     */
+    public <T extends ClassTemplate> T nativeTemplate(Class<T> clzTemplate) {
+        return container().nativeTemplate(clzTemplate);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/MainContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/MainContainer.java
@@ -67,7 +67,7 @@ public class MainContainer
             if (typeRequired.equals(typeStrings)) {
                 // require String[], return the whole List<String> as an array
                 String[] asValue = listValue.toArray(String[]::new);
-                return xString.makeArrayHandle(frame.f_context.f_container, asValue);
+                return xString.makeArrayHandle(frame.container(), asValue);
             }
             if (typeRequired.isEnum()) {
                 TypeComposition clz    = typeRequired.ensureClass(frame);

--- a/javatools/src/main/java/org/xvm/runtime/MainContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/MainContainer.java
@@ -62,12 +62,12 @@ public class MainContainer
         if (!listValue.isEmpty()) {
             if (typeRequired.equals(typeString)) {
                 // require String, return the last element
-                return xString.makeHandle(listValue.getLast());
+                return xString.makeHandle(frame, listValue.getLast());
             }
             if (typeRequired.equals(typeStrings)) {
                 // require String[], return the whole List<String> as an array
                 String[] asValue = listValue.toArray(String[]::new);
-                return xString.makeArrayHandle(asValue);
+                return xString.makeArrayHandle(frame.f_context.f_container, asValue);
             }
             if (typeRequired.isEnum()) {
                 TypeComposition clz    = typeRequired.ensureClass(frame);
@@ -108,7 +108,7 @@ public class MainContainer
         TypeComposition clz      = type.ensureClass(frame);
         ClassTemplate   template = clz.getTemplate();
         MethodStructure ctor     = template.getStructure().findMethod("construct", 1, pool.typeString());
-        ObjectHandle[]  ahArgs   = new ObjectHandle[]{xString.makeHandle(sValue)};
+        ObjectHandle[]  ahArgs   = new ObjectHandle[]{xString.makeHandle(frame, sValue)};
         int             iResult  = template.construct(frame, ctor, clz, null, ahArgs, Op.A_STACK);
         return frame.popResult(iResult);
     }
@@ -203,7 +203,7 @@ public class MainContainer
             CallChain         chain      = clzModule.getMethodCallChain(sigMethod);
             boolean           fReturn    = sigMethod.getReturnCount() > 0;
 
-            FunctionHandle hInstantiateModuleAndRun = new NativeFunctionHandle((frame, ah, iRet) -> {
+            FunctionHandle hInstantiateModuleAndRun = new NativeFunctionHandle(this, (frame, ah, iRet) -> {
                 SingletonConstant idModule = frame.poolContext().ensureSingletonConstConstant(f_idModule);
                 ObjectHandle      hModule  = frame.getConstHandle(idModule);
                 int               iReturn  = fReturn ? Op.A_STACK : Op.A_IGNORE;

--- a/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
@@ -167,8 +167,8 @@ public class NativeContainer
             scanNativeDirectory(dirTemplates, "", mapTemplateClasses);
         }
 
-        // we need a number of INSTANCE static variables to be set up right away
-        // (they are used by the ClassTemplate constructor)
+        // these have to be registered before anything else: the templates constructed below look
+        // them up through the container's native template table while they are being built
         storeNativeTemplate(new xObject (this, getClassStructure("Object"),  true));
         storeNativeTemplate(new xEnum   (this, getClassStructure("Enum"),    true));
         storeNativeTemplate(new xConst  (this, getClassStructure("Const"),   true));
@@ -202,8 +202,8 @@ public class NativeContainer
         }
 
         // add run-time templates
-        f_mapTemplatesByType.put(pool.typeFunction(), xRTFunction.INSTANCE);
-        f_mapTemplatesByType.put(pool.typeType()    , xRTType.INSTANCE);
+        f_mapTemplatesByType.put(pool.typeFunction(), f_templates.get(xRTFunction.class));
+        f_mapTemplatesByType.put(pool.typeType()    , f_templates.get(xRTType.class));
 
         // clone the map since the loop below can add to it
         Set<ClassTemplate> setTemplates = new HashSet<>(f_mapTemplatesByType.values());
@@ -301,24 +301,24 @@ public class NativeContainer
 
     private void initResources(ConstantPool pool) {
         // +++ temporal.LocalClock
-        xLocalClock  templateClock = xLocalClock.INSTANCE;
+        xLocalClock  templateClock = f_templates.get(xLocalClock.class);
         TypeConstant typeClock     = templateClock.getCanonicalType();
         addResourceSupplier(new InjectionKey("clock"     , typeClock), templateClock::ensureDefaultClock);
         addResourceSupplier(new InjectionKey("localClock", typeClock), templateClock::ensureLocalClock);
         addResourceSupplier(new InjectionKey("utcClock"  , typeClock), templateClock::ensureUTCClock);
 
         // +++ temporal.NanosTimer
-        xNanosTimer  templateTimer = xNanosTimer.INSTANCE;
+        xNanosTimer  templateTimer = f_templates.get(xNanosTimer.class);
         TypeConstant typeTimer     = templateTimer.getCanonicalType();
         addResourceSupplier(new InjectionKey("timer", typeTimer), templateTimer::ensureTimer);
 
         // +++ io.Console
-        xTerminalConsole templateConsole = xTerminalConsole.INSTANCE;
+        xTerminalConsole templateConsole = f_templates.get(xTerminalConsole.class);
         TypeConstant     typeConsole     = templateConsole.getCanonicalType();
         addResourceSupplier(new InjectionKey("console", typeConsole), templateConsole::ensureConsole);
 
         // +++ numbers.Random
-        xRTRandom    templateRandom = xRTRandom.INSTANCE;
+        xRTRandom    templateRandom = f_templates.get(xRTRandom.class);
         TypeConstant typeRandom     = templateRandom.getCanonicalType();
         addResourceSupplier(new InjectionKey("rnd"   , typeRandom), templateRandom::ensureDefaultRandom);
         addResourceSupplier(new InjectionKey("random", typeRandom), templateRandom::ensureDefaultRandom);
@@ -333,55 +333,55 @@ public class NativeContainer
         addResourceSupplier(new InjectionKey("tmpDir" , typeDirectory), this::ensureTmpDir);
 
         // +++ net:Network
-        xRTNetwork   templateNetwork = xRTNetwork.INSTANCE;
+        xRTNetwork   templateNetwork = f_templates.get(xRTNetwork.class);
         TypeConstant typeNetwork     = templateNetwork.getCanonicalType();
         addResourceSupplier(new InjectionKey("network"        , typeNetwork), this::ensureInsecureNetwork);
         addResourceSupplier(new InjectionKey("insecureNetwork", typeNetwork), this::ensureInsecureNetwork);
         addResourceSupplier(new InjectionKey("secureNetwork"  , typeNetwork), this::ensureSecureNetwork);
 
         // +++ crypto:KeyStore
-        xRTKeyStore  templateKeyStore = xRTKeyStore.INSTANCE;
+        xRTKeyStore  templateKeyStore = f_templates.get(xRTKeyStore.class);
         TypeConstant typeKeyStore     = templateKeyStore.getCanonicalType();
         addResourceSupplier(new InjectionKey("keystore", typeKeyStore), templateKeyStore::ensureKeyStore);
 
         // +++ crypto:CertificateManager
-        xRTCertificateManager templateCertManager = xRTCertificateManager.INSTANCE;
+        xRTCertificateManager templateCertManager = f_templates.get(xRTCertificateManager.class);
         TypeConstant          typeCertManager     = templateCertManager.getCanonicalType();
         addResourceSupplier(new InjectionKey("manager", typeCertManager), templateCertManager::ensureManager);
 
         // +++ crypto:Algorithms
-        xRTAlgorithms templateAlgorithms = xRTAlgorithms.INSTANCE;
+        xRTAlgorithms templateAlgorithms = f_templates.get(xRTAlgorithms.class);
         TypeConstant  typeAlgorithms     = pool.ensureTerminalTypeConstant(
                 pool.ensureClassConstant(pool.ensureModuleConstant("crypto.xtclang.org"), "Algorithms"));
         addResourceSupplier(new InjectionKey("algorithms", typeAlgorithms), templateAlgorithms::ensureAlgorithms);
 
         // +++ web:Client.Connector
-        xRTConnector templateConnector = xRTConnector.INSTANCE;
+        xRTConnector templateConnector = f_templates.get(xRTConnector.class);
         TypeConstant typeConnector     = templateConnector.getCanonicalType();
         addResourceSupplier(new InjectionKey("connector", typeConnector), templateConnector::ensureConnector);
 
         // +++ web:WebServer
-        xRTServer templateServer = xRTServer.INSTANCE;
+        xRTServer templateServer = f_templates.get(xRTServer.class);
         TypeConstant typeServer  = templateServer.getCanonicalType();
         addResourceSupplier(new InjectionKey("server", typeServer), templateServer::ensureServer);
 
         // +++ mgmt.Linker
-        xContainerLinker templateLinker = xContainerLinker.INSTANCE;
+        xContainerLinker templateLinker = f_templates.get(xContainerLinker.class);
         TypeConstant     typeLinker     = templateLinker.getCanonicalType();
         addResourceSupplier(new InjectionKey("linker", typeLinker), templateLinker::ensureLinker);
 
         // +++ mgmt.ModuleRepository
-        xCoreRepository templateRepo = xCoreRepository.INSTANCE;
+        xCoreRepository templateRepo = f_templates.get(xCoreRepository.class);
         TypeConstant    typeRepo     = templateRepo.getCanonicalType();
         addResourceSupplier(new InjectionKey("repository", typeRepo), templateRepo::ensureModuleRepository);
 
         // +++ lang.src.Compiler
-        xRTCompiler  templateCompiler = xRTCompiler.INSTANCE;
+        xRTCompiler  templateCompiler = f_templates.get(xRTCompiler.class);
         TypeConstant typeCompiler     = templateCompiler.getCanonicalType();
         addResourceSupplier(new InjectionKey("compiler", typeCompiler), templateCompiler::ensureCompiler);
 
         // +++ reflect.Injector
-        xInjector templateInjector = xInjector.INSTANCE;
+        xInjector templateInjector = f_templates.get(xInjector.class);
         TypeConstant typeInjector = templateInjector.getCanonicalType();
         addResourceSupplier(new InjectionKey("injector", typeInjector), templateInjector::ensureInjector);
 
@@ -390,7 +390,7 @@ public class NativeContainer
         addResourceSupplier(new InjectionKey("properties", typeProps), this::ensureProperties);
 
         // +++ collections.HashCollector
-        xBasicHashCollector templateHashCollector = xBasicHashCollector.INSTANCE;
+        xBasicHashCollector templateHashCollector = f_templates.get(xBasicHashCollector.class);
         TypeConstant        typeHashCollector     = templateHashCollector.getCanonicalType();
         addResourceSupplier(new InjectionKey("hash", typeHashCollector), templateHashCollector::ensureCollector);
     }
@@ -522,8 +522,8 @@ public class NativeContainer
                 if (sKey.startsWith("xvm.")) {
                     String sVal = System.getProperty(sKey);
                     if (sVal != null) {
-                        listKeys.add(xString.makeHandle(sKey.substring(4)));
-                        listVals.add(xString.makeHandle(sVal));
+                        listKeys.add(xString.makeHandle(frame, sKey.substring(4)));
+                        listVals.add(xString.makeHandle(frame, sVal));
                     }
                 }
             }

--- a/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeContainer.java
@@ -884,6 +884,11 @@ public class NativeContainer
     private ObjectHandle m_hSecureNetwork;
     private ObjectHandle m_hInsecureNetwork;
 
+    /**
+     * This container's native template table; see {@link NativeTemplates}.
+     */
+    final NativeTemplates f_templates = new NativeTemplates(this);
+
     private final ModuleRepository f_repository;
     private       ModuleStructure  m_moduleSystem;
     private       ModuleStructure  m_moduleTurtle;

--- a/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
@@ -124,29 +124,20 @@ public final class NativeTemplates {
     }
 
     /**
-     * @return true iff the specified template is this container's native template for its class,
-     *         as opposed to one of the per-structure templates that the same Java class also backs
-     *         (a {@code xEnum} exists for every enumeration, an {@code xObject} for every class)
-     */
-    public boolean isNativeInstance(ClassTemplate template) {
-        return template != null && template == get(template.getClass());
-    }
-
-    /**
      * Add a template that cannot be found by name because it implements a composite type declared
      * by another template.
      *
      * <p>Called from {@link ClassTemplate#registerNativeTemplates()}, after the template has been
      * fully constructed - the map write is what publishes it.</p>
      *
+     * <p>The last registration for a class wins, which is what the {@code INSTANCE} assignment in
+     * the constructor did. It matters: {@code xRTDelegate} registers a nibble delegate twice, and
+     * the second one is the template the runtime used to hand out.</p>
+     *
      * @param template  the fully constructed template to publish
      */
     void register(ClassTemplate template) {
-        requireNonNull(template, "template");
-
-        ClassTemplate templatePrev = f_mapByClass.putIfAbsent(template.getClass(), template);
-        assert templatePrev == null || templatePrev == template
-                : "duplicate native template for " + template.getClass().getName();
+        f_mapByClass.put(requireNonNull(template, "template").getClass(), template);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
@@ -64,18 +64,26 @@ public final class NativeTemplates {
 
     // ----- resolving the table -------------------------------------------------------------------
 
+    // The adapter: whatever owner-bearing thing is in hand, this is its table. Its job is
+    // normalising the four inputs - in particular ClassTemplate and TypeComposition, which have no
+    // lookup method of their own and are not meant to grow one.
+    //
+    // The other two ways in are Container.nativeTemplates(), the table itself for bulk work, and
+    // Container.nativeTemplate(clz) / Frame.nativeTemplate(clz), the shorthand for a single lookup.
+    // Three layers, not three spellings of one thing; none of them is redundant.
+
     /**
      * @return the native template table for the specified container
      */
     public static NativeTemplates of(Container container) {
-        return requireNonNull(container, "container").getNativeContainer().nativeTemplates();
+        return requireNonNull(container, "container").nativeTemplates();
     }
 
     /**
      * @return the native template table for the container the specified frame runs in
      */
     public static NativeTemplates of(Frame frame) {
-        return of(requireNonNull(frame, "frame").f_context.f_container);
+        return of(requireNonNull(frame, "frame").container());
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
@@ -1,6 +1,8 @@
 package org.xvm.runtime;
 
 
+import java.util.List;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -114,6 +116,26 @@ public final class NativeTemplates {
      *
      * @return the template of that class belonging to this container
      */
+    /**
+     * The component names of the templates this container has actually resolved, in order.
+     *
+     * <p>This is the reason the table exists rather than 139 static fields: what a container has
+     * pulled in is now a question with one place to ask it. Footprinting a long-lived host - which
+     * templates a session actually touched, and how that grows - was not expressible when the answer
+     * was spread across a static per template class.</p>
+     *
+     * @return the resolved template names, sorted; never null
+     */
+    public List<String> resolvedNames() {
+        // Named from the template's own structure, not derived from its Java class: the table also
+        // holds templates whose class name maps to no component (Proxy, Identity), and an
+        // instrumentation view must not throw on the very entries it exists to report.
+        return f_mapByClass.values().stream()
+                .map(template -> template.getStructure().getIdentityConstant().getPathString())
+                .sorted()
+                .toList();
+    }
+
     public <T extends ClassTemplate> T get(Class<T> clzTemplate) {
         ClassTemplate template = f_mapByClass.get(requireNonNull(clzTemplate, "clzTemplate"));
         if (template == null) {

--- a/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
+++ b/javatools/src/main/java/org/xvm/runtime/NativeTemplates.java
@@ -1,0 +1,177 @@
+package org.xvm.runtime;
+
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.util.Objects.requireNonNull;
+
+import org.xvm.runtime.template.Proxy;
+
+
+/**
+ * The container-owned lookup table for native templates.
+ *
+ * <p>Native templates are built per container - {@link NativeContainer} constructs a complete set
+ * for every instance, and a single JVM can build several. Every template therefore carries an
+ * owner ({@link ClassTemplate#f_container}), and a lookup has to answer with the template that
+ * belongs to the container doing the asking.</p>
+ *
+ * <p>This class is the one place that answers that question. It replaces the {@code INSTANCE}
+ * static that each native template used to publish from its own constructor: a process-global
+ * mutable field, written by a {@code this}-escape, which the last container to be constructed
+ * silently took over from every container built before it.</p>
+ *
+ * <h2>How a template is found</h2>
+ *
+ * <p>Most native templates are addressable by name in the container's own registry, and the name
+ * is derived from the template class - {@code org.xvm.runtime.template.numbers.xFloat64} is the
+ * template for {@code numbers.Float64}. Those are resolved lazily, on first use, through
+ * {@link Container#getTemplate(String, Class)}; nothing is published while a template is still
+ * being constructed.</p>
+ *
+ * <p>A minority of templates have no name of their own, because they implement a composite type
+ * declared by some other template - the bit/byte/nibble arrays, the array delegates and the array
+ * views, and {@code Identity}. Those are handed to {@link #register} by the template that declares
+ * them, from {@link ClassTemplate#registerNativeTemplates()}, which runs after construction has
+ * finished.</p>
+ *
+ * <p>{@link Proxy} has neither a name nor a declaring template: it borrows {@code Object}'s
+ * structure and exists only to back proxied service handles. It is created on demand, once per
+ * container.</p>
+ */
+public final class NativeTemplates {
+    /**
+     * The owning container. Always a {@link NativeContainer}; nested containers share their
+     * native container's templates, exactly as {@link Container#getTemplate(String)} does.
+     */
+    private final Container f_container;
+
+    /**
+     * The resolved templates, keyed by template class.
+     */
+    private final ConcurrentMap<Class<?>, ClassTemplate> f_mapByClass = new ConcurrentHashMap<>();
+
+    /**
+     * The package prefix shared by every native template class.
+     */
+    private static final String TEMPLATE_PACKAGE = "org.xvm.runtime.template.";
+
+    NativeTemplates(Container container) {
+        f_container = requireNonNull(container, "container");
+    }
+
+
+    // ----- resolving the table -------------------------------------------------------------------
+
+    /**
+     * @return the native template table for the specified container
+     */
+    public static NativeTemplates of(Container container) {
+        return requireNonNull(container, "container").getNativeContainer().nativeTemplates();
+    }
+
+    /**
+     * @return the native template table for the container the specified frame runs in
+     */
+    public static NativeTemplates of(Frame frame) {
+        return of(requireNonNull(frame, "frame").f_context.f_container);
+    }
+
+    /**
+     * @return the native template table for the specified template's container
+     */
+    public static NativeTemplates of(ClassTemplate template) {
+        return of(requireNonNull(template, "template").f_container);
+    }
+
+    /**
+     * @return the native template table for the container the specified composition belongs to
+     */
+    public static NativeTemplates of(TypeComposition composition) {
+        return of(requireNonNull(composition, "composition").getContainer());
+    }
+
+
+    // ----- looking a template up -----------------------------------------------------------------
+
+    /**
+     * Obtain this container's native template of the specified class.
+     *
+     * <p>This is the container-scoped replacement for the old {@code Xxx.INSTANCE} static: the
+     * answer is always owned by this table's container, never by whichever container happened to
+     * be constructed most recently.</p>
+     *
+     * @param clzTemplate  the native template class
+     *
+     * @return the template of that class belonging to this container
+     */
+    public <T extends ClassTemplate> T get(Class<T> clzTemplate) {
+        ClassTemplate template = f_mapByClass.get(requireNonNull(clzTemplate, "clzTemplate"));
+        if (template == null) {
+            // Resolve outside of the map's update path: a lookup can recurse during bootstrap, and
+            // computeIfAbsent() forbids recursive updates to the same map.
+            template = clzTemplate == Proxy.class
+                    ? new Proxy(f_container)
+                    : f_container.getTemplate(componentNameOf(clzTemplate), clzTemplate);
+
+            ClassTemplate templateExisting = f_mapByClass.putIfAbsent(clzTemplate, template);
+            if (templateExisting != null) {
+                template = templateExisting;
+            }
+        }
+        return clzTemplate.cast(template);
+    }
+
+    /**
+     * @return true iff the specified template is this container's native template for its class,
+     *         as opposed to one of the per-structure templates that the same Java class also backs
+     *         (a {@code xEnum} exists for every enumeration, an {@code xObject} for every class)
+     */
+    public boolean isNativeInstance(ClassTemplate template) {
+        return template != null && template == get(template.getClass());
+    }
+
+    /**
+     * Add a template that cannot be found by name because it implements a composite type declared
+     * by another template.
+     *
+     * <p>Called from {@link ClassTemplate#registerNativeTemplates()}, after the template has been
+     * fully constructed - the map write is what publishes it.</p>
+     *
+     * @param template  the fully constructed template to publish
+     */
+    void register(ClassTemplate template) {
+        requireNonNull(template, "template");
+
+        ClassTemplate templatePrev = f_mapByClass.putIfAbsent(template.getClass(), template);
+        assert templatePrev == null || templatePrev == template
+                : "duplicate native template for " + template.getClass().getName();
+    }
+
+
+    // ----- helpers -------------------------------------------------------------------------------
+
+    /**
+     * Derive the component name a native template is registered under from its class name, using
+     * the same rule {@link NativeContainer} uses when it scans for template classes:
+     * {@code org.xvm.runtime.template.numbers.xFloat64} backs {@code numbers.Float64}.
+     *
+     * @param clzTemplate  the native template class
+     *
+     * @return the component name
+     */
+    static String componentNameOf(Class<? extends ClassTemplate> clzTemplate) {
+        String sClass = clzTemplate.getName();
+
+        assert sClass.startsWith(TEMPLATE_PACKAGE) : sClass + " is not a native template";
+
+        String sPath   = sClass.substring(TEMPLATE_PACKAGE.length());
+        int    ofDot   = sPath.lastIndexOf('.');
+        String sSimple = sPath.substring(ofDot + 1);
+
+        assert sSimple.charAt(0) == 'x' : sClass + " has no derivable component name";
+
+        return sPath.substring(0, ofDot + 1) + sSimple.substring(1);
+    }
+}

--- a/javatools/src/main/java/org/xvm/runtime/ObjectHandle.java
+++ b/javatools/src/main/java/org/xvm/runtime/ObjectHandle.java
@@ -731,7 +731,8 @@ public abstract class ObjectHandle
 
         @Override
         public String toString() {
-            return super.toString() + (m_clazz.getTemplate() == xChar.INSTANCE
+            return super.toString()
+                    + (m_clazz.getTemplate() == NativeTemplates.of(m_clazz).get(xChar.class)
                     ? Handy.quotedChar((char) m_lValue)
                     : String.valueOf(m_lValue));
         }

--- a/javatools/src/main/java/org/xvm/runtime/ProxyComposition.java
+++ b/javatools/src/main/java/org/xvm/runtime/ProxyComposition.java
@@ -20,7 +20,8 @@ public class ProxyComposition
     public ProxyComposition(TypeComposition clzOrigin, TypeConstant typeProxy) {
         super(clzOrigin);
 
-        f_typeProxy = typeProxy;
+        f_typeProxy     = typeProxy;
+        f_templateProxy = NativeTemplates.of(clzOrigin.getContainer()).get(Proxy.class);
     }
 
     /**
@@ -32,12 +33,12 @@ public class ProxyComposition
 
     @Override
     public OpSupport getSupport() {
-        return Proxy.INSTANCE;
+        return getTemplate();
     }
 
     @Override
     public ClassTemplate getTemplate() {
-        return Proxy.INSTANCE;
+        return f_templateProxy;
     }
 
     @Override
@@ -117,4 +118,10 @@ public class ProxyComposition
      * The revealed (proxying) type.
      */
     private final TypeConstant f_typeProxy;
+
+    /**
+     * The Proxy template of the container this composition belongs to; resolved once, since
+     * getSupport()/getTemplate() sit on the op-dispatch path.
+     */
+    private final ClassTemplate f_templateProxy;
 }

--- a/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
+++ b/javatools/src/main/java/org/xvm/runtime/ServiceContext.java
@@ -1515,7 +1515,7 @@ public class ServiceContext {
     protected void callUnhandledExceptionHandler(ExceptionHandle hException) {
         FunctionHandle hFunction = m_hExceptionHandler;
         if (hFunction == null) {
-            hFunction = new NativeFunctionHandle((frame, ahArg, iReturn) -> {
+            hFunction = new NativeFunctionHandle(f_container, (frame, ahArg, iReturn) -> {
                 switch (Utils.callToString(frame, ahArg[0])) {
                 case Op.R_NEXT -> {
                     Utils.log(frame, "\nUnhandled exception: " +

--- a/javatools/src/main/java/org/xvm/runtime/Utils.java
+++ b/javatools/src/main/java/org/xvm/runtime/Utils.java
@@ -91,8 +91,7 @@ public abstract class Utils {
         ANNOTATION_TEMPLATE_CONSTRUCT = ANNOTATION_TEMPLATE_TEMPLATE.getStructure().findMethod("construct", 2);
         ARGUMENT_CONSTRUCT            = ARGUMENT_TEMPLATE.getStructure().findMethod("construct", 2);
         RT_PARAMETER_CONSTRUCT        = RT_PARAMETER_TEMPLATE.getStructure().findMethod("construct", 5);
-        LIST_MAP_CONSTRUCT            = container.nativeTemplates().
-                                            get(xListMap.class).ensureConstructor();
+        LIST_MAP_CONSTRUCT            = container.nativeTemplate(xListMap.class).ensureConstructor();
         ANNOTATION_ARRAY_TYPE         = pool.ensureArrayType(pool.ensureEcstasyTypeConstant("reflect.Annotation"));
         ARGUMENT_ARRAY_TYPE           = pool.ensureArrayType(pool.ensureEcstasyTypeConstant("reflect.Argument"));
         CONST_HELPER                  = container.getClassStructure("_native.ConstHelper");
@@ -138,7 +137,7 @@ public abstract class Utils {
 
         return methodFinally == null
             ? null
-            : xRTFunction.makeInternalHandle(frame.f_context.f_container, methodFinally).
+            : xRTFunction.makeInternalHandle(frame.container(), methodFinally).
                     bindArguments(ahArg);
     }
 
@@ -876,12 +875,10 @@ public abstract class Utils {
 
         switch (constValue.getFormat()) {
         case Module:
-            return frame.f_context.f_container.nativeTemplates().
-                    get(xModule.class).createConstHandle(frame, constValue);
+            return frame.nativeTemplate(xModule.class).createConstHandle(frame, constValue);
 
         case Package:
-            return frame.f_context.f_container.nativeTemplates().
-                    get(xPackage.class).createConstHandle(frame, constValue);
+            return frame.nativeTemplate(xPackage.class).createConstHandle(frame, constValue);
 
         case Property:
             return callPropertyInitializer(frame, (PropertyConstant) constValue);
@@ -1548,7 +1545,7 @@ public abstract class Utils {
     public static ArrayHandle makeAnnoArrayHandle(Container container, ObjectHandle[] ahAnno) {
         return xArray.makeArrayHandle(
                 container.ensureClassComposition(ANNOTATION_ARRAY_TYPE,
-                        container.nativeTemplates().get(xArray.class)),
+                        container.nativeTemplate(xArray.class)),
                 ahAnno.length, ahAnno, Mutability.Constant);
     }
 
@@ -1558,7 +1555,7 @@ public abstract class Utils {
     public static ArrayHandle makeArgumentArrayHandle(Container container, ObjectHandle[] ahArg) {
         return xArray.makeArrayHandle(
                 container.ensureClassComposition(ARGUMENT_ARRAY_TYPE,
-                        container.nativeTemplates().get(xArray.class)),
+                        container.nativeTemplate(xArray.class)),
                 ahArg.length, ahArg, Mutability.Constant);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/Utils.java
+++ b/javatools/src/main/java/org/xvm/runtime/Utils.java
@@ -91,7 +91,8 @@ public abstract class Utils {
         ANNOTATION_TEMPLATE_CONSTRUCT = ANNOTATION_TEMPLATE_TEMPLATE.getStructure().findMethod("construct", 2);
         ARGUMENT_CONSTRUCT            = ARGUMENT_TEMPLATE.getStructure().findMethod("construct", 2);
         RT_PARAMETER_CONSTRUCT        = RT_PARAMETER_TEMPLATE.getStructure().findMethod("construct", 5);
-        LIST_MAP_CONSTRUCT            = xListMap.INSTANCE.ensureConstructor();
+        LIST_MAP_CONSTRUCT            = container.nativeTemplates().
+                                            get(xListMap.class).ensureConstructor();
         ANNOTATION_ARRAY_TYPE         = pool.ensureArrayType(pool.ensureEcstasyTypeConstant("reflect.Annotation"));
         ARGUMENT_ARRAY_TYPE           = pool.ensureArrayType(pool.ensureEcstasyTypeConstant("reflect.Argument"));
         CONST_HELPER                  = container.getClassStructure("_native.ConstHelper");
@@ -137,7 +138,8 @@ public abstract class Utils {
 
         return methodFinally == null
             ? null
-            : xRTFunction.makeInternalHandle(frame, methodFinally).bindArguments(ahArg);
+            : xRTFunction.makeInternalHandle(frame.f_context.f_container, methodFinally).
+                    bindArguments(ahArg);
     }
 
     /**
@@ -286,7 +288,7 @@ public abstract class Utils {
 
             ObjectHandle[] ahArg = new ObjectHandle[chain.getMaxVars()];
             ahArg[0] = type.ensureTypeHandle(frame.f_context.f_container);
-            ahArg[1] = xString.makeHandle(sName);
+            ahArg[1] = xString.makeHandle(frame, sName);
 
             iResult = chain.invoke(frame, hInjector, ahArg, Op.A_STACK);
         }
@@ -332,7 +334,7 @@ public abstract class Utils {
             ObjectHandle[] ahArg = new ObjectHandle[chain.getMaxVars()];
             ahArg[0] = type.ensureTypeHandle(frame.f_context.f_container);
             ahArg[1] = ahArg[0];
-            ahArg[2] = xString.makeHandle(sName);
+            ahArg[2] = xString.makeHandle(frame, sName);
             ahArg[3] = hOpts;
 
             iResult = chain.invoke(frame, hInjector, ahArg, Op.A_STACK);
@@ -874,10 +876,12 @@ public abstract class Utils {
 
         switch (constValue.getFormat()) {
         case Module:
-            return xModule.INSTANCE.createConstHandle(frame, constValue);
+            return frame.f_context.f_container.nativeTemplates().
+                    get(xModule.class).createConstHandle(frame, constValue);
 
         case Package:
-            return xPackage.INSTANCE.createConstHandle(frame, constValue);
+            return frame.f_context.f_container.nativeTemplates().
+                    get(xPackage.class).createConstHandle(frame, constValue);
 
         case Property:
             return callPropertyInitializer(frame, (PropertyConstant) constValue);
@@ -1543,7 +1547,8 @@ public abstract class Utils {
      */
     public static ArrayHandle makeAnnoArrayHandle(Container container, ObjectHandle[] ahAnno) {
         return xArray.makeArrayHandle(
-                container.ensureClassComposition(ANNOTATION_ARRAY_TYPE, xArray.INSTANCE),
+                container.ensureClassComposition(ANNOTATION_ARRAY_TYPE,
+                        container.nativeTemplates().get(xArray.class)),
                 ahAnno.length, ahAnno, Mutability.Constant);
     }
 
@@ -1552,7 +1557,8 @@ public abstract class Utils {
      */
     public static ArrayHandle makeArgumentArrayHandle(Container container, ObjectHandle[] ahArg) {
         return xArray.makeArrayHandle(
-                container.ensureClassComposition(ARGUMENT_ARRAY_TYPE, xArray.INSTANCE),
+                container.ensureClassComposition(ARGUMENT_ARRAY_TYPE,
+                        container.nativeTemplates().get(xArray.class)),
                 ahArg.length, ahArg, Mutability.Constant);
     }
 
@@ -1596,8 +1602,8 @@ public abstract class Utils {
 
                 MethodStructure  construct = RT_PARAMETER_CONSTRUCT;
                 ObjectHandle[]   ahArg     = new ObjectHandle[construct.getMaxVars()];
-                ahArg[0] = xInt64.makeHandle(index); // ordinal
-                ahArg[1] = sName == null ? xNullable.NULL : xString.makeHandle(sName);
+                ahArg[0] = xInt64.makeHandle(frameCaller, index); // ordinal
+                ahArg[1] = sName == null ? xNullable.NULL : xString.makeHandle(frameCaller, sName);
                 ahArg[2] = xBoolean.makeHandle(fFormal);
                 if (constDefault == null) {
                     ahArg[3] = xBoolean.FALSE;
@@ -1661,7 +1667,7 @@ public abstract class Utils {
         MethodStructure constructor = ARGUMENT_CONSTRUCT;
         ObjectHandle[]  ahArg       = new ObjectHandle[constructor.getMaxVars()];
         ahArg[0] = hValue;
-        ahArg[1] = sName == null ? xNullable.NULL : xString.makeHandle(sName);
+        ahArg[1] = sName == null ? xNullable.NULL : xString.makeHandle(frame, sName);
 
         TypeComposition clzArg = ARGUMENT_TEMPLATE.
                 ensureParameterizedClass(frame.f_context.f_container, typeReferent);

--- a/javatools/src/main/java/org/xvm/runtime/template/Identity.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/Identity.java
@@ -28,10 +28,10 @@ public class Identity
      */
     private final ClassConstant f_idInception;
 
-    public Identity(Container container, ClassStructure structure, boolean fInstance) {
+    public Identity(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
 
-        f_idInception = fInstance
+        f_idInception = fBaseTemplate
                 ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
                 : null;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/Identity.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/Identity.java
@@ -11,6 +11,7 @@ import org.xvm.runtime.ClassComposition;
 import org.xvm.runtime.ClassTemplate;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.TypeComposition;
 
@@ -22,17 +23,17 @@ import org.xvm.runtime.template.numbers.xInt64;
  */
 public class Identity
         extends ClassTemplate {
-    public static Identity INSTANCE;
-    public static ClassConstant INCEPTION_CLASS;
+    /**
+     * The rebased inception class for this container's Identity template.
+     */
+    private final ClassConstant f_idInception;
 
     public Identity(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
 
-        if (fInstance) {
-            INSTANCE = this;
-            INCEPTION_CLASS = new NativeRebaseConstant(
-                    (ClassConstant) structure.getIdentityConstant());
-        }
+        f_idInception = fInstance
+                ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
+                : null;
     }
 
     @Override
@@ -45,7 +46,7 @@ public class Identity
 
     @Override
     protected ClassConstant getInceptionClassConstant() {
-        return INCEPTION_CLASS;
+        return f_idInception;
     }
 
     @Override
@@ -60,7 +61,7 @@ public class Identity
 
         case "hashCode": {
             IdentityHandle hId = (IdentityHandle) ahArg[1];
-            return frame.assignValue(iReturn, xInt64.makeHandle(hId.hashCode()));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, hId.hashCode()));
         }
         }
 
@@ -80,7 +81,8 @@ public class Identity
      * Create an identity handle for a mutable or non-hashable object.
      */
     public static IdentityHandle ensureIdentity(ObjectHandle h) {
-        return new IdentityHandle(INSTANCE.getCanonicalClass(), h);
+        return new IdentityHandle(NativeTemplates.of(h.getComposition()).
+                get(Identity.class).getCanonicalClass(), h);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/IndexSupport.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/IndexSupport.java
@@ -7,6 +7,7 @@ import org.xvm.asm.Op;
 
 import org.xvm.asm.constants.TypeConstant;
 
+import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.ExceptionHandle;
@@ -88,9 +89,12 @@ public interface IndexSupport {
         try {
             TypeConstant typeEl = getElementType(frame, hTarget, lIndex);
 
-            TypeComposition clzRef = fReadOnly
-                ? xRef.INSTANCE.ensureParameterizedClass(frame.f_context.f_container, typeEl)
-                : xVar.INSTANCE.ensureParameterizedClass(frame.f_context.f_container, typeEl);
+            Container       container = frame.f_context.f_container;
+            TypeComposition clzRef    = fReadOnly
+                ? container.nativeTemplates().get(xRef.class).
+                        ensureParameterizedClass(container, typeEl)
+                : container.nativeTemplates().get(xVar.class).
+                        ensureParameterizedClass(container, typeEl);
 
             IndexedRefHandle hRef = new IndexedRefHandle(clzRef, hTarget, lIndex);
 

--- a/javatools/src/main/java/org/xvm/runtime/template/IndexSupport.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/IndexSupport.java
@@ -89,11 +89,11 @@ public interface IndexSupport {
         try {
             TypeConstant typeEl = getElementType(frame, hTarget, lIndex);
 
-            Container       container = frame.f_context.f_container;
+            Container       container = frame.container();
             TypeComposition clzRef    = fReadOnly
-                ? container.nativeTemplates().get(xRef.class).
+                ? container.nativeTemplate(xRef.class).
                         ensureParameterizedClass(container, typeEl)
-                : container.nativeTemplates().get(xVar.class).
+                : container.nativeTemplate(xVar.class).
                         ensureParameterizedClass(container, typeEl);
 
             IndexedRefHandle hRef = new IndexedRefHandle(clzRef, hTarget, lIndex);

--- a/javatools/src/main/java/org/xvm/runtime/template/Proxy.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/Proxy.java
@@ -32,12 +32,8 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
  */
 public class Proxy
         extends xService {
-    public static Proxy INSTANCE;
-
     public Proxy(Container container) {
-        super(container, xObject.INSTANCE.getStructure(), false);
-
-        INSTANCE = this;
+        super(container, container.nativeTemplates().get(xObject.class).getStructure(), false);
     }
 
     @Override
@@ -211,7 +207,7 @@ public class Proxy
      * service boundaries.
      */
     private FunctionHandle makeAsyncNativeHandle(ObjectHandle hTarget, MethodStructure method) {
-        return new AsyncHandle(INSTANCE.f_container, method) {
+        return new AsyncHandle(f_container, method) {
             @Override
             protected ObjectHandle getContextTarget(Frame frame, ObjectHandle hService) {
                 return hTarget;

--- a/javatools/src/main/java/org/xvm/runtime/template/Proxy.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/Proxy.java
@@ -33,7 +33,7 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
 public class Proxy
         extends xService {
     public Proxy(Container container) {
-        super(container, container.nativeTemplates().get(xObject.class).getStructure(), false);
+        super(container, container.nativeTemplate(xObject.class).getStructure(), false);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/BitBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/BitBasedDelegate.java
@@ -135,7 +135,7 @@ public abstract class BitBasedDelegate
     public int getPropertyCapacity(Frame frame, ObjectHandle hTarget, int iReturn) {
         BitArrayHandle hDelegate = (BitArrayHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle((long) hDelegate.m_abValue.length << 3));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, (long) hDelegate.m_abValue.length << 3));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedBitView.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedBitView.java
@@ -42,7 +42,7 @@ public abstract class ByteBasedBitView
 
             DelegateHandle hView = hSource instanceof ByteArrayHandle hBytes
                     ? new ViewHandle(clzView, hBytes, hBytes.getBitCount(), mutability)
-                    : xRTViewToBit.INSTANCE.createBitViewDelegate(hSource, mutability);
+                    : nativeTemplates().get(xRTViewToBit.class).createBitViewDelegate(hSource, mutability);
 
             return slice(hView, hSlice.f_ofStart*8, hSlice.m_cSize*8, false);
         }
@@ -53,7 +53,7 @@ public abstract class ByteBasedBitView
 
         return hSource instanceof ByteArrayHandle hBytes
                     ? new ViewHandle(clzView, hBytes, hBytes.getBitCount(), mutability)
-                    : xRTViewToBit.INSTANCE.createBitViewDelegate(hSource, mutability);
+                    : nativeTemplates().get(xRTViewToBit.class).createBitViewDelegate(hSource, mutability);
     }
 
 
@@ -66,7 +66,7 @@ public abstract class ByteBasedBitView
 
         byte[] abBits = getBits(hView, ofStart, cSize, fReverse);
 
-        return xRTBitDelegate.INSTANCE.makeHandle(abBits, cSize, mutability);
+        return nativeTemplates().get(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedBitView.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedBitView.java
@@ -42,7 +42,7 @@ public abstract class ByteBasedBitView
 
             DelegateHandle hView = hSource instanceof ByteArrayHandle hBytes
                     ? new ViewHandle(clzView, hBytes, hBytes.getBitCount(), mutability)
-                    : nativeTemplates().get(xRTViewToBit.class).createBitViewDelegate(hSource, mutability);
+                    : f_container.nativeTemplate(xRTViewToBit.class).createBitViewDelegate(hSource, mutability);
 
             return slice(hView, hSlice.f_ofStart*8, hSlice.m_cSize*8, false);
         }
@@ -53,7 +53,7 @@ public abstract class ByteBasedBitView
 
         return hSource instanceof ByteArrayHandle hBytes
                     ? new ViewHandle(clzView, hBytes, hBytes.getBitCount(), mutability)
-                    : nativeTemplates().get(xRTViewToBit.class).createBitViewDelegate(hSource, mutability);
+                    : f_container.nativeTemplate(xRTViewToBit.class).createBitViewDelegate(hSource, mutability);
     }
 
 
@@ -66,7 +66,7 @@ public abstract class ByteBasedBitView
 
         byte[] abBits = getBits(hView, ofStart, cSize, fReverse);
 
-        return nativeTemplates().get(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
+        return f_container.nativeTemplate(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/ByteBasedDelegate.java
@@ -13,6 +13,7 @@ import org.xvm.asm.constants.TypeConstant;
 import org.xvm.runtime.ClassTemplate;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.JavaLong;
 import org.xvm.runtime.TypeComposition;
@@ -70,7 +71,7 @@ public abstract class ByteBasedDelegate
     public int getPropertyCapacity(Frame frame, ObjectHandle hTarget, int iReturn) {
         ByteArrayHandle hDelegate = (ByteArrayHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hDelegate.m_abValue.length));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hDelegate.m_abValue.length));
     }
 
     @Override
@@ -198,7 +199,7 @@ public abstract class ByteBasedDelegate
         if (cbThat == 0) {
             return ofStart > cbThis
                 ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
-                : frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(ofStart));
+                : frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, ofStart));
         }
         if (ofStart > cbThis - cbThat) {
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
@@ -213,7 +214,7 @@ public abstract class ByteBasedDelegate
                         continue Next;
                     }
                 }
-                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(of));
+                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, of));
             }
         }
         return frame.assignValue(aiReturn[0], xBoolean.FALSE);
@@ -435,8 +436,10 @@ public abstract class ByteBasedDelegate
             return switch (getTemplate()) {
                 case xRTBitDelegate     _ -> templateValue == xBit.ZERO.getTemplate();
                 case xRTBooleanDelegate _ -> templateValue == xBoolean.TRUE.getTemplate();
-                case xRTInt8Delegate    _ -> templateValue == xInt8.INSTANCE;
-                case xRTUInt8Delegate   _ -> templateValue == xUInt8.INSTANCE;
+                case xRTInt8Delegate    _ ->
+                    templateValue == NativeTemplates.of(getComposition()).get(xInt8.class);
+                case xRTUInt8Delegate   _ ->
+                    templateValue == NativeTemplates.of(getComposition()).get(xUInt8.class);
                 default                   -> super.checkAssign(hValue);
             };
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedBitView.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedBitView.java
@@ -64,7 +64,7 @@ public abstract class LongBasedBitView
 
         byte[] abBits = getBits(hView, ofStart, cSize, fReverse);
 
-        return nativeTemplates().get(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
+        return f_container.nativeTemplate(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedBitView.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedBitView.java
@@ -25,8 +25,6 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
 public abstract class LongBasedBitView
         extends xRTViewToBit
         implements BitView {
-    public static LongBasedBitView INSTANCE;
-
     public LongBasedBitView(Container container, ClassStructure structure, int nBitsPerValue) {
         super(container, structure, false);
 
@@ -66,7 +64,7 @@ public abstract class LongBasedBitView
 
         byte[] abBits = getBits(hView, ofStart, cSize, fReverse);
 
-        return xRTBitDelegate.INSTANCE.makeHandle(abBits, cSize, mutability);
+        return nativeTemplates().get(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongBasedDelegate.java
@@ -11,6 +11,7 @@ import org.xvm.asm.constants.TypeConstant;
 import org.xvm.runtime.ClassTemplate;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.JavaLong;
 import org.xvm.runtime.TypeComposition;
@@ -101,7 +102,7 @@ public abstract class LongBasedDelegate
         LongArrayHandle hDelegate = (LongArrayHandle) hTarget;
 
         return frame.assignValue(iReturn,
-                xInt64.makeHandle((long) hDelegate.m_alValue.length * f_nValuesPerLong));
+                xInt64.makeHandle(frame, (long) hDelegate.m_alValue.length * f_nValuesPerLong));
     }
 
     @Override
@@ -577,15 +578,15 @@ public abstract class LongBasedDelegate
         public boolean checkAssign(ObjectHandle hValue) {
             ClassTemplate templateValue = hValue.getTemplate();
             return switch (getTemplate()) {
-                case xRTInt16Delegate   _ -> templateValue == xInt16.INSTANCE;
-                case xRTUInt16Delegate  _ -> templateValue == xUInt16.INSTANCE;
-                case xRTInt32Delegate   _ -> templateValue == xInt32.INSTANCE;
-                case xRTUInt32Delegate  _ -> templateValue == xUInt32.INSTANCE;
-                case xRTInt64Delegate   _ -> templateValue == xInt64.INSTANCE;
-                case xRTUInt64Delegate  _ -> templateValue == xUInt64.INSTANCE;
-                case xRTInt128Delegate  _ -> templateValue == xInt128.INSTANCE;
-                case xRTUInt128Delegate _ -> templateValue == xUInt128.INSTANCE;
-                case xRTNibbleDelegate _  -> templateValue == xNibble.INSTANCE;
+                case xRTInt16Delegate   _ -> templateValue == NativeTemplates.of(getComposition()).get(xInt16.class);
+                case xRTUInt16Delegate  _ -> templateValue == NativeTemplates.of(getComposition()).get(xUInt16.class);
+                case xRTInt32Delegate   _ -> templateValue == NativeTemplates.of(getComposition()).get(xInt32.class);
+                case xRTUInt32Delegate  _ -> templateValue == NativeTemplates.of(getComposition()).get(xUInt32.class);
+                case xRTInt64Delegate   _ -> templateValue == NativeTemplates.of(getComposition()).get(xInt64.class);
+                case xRTUInt64Delegate  _ -> templateValue == NativeTemplates.of(getComposition()).get(xUInt64.class);
+                case xRTInt128Delegate  _ -> templateValue == NativeTemplates.of(getComposition()).get(xInt128.class);
+                case xRTUInt128Delegate _ -> templateValue == NativeTemplates.of(getComposition()).get(xUInt128.class);
+                case xRTNibbleDelegate _  -> templateValue == NativeTemplates.of(getComposition()).get(xNibble.class);
                 default                   -> hValue.getType().isA(getElementType());
             };
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongDelegate.java
@@ -17,8 +17,6 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public abstract class LongDelegate
         extends LongBasedDelegate {
-    public static LongDelegate INSTANCE;
-
     public LongDelegate(Container container, ClassStructure structure, boolean fSigned) {
         super(container, structure, 64, fSigned);
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
@@ -30,8 +30,6 @@ import org.xvm.runtime.template._native.collections.arrays.LongBasedDelegate.Lon
  */
 public abstract class LongLongDelegate
         extends xRTDelegate {
-    public static LongLongDelegate INSTANCE;
-
     public LongLongDelegate(Container container, ClassStructure structure, boolean fSigned) {
         super(container, structure, false);
 
@@ -78,7 +76,7 @@ public abstract class LongLongDelegate
         LongArrayHandle hDelegate = (LongArrayHandle) hTarget;
 
         return frame.assignValue(iReturn,
-                xInt64.makeHandle((long) hDelegate.m_alValue.length / 2));
+                xInt64.makeHandle(frame, (long) hDelegate.m_alValue.length / 2));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/LongLongDelegate.java
@@ -76,7 +76,7 @@ public abstract class LongLongDelegate
         LongArrayHandle hDelegate = (LongArrayHandle) hTarget;
 
         return frame.assignValue(iReturn,
-                xInt64.makeHandle(frame, (long) hDelegate.m_alValue.length / 2));
+                xInt64.makeHandle(frame, hDelegate.m_alValue.length / 2));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBitDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBitDelegate.java
@@ -20,7 +20,7 @@ import org.xvm.runtime.template.numbers.xBit;
  */
 public class xRTBitDelegate
         extends BitBasedDelegate {
-    public xRTBitDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTBitDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBitDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBitDelegate.java
@@ -20,14 +20,8 @@ import org.xvm.runtime.template.numbers.xBit;
  */
 public class xRTBitDelegate
         extends BitBasedDelegate {
-    public static xRTBitDelegate INSTANCE;
-
     public xRTBitDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBooleanDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBooleanDelegate.java
@@ -20,7 +20,7 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
  */
 public class xRTBooleanDelegate
         extends BitBasedDelegate {
-    public xRTBooleanDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTBooleanDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBooleanDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTBooleanDelegate.java
@@ -20,14 +20,8 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
  */
 public class xRTBooleanDelegate
         extends BitBasedDelegate {
-    public static xRTBooleanDelegate INSTANCE;
-
     public xRTBooleanDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
@@ -11,6 +11,7 @@ import org.xvm.asm.constants.TypeConstant;
 
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.JavaLong;
 import org.xvm.runtime.TypeComposition;
@@ -30,14 +31,8 @@ import org.xvm.runtime.template.text.xChar;
  */
 public class xRTCharDelegate
         extends xRTDelegate {
-    public static xRTCharDelegate INSTANCE;
-
     public xRTCharDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -81,7 +76,7 @@ public class xRTCharDelegate
             --hDelegate.m_achValue[(int) lIndex];
             return overflow(frame);
         }
-        return frame.assignValue(iReturn, xChar.makeHandle(chValue+1));
+        return frame.assignValue(iReturn, xChar.makeHandle(frame, chValue+1));
     }
 
     @Override
@@ -98,7 +93,7 @@ public class xRTCharDelegate
             ++hDelegate.m_achValue[(int) lIndex];
             return overflow(frame);
         }
-        return frame.assignValue(iReturn, xChar.makeHandle(chValue-1));
+        return frame.assignValue(iReturn, xChar.makeHandle(frame, chValue-1));
     }
 
     @Override
@@ -114,7 +109,7 @@ public class xRTCharDelegate
             --hDelegate.m_achValue[(int) lIndex];
             return overflow(frame);
         }
-        return frame.assignValue(iReturn, xChar.makeHandle(chValue));
+        return frame.assignValue(iReturn, xChar.makeHandle(frame, chValue));
     }
 
     @Override
@@ -130,7 +125,7 @@ public class xRTCharDelegate
             ++hDelegate.m_achValue[(int) lIndex];
             return overflow(frame);
         }
-        return frame.assignValue(iReturn, xChar.makeHandle(chValue));
+        return frame.assignValue(iReturn, xChar.makeHandle(frame, chValue));
     }
 
     @Override
@@ -146,7 +141,7 @@ public class xRTCharDelegate
     public int getPropertyCapacity(Frame frame, ObjectHandle hTarget, int iReturn) {
         CharArrayHandle hDelegate = (CharArrayHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hDelegate.m_achValue.length));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hDelegate.m_achValue.length));
     }
 
     @Override
@@ -214,7 +209,7 @@ public class xRTCharDelegate
     protected int extractArrayValueImpl(Frame frame, DelegateHandle hTarget, long lIndex, int iReturn) {
         CharArrayHandle hDelegate = (CharArrayHandle) hTarget;
 
-        return frame.assignValue(iReturn, xChar.makeHandle(hDelegate.m_achValue[(int) lIndex]));
+        return frame.assignValue(iReturn, xChar.makeHandle(frame, hDelegate.m_achValue[(int) lIndex]));
     }
 
     @Override
@@ -300,7 +295,7 @@ public class xRTCharDelegate
         if (cchThat == 0) {
             return ofStart > cchThis
                 ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
-                : frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(ofStart));
+                : frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, ofStart));
         }
         if (ofStart > cchThis - cchThat) {
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
@@ -315,7 +310,7 @@ public class xRTCharDelegate
                         continue Next;
                     }
                 }
-                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(of));
+                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, of));
             }
         }
         return frame.assignValue(aiReturn[0], xBoolean.FALSE);
@@ -384,7 +379,8 @@ public class xRTCharDelegate
 
         @Override
         public boolean checkAssign(ObjectHandle hValue) {
-            return hValue.getTemplate() == xChar.INSTANCE;
+            return hValue.getTemplate()
+                    == NativeTemplates.of(getComposition()).get(xChar.class);
         }
 
         @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTCharDelegate.java
@@ -31,7 +31,7 @@ import org.xvm.runtime.template.text.xChar;
  */
 public class xRTCharDelegate
         extends xRTDelegate {
-    public xRTCharDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTCharDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
@@ -81,28 +81,28 @@ public class xRTDelegate
             ConstantPool                   pool         = pool();
             Map<TypeConstant, xRTDelegate> mapDelegates = new HashMap<>();
 
-            mapDelegates.put(pool.typeNibble(),  nativeTemplates().get(xRTNibbleDelegate.class));
+            mapDelegates.put(pool.typeNibble(),  f_container.nativeTemplate(xRTNibbleDelegate.class));
 
-            mapDelegates.put(pool.typeBoolean(), nativeTemplates().get(xRTBooleanDelegate.class));
-            mapDelegates.put(pool.typeBit(),     nativeTemplates().get(xRTBitDelegate.class));
-            mapDelegates.put(pool.typeChar(),    nativeTemplates().get(xRTCharDelegate.class));
+            mapDelegates.put(pool.typeBoolean(), f_container.nativeTemplate(xRTBooleanDelegate.class));
+            mapDelegates.put(pool.typeBit(),     f_container.nativeTemplate(xRTBitDelegate.class));
+            mapDelegates.put(pool.typeChar(),    f_container.nativeTemplate(xRTCharDelegate.class));
 
-            mapDelegates.put(pool.typeInt8(),    nativeTemplates().get(xRTInt8Delegate.class));
-            mapDelegates.put(pool.typeInt16(),   nativeTemplates().get(xRTInt16Delegate.class));
-            mapDelegates.put(pool.typeInt32(),   nativeTemplates().get(xRTInt32Delegate.class));
-            mapDelegates.put(pool.typeInt64(),   nativeTemplates().get(xRTInt64Delegate.class));
-            mapDelegates.put(pool.typeInt128(),  nativeTemplates().get(xRTInt128Delegate.class));
+            mapDelegates.put(pool.typeInt8(),    f_container.nativeTemplate(xRTInt8Delegate.class));
+            mapDelegates.put(pool.typeInt16(),   f_container.nativeTemplate(xRTInt16Delegate.class));
+            mapDelegates.put(pool.typeInt32(),   f_container.nativeTemplate(xRTInt32Delegate.class));
+            mapDelegates.put(pool.typeInt64(),   f_container.nativeTemplate(xRTInt64Delegate.class));
+            mapDelegates.put(pool.typeInt128(),  f_container.nativeTemplate(xRTInt128Delegate.class));
 
-            mapDelegates.put(pool.typeNibble(),  nativeTemplates().get(xRTNibbleDelegate.class));
-            mapDelegates.put(pool.typeUInt8(),   nativeTemplates().get(xRTUInt8Delegate.class));
-            mapDelegates.put(pool.typeUInt16(),  nativeTemplates().get(xRTUInt16Delegate.class));
-            mapDelegates.put(pool.typeUInt32(),  nativeTemplates().get(xRTUInt32Delegate.class));
-            mapDelegates.put(pool.typeUInt64(),  nativeTemplates().get(xRTUInt64Delegate.class));
-            mapDelegates.put(pool.typeUInt128(), nativeTemplates().get(xRTUInt128Delegate.class));
+            mapDelegates.put(pool.typeNibble(),  f_container.nativeTemplate(xRTNibbleDelegate.class));
+            mapDelegates.put(pool.typeUInt8(),   f_container.nativeTemplate(xRTUInt8Delegate.class));
+            mapDelegates.put(pool.typeUInt16(),  f_container.nativeTemplate(xRTUInt16Delegate.class));
+            mapDelegates.put(pool.typeUInt32(),  f_container.nativeTemplate(xRTUInt32Delegate.class));
+            mapDelegates.put(pool.typeUInt64(),  f_container.nativeTemplate(xRTUInt64Delegate.class));
+            mapDelegates.put(pool.typeUInt128(), f_container.nativeTemplate(xRTUInt128Delegate.class));
 
-            mapDelegates.put(pool.typeFloat64(), nativeTemplates().get(xRTFloat64Delegate.class));
+            mapDelegates.put(pool.typeFloat64(), f_container.nativeTemplate(xRTFloat64Delegate.class));
 
-            mapDelegates.put(pool.typeString(),  nativeTemplates().get(xRTStringDelegate.class));
+            mapDelegates.put(pool.typeString(),  f_container.nativeTemplate(xRTStringDelegate.class));
 
             DELEGATES = mapDelegates;
 
@@ -431,7 +431,7 @@ public class xRTDelegate
     public DelegateHandle slice(DelegateHandle hTarget, long ofStart, long cSize, boolean fReverse) {
         return ofStart == 0 && cSize == hTarget.m_cSize && !fReverse
             ? hTarget
-            : nativeTemplates().get(xRTSlicingDelegate.class).makeHandle(hTarget, ofStart, cSize, fReverse);
+            : f_container.nativeTemplate(xRTSlicingDelegate.class).makeHandle(hTarget, ofStart, cSize, fReverse);
     }
 
     /**
@@ -713,7 +713,7 @@ public class xRTDelegate
     public static xRTDelegate getArrayTemplate(Container container, TypeConstant typeParam) {
         xRTDelegate template = DELEGATES.get(typeParam);
         return template == null
-                ? container.nativeTemplates().get(xRTDelegate.class)
+                ? container.nativeTemplate(xRTDelegate.class)
                 : template;
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
@@ -42,19 +42,13 @@ import org.xvm.runtime.template.numbers.xInt64;
 public class xRTDelegate
         extends ClassTemplate
         implements IndexSupport {
-    public static xRTDelegate INSTANCE;
-
     public xRTDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTDelegate.class)) {
             registerNativeTemplate(new xRTNibbleDelegate  (f_container, f_struct, true));
 
             registerNativeTemplate(new xRTBooleanDelegate (f_container, f_struct, true));
@@ -82,33 +76,33 @@ public class xRTDelegate
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTDelegate.class)) {
             // register native delegations
             ConstantPool                   pool         = pool();
             Map<TypeConstant, xRTDelegate> mapDelegates = new HashMap<>();
 
-            mapDelegates.put(pool.typeNibble(),  xRTNibbleDelegate .INSTANCE);
+            mapDelegates.put(pool.typeNibble(),  nativeTemplates().get(xRTNibbleDelegate.class));
 
-            mapDelegates.put(pool.typeBoolean(), xRTBooleanDelegate.INSTANCE);
-            mapDelegates.put(pool.typeBit(),     xRTBitDelegate    .INSTANCE);
-            mapDelegates.put(pool.typeChar(),    xRTCharDelegate   .INSTANCE);
+            mapDelegates.put(pool.typeBoolean(), nativeTemplates().get(xRTBooleanDelegate.class));
+            mapDelegates.put(pool.typeBit(),     nativeTemplates().get(xRTBitDelegate.class));
+            mapDelegates.put(pool.typeChar(),    nativeTemplates().get(xRTCharDelegate.class));
 
-            mapDelegates.put(pool.typeInt8(),    xRTInt8Delegate   .INSTANCE);
-            mapDelegates.put(pool.typeInt16(),   xRTInt16Delegate  .INSTANCE);
-            mapDelegates.put(pool.typeInt32(),   xRTInt32Delegate  .INSTANCE);
-            mapDelegates.put(pool.typeInt64(),   xRTInt64Delegate  .INSTANCE);
-            mapDelegates.put(pool.typeInt128(),  xRTInt128Delegate .INSTANCE);
+            mapDelegates.put(pool.typeInt8(),    nativeTemplates().get(xRTInt8Delegate.class));
+            mapDelegates.put(pool.typeInt16(),   nativeTemplates().get(xRTInt16Delegate.class));
+            mapDelegates.put(pool.typeInt32(),   nativeTemplates().get(xRTInt32Delegate.class));
+            mapDelegates.put(pool.typeInt64(),   nativeTemplates().get(xRTInt64Delegate.class));
+            mapDelegates.put(pool.typeInt128(),  nativeTemplates().get(xRTInt128Delegate.class));
 
-            mapDelegates.put(pool.typeNibble(),  xRTNibbleDelegate  .INSTANCE);
-            mapDelegates.put(pool.typeUInt8(),   xRTUInt8Delegate  .INSTANCE);
-            mapDelegates.put(pool.typeUInt16(),  xRTUInt16Delegate .INSTANCE);
-            mapDelegates.put(pool.typeUInt32(),  xRTUInt32Delegate .INSTANCE);
-            mapDelegates.put(pool.typeUInt64(),  xRTUInt64Delegate .INSTANCE);
-            mapDelegates.put(pool.typeUInt128(), xRTUInt128Delegate.INSTANCE);
+            mapDelegates.put(pool.typeNibble(),  nativeTemplates().get(xRTNibbleDelegate.class));
+            mapDelegates.put(pool.typeUInt8(),   nativeTemplates().get(xRTUInt8Delegate.class));
+            mapDelegates.put(pool.typeUInt16(),  nativeTemplates().get(xRTUInt16Delegate.class));
+            mapDelegates.put(pool.typeUInt32(),  nativeTemplates().get(xRTUInt32Delegate.class));
+            mapDelegates.put(pool.typeUInt64(),  nativeTemplates().get(xRTUInt64Delegate.class));
+            mapDelegates.put(pool.typeUInt128(), nativeTemplates().get(xRTUInt128Delegate.class));
 
-            mapDelegates.put(pool.typeFloat64(), xRTFloat64Delegate.INSTANCE);
+            mapDelegates.put(pool.typeFloat64(), nativeTemplates().get(xRTFloat64Delegate.class));
 
-            mapDelegates.put(pool.typeString(),  xRTStringDelegate .INSTANCE);
+            mapDelegates.put(pool.typeString(),  nativeTemplates().get(xRTStringDelegate.class));
 
             DELEGATES = mapDelegates;
 
@@ -146,7 +140,7 @@ public class xRTDelegate
 
     @Override
     public ClassTemplate getTemplate(TypeConstant type) {
-        return getArrayTemplate(type.getParamType(0));
+        return getArrayTemplate(f_container, type.getParamType(0));
     }
 
     /**
@@ -319,7 +313,7 @@ public class xRTDelegate
     protected int getPropertyCapacity(Frame frame, ObjectHandle hTarget, int iReturn) {
         GenericArrayDelegate hDelegate = (GenericArrayDelegate) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hDelegate.m_ahValue.length));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hDelegate.m_ahValue.length));
     }
 
     /**
@@ -352,7 +346,7 @@ public class xRTDelegate
     protected int getPropertySize(Frame frame, ObjectHandle hTarget, int iReturn) {
         DelegateHandle hDelegate = (DelegateHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hDelegate.m_cSize));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hDelegate.m_cSize));
     }
 
     /**
@@ -437,7 +431,7 @@ public class xRTDelegate
     public DelegateHandle slice(DelegateHandle hTarget, long ofStart, long cSize, boolean fReverse) {
         return ofStart == 0 && cSize == hTarget.m_cSize && !fReverse
             ? hTarget
-            : xRTSlicingDelegate.INSTANCE.makeHandle(hTarget, ofStart, cSize, fReverse);
+            : nativeTemplates().get(xRTSlicingDelegate.class).makeHandle(hTarget, ofStart, cSize, fReverse);
     }
 
     /**
@@ -716,9 +710,11 @@ public class xRTDelegate
 
     // ----- helper methods ------------------------------------------------------------------------
 
-    public static xRTDelegate getArrayTemplate(TypeConstant typeParam) {
+    public static xRTDelegate getArrayTemplate(Container container, TypeConstant typeParam) {
         xRTDelegate template = DELEGATES.get(typeParam);
-        return template == null ? INSTANCE : template;
+        return template == null
+                ? container.nativeTemplates().get(xRTDelegate.class)
+                : template;
     }
 
     private static ObjectHandle[] reverse(ObjectHandle[] ahValue, int cSize) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTDelegate.java
@@ -42,7 +42,7 @@ import org.xvm.runtime.template.numbers.xInt64;
 public class xRTDelegate
         extends ClassTemplate
         implements IndexSupport {
-    public xRTDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
@@ -29,7 +29,7 @@ import org.xvm.runtime.template.numbers.xInt64;
  */
 public class xRTFloat64Delegate
         extends xRTDelegate {
-    public xRTFloat64Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTFloat64Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
@@ -10,6 +10,7 @@ import org.xvm.asm.constants.TypeConstant;
 
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.TypeComposition;
 
@@ -28,14 +29,8 @@ import org.xvm.runtime.template.numbers.xInt64;
  */
 public class xRTFloat64Delegate
         extends xRTDelegate {
-    public static xRTFloat64Delegate INSTANCE;
-
     public xRTFloat64Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -78,7 +73,7 @@ public class xRTFloat64Delegate
     public int getPropertyCapacity(Frame frame, ObjectHandle hTarget, int iReturn) {
         DoubleArrayHandle hDelegate = (DoubleArrayHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hDelegate.m_adValue.length));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hDelegate.m_adValue.length));
     }
 
     @Override
@@ -127,7 +122,7 @@ public class xRTFloat64Delegate
         DoubleArrayHandle hDelegate = (DoubleArrayHandle) hTarget;
 
         return frame.assignValue(iReturn,
-                xFloat64.INSTANCE.makeHandle(hDelegate.m_adValue[(int) lIndex]));
+                nativeTemplates().get(xFloat64.class).makeHandle(hDelegate.m_adValue[(int) lIndex]));
     }
 
     @Override
@@ -304,7 +299,8 @@ public class xRTFloat64Delegate
 
         @Override
         public boolean checkAssign(ObjectHandle hValue) {
-            return hValue.getTemplate() == xFloat64.INSTANCE;
+            return hValue.getTemplate()
+                    == NativeTemplates.of(getComposition()).get(xFloat64.class);
         }
 
         @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTFloat64Delegate.java
@@ -122,7 +122,7 @@ public class xRTFloat64Delegate
         DoubleArrayHandle hDelegate = (DoubleArrayHandle) hTarget;
 
         return frame.assignValue(iReturn,
-                nativeTemplates().get(xFloat64.class).makeHandle(hDelegate.m_adValue[(int) lIndex]));
+                f_container.nativeTemplate(xFloat64.class).makeHandle(hDelegate.m_adValue[(int) lIndex]));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt128Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt128Delegate.java
@@ -36,6 +36,6 @@ public class xRTInt128Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(LongLong ll) {
-        return nativeTemplates().get(xInt128.class).makeHandle(ll);
+        return f_container.nativeTemplate(xInt128.class).makeHandle(ll);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt128Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt128Delegate.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.template.numbers.xInt128;
  */
 public class xRTInt128Delegate
         extends LongLongDelegate {
-    public xRTInt128Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTInt128Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, true);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt128Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt128Delegate.java
@@ -18,14 +18,8 @@ import org.xvm.runtime.template.numbers.xInt128;
  */
 public class xRTInt128Delegate
         extends LongLongDelegate {
-    public static xRTInt128Delegate INSTANCE;
-
     public xRTInt128Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, true);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -42,6 +36,6 @@ public class xRTInt128Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(LongLong ll) {
-        return xInt128.INSTANCE.makeHandle(ll);
+        return nativeTemplates().get(xInt128.class).makeHandle(ll);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt16Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt16Delegate.java
@@ -20,7 +20,7 @@ import org.xvm.runtime.template.numbers.xInt16;
 public class xRTInt16Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public xRTInt16Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTInt16Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 16, true);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt16Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt16Delegate.java
@@ -20,14 +20,8 @@ import org.xvm.runtime.template.numbers.xInt16;
 public class xRTInt16Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public static xRTInt16Delegate INSTANCE;
-
     public xRTInt16Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 16, true);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -44,7 +38,7 @@ public class xRTInt16Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xInt16.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xInt16.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt16Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt16Delegate.java
@@ -38,7 +38,7 @@ public class xRTInt16Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xInt16.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xInt16.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt32Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt32Delegate.java
@@ -20,14 +20,8 @@ import org.xvm.runtime.template.numbers.xInt32;
 public class xRTInt32Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public static xRTInt32Delegate INSTANCE;
-
     public xRTInt32Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 32, true);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -44,7 +38,7 @@ public class xRTInt32Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xInt32.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xInt32.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt32Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt32Delegate.java
@@ -38,7 +38,7 @@ public class xRTInt32Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xInt32.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xInt32.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt32Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt32Delegate.java
@@ -20,7 +20,7 @@ import org.xvm.runtime.template.numbers.xInt32;
 public class xRTInt32Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public xRTInt32Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTInt32Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 32, true);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt64Delegate.java
@@ -17,7 +17,7 @@ import org.xvm.runtime.template.numbers.xInt64;
  */
 public class xRTInt64Delegate
         extends LongDelegate {
-    public xRTInt64Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTInt64Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, true);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt64Delegate.java
@@ -17,14 +17,8 @@ import org.xvm.runtime.template.numbers.xInt64;
  */
 public class xRTInt64Delegate
         extends LongDelegate {
-    public static xRTInt64Delegate INSTANCE;
-
     public xRTInt64Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, true);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -41,6 +35,6 @@ public class xRTInt64Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xInt64.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xInt64.class).makeJavaLong(lValue);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt64Delegate.java
@@ -35,6 +35,6 @@ public class xRTInt64Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xInt64.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xInt64.class).makeJavaLong(lValue);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt8Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt8Delegate.java
@@ -36,6 +36,6 @@ public class xRTInt8Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xInt8.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xInt8.class).makeJavaLong(lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt8Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt8Delegate.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.template.numbers.xInt8;
 public class xRTInt8Delegate
         extends ByteBasedDelegate
         implements ByteView {
-    public xRTInt8Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTInt8Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Byte.MIN_VALUE, Byte.MAX_VALUE);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt8Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTInt8Delegate.java
@@ -18,14 +18,8 @@ import org.xvm.runtime.template.numbers.xInt8;
 public class xRTInt8Delegate
         extends ByteBasedDelegate
         implements ByteView {
-    public static xRTInt8Delegate INSTANCE;
-
     public xRTInt8Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Byte.MIN_VALUE, Byte.MAX_VALUE);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -42,6 +36,6 @@ public class xRTInt8Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xInt8.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xInt8.class).makeJavaLong(lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTNibbleDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTNibbleDelegate.java
@@ -19,7 +19,7 @@ import org.xvm.runtime.template.numbers.xNibble;
 public class xRTNibbleDelegate
         extends LongBasedDelegate
         implements ByteView {
-    public xRTNibbleDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTNibbleDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 4, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTNibbleDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTNibbleDelegate.java
@@ -19,14 +19,8 @@ import org.xvm.runtime.template.numbers.xNibble;
 public class xRTNibbleDelegate
         extends LongBasedDelegate
         implements ByteView {
-    public static xRTNibbleDelegate INSTANCE;
-
     public xRTNibbleDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 4, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -43,7 +37,7 @@ public class xRTNibbleDelegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xNibble.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xNibble.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTNibbleDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTNibbleDelegate.java
@@ -37,7 +37,7 @@ public class xRTNibbleDelegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xNibble.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xNibble.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
@@ -22,7 +22,7 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
  */
 public class xRTSlicingDelegate
         extends xRTDelegate {
-    public xRTSlicingDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTSlicingDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTSlicingDelegate.java
@@ -22,14 +22,8 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
  */
 public class xRTSlicingDelegate
         extends xRTDelegate {
-    public static xRTSlicingDelegate INSTANCE;
-
     public xRTSlicingDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
@@ -31,14 +31,8 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xRTStringDelegate
         extends xRTDelegate {
-    public static xRTStringDelegate INSTANCE;
-
     public xRTStringDelegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     // ----- RTDelegate API ------------------------------------------------------------------------
@@ -80,7 +74,7 @@ public class xRTStringDelegate
     public int getPropertyCapacity(Frame frame, ObjectHandle hTarget, int iReturn) {
         StringArrayHandle hDelegate = (StringArrayHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hDelegate.m_asValue.length));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hDelegate.m_asValue.length));
     }
 
     @Override
@@ -123,7 +117,7 @@ public class xRTStringDelegate
         StringArrayHandle hDelegate = (StringArrayHandle) hTarget;
 
         String s = hDelegate.m_asValue[(int) lIndex];
-        return frame.assignValue(iReturn, xString.makeHandle(s));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, s));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTStringDelegate.java
@@ -31,7 +31,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xRTStringDelegate
         extends xRTDelegate {
-    public xRTStringDelegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTStringDelegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt128Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt128Delegate.java
@@ -36,6 +36,6 @@ public class xRTUInt128Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(LongLong ll) {
-        return nativeTemplates().get(xUInt128.class).makeHandle(ll);
+        return f_container.nativeTemplate(xUInt128.class).makeHandle(ll);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt128Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt128Delegate.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.template.numbers.xUInt128;
  */
 public class xRTUInt128Delegate
         extends LongLongDelegate {
-    public xRTUInt128Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTUInt128Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt128Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt128Delegate.java
@@ -18,14 +18,8 @@ import org.xvm.runtime.template.numbers.xUInt128;
  */
 public class xRTUInt128Delegate
         extends LongLongDelegate {
-    public static xRTUInt128Delegate INSTANCE;
-
     public xRTUInt128Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -42,6 +36,6 @@ public class xRTUInt128Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(LongLong ll) {
-        return xUInt128.INSTANCE.makeHandle(ll);
+        return nativeTemplates().get(xUInt128.class).makeHandle(ll);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt16Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt16Delegate.java
@@ -18,14 +18,8 @@ import org.xvm.runtime.template.numbers.xUInt16;
 public class xRTUInt16Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public static xRTUInt16Delegate INSTANCE;
-
     public xRTUInt16Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 16, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -42,6 +36,6 @@ public class xRTUInt16Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xUInt16.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xUInt16.class).makeJavaLong(lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt16Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt16Delegate.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.template.numbers.xUInt16;
 public class xRTUInt16Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public xRTUInt16Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTUInt16Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 16, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt16Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt16Delegate.java
@@ -36,6 +36,6 @@ public class xRTUInt16Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xUInt16.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xUInt16.class).makeJavaLong(lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt32Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt32Delegate.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.template.numbers.xUInt32;
 public class xRTUInt32Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public xRTUInt32Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTUInt32Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 32, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt32Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt32Delegate.java
@@ -18,14 +18,8 @@ import org.xvm.runtime.template.numbers.xUInt32;
 public class xRTUInt32Delegate
         extends LongBasedDelegate
         implements ByteView {
-    public static xRTUInt32Delegate INSTANCE;
-
     public xRTUInt32Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 32, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -42,6 +36,6 @@ public class xRTUInt32Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xUInt32.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xUInt32.class).makeJavaLong(lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt32Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt32Delegate.java
@@ -36,6 +36,6 @@ public class xRTUInt32Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xUInt32.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xUInt32.class).makeJavaLong(lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt64Delegate.java
@@ -35,6 +35,6 @@ public class xRTUInt64Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xUInt64.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xUInt64.class).makeJavaLong(lValue);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt64Delegate.java
@@ -17,7 +17,7 @@ import org.xvm.runtime.template.numbers.xUInt64;
  */
 public class xRTUInt64Delegate
         extends LongDelegate {
-    public xRTUInt64Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTUInt64Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt64Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt64Delegate.java
@@ -17,14 +17,8 @@ import org.xvm.runtime.template.numbers.xUInt64;
  */
 public class xRTUInt64Delegate
         extends LongDelegate {
-    public static xRTUInt64Delegate INSTANCE;
-
     public xRTUInt64Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -41,6 +35,6 @@ public class xRTUInt64Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xUInt64.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xUInt64.class).makeJavaLong(lValue);
     }
    }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt8Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt8Delegate.java
@@ -37,7 +37,7 @@ public class xRTUInt8Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return nativeTemplates().get(xUInt8.class).makeJavaLong(lValue);
+        return f_container.nativeTemplate(xUInt8.class).makeJavaLong(lValue);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt8Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt8Delegate.java
@@ -7,6 +7,7 @@ import org.xvm.asm.ConstantPool;
 import org.xvm.asm.constants.TypeConstant;
 
 import org.xvm.runtime.Container;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 
 import org.xvm.runtime.template.numbers.xUInt8;
@@ -18,14 +19,8 @@ import org.xvm.runtime.template.numbers.xUInt8;
 public class xRTUInt8Delegate
         extends ByteBasedDelegate
         implements ByteView {
-    public static xRTUInt8Delegate INSTANCE;
-
     public xRTUInt8Delegate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, (byte) 0, (byte) 0xFF);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -42,13 +37,14 @@ public class xRTUInt8Delegate
 
     @Override
     protected ObjectHandle makeElementHandle(long lValue) {
-        return xUInt8.INSTANCE.makeJavaLong(lValue);
+        return nativeTemplates().get(xUInt8.class).makeJavaLong(lValue);
     }
 
     /**
      * Obtain an array of bytes from the specified ByteArrayHandle.
      */
     public static byte[] getBytes(ByteArrayHandle hDelegate) {
-        return INSTANCE.getBytes(hDelegate, 0, hDelegate.m_cSize, false);
+        return NativeTemplates.of(hDelegate.getComposition()).get(xRTUInt8Delegate.class).
+                getBytes(hDelegate, 0, hDelegate.m_cSize, false);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt8Delegate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTUInt8Delegate.java
@@ -19,7 +19,7 @@ import org.xvm.runtime.template.numbers.xUInt8;
 public class xRTUInt8Delegate
         extends ByteBasedDelegate
         implements ByteView {
-    public xRTUInt8Delegate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTUInt8Delegate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, (byte) 0, (byte) 0xFF);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBit.java
@@ -16,7 +16,7 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
 public class xRTViewFromBit
         extends xRTView
         implements ByteView {
-    public xRTViewFromBit(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromBit(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBit.java
@@ -16,19 +16,13 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
 public class xRTViewFromBit
         extends xRTView
         implements ByteView {
-    public static xRTViewFromBit INSTANCE;
-
     public xRTViewFromBit(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTViewFromBit.class)) {
             registerNativeTemplate(new xRTViewFromBitToBoolean (f_container, f_struct, true));
             registerNativeTemplate(new xRTViewFromBitToByte    (f_container, f_struct, true));
             registerNativeTemplate(new xRTViewFromBitToNibble  (f_container, f_struct, true));

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToBoolean.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToBoolean.java
@@ -25,7 +25,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
  */
 public class xRTViewFromBitToBoolean
         extends xRTViewFromBit {
-    public xRTViewFromBitToBoolean(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromBitToBoolean(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToBoolean.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToBoolean.java
@@ -67,7 +67,7 @@ public class xRTViewFromBitToBoolean
         if (tSource instanceof BitView tView) {
             byte[] abBits = tView.getBytes(hSource, ofStart, cSize, fReverse);
 
-            return nativeTemplates().get(xRTBooleanDelegate.class).makeHandle(abBits, cSize, mutability);
+            return f_container.nativeTemplate(xRTBooleanDelegate.class).makeHandle(abBits, cSize, mutability);
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToBoolean.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToBoolean.java
@@ -25,14 +25,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
  */
 public class xRTViewFromBitToBoolean
         extends xRTViewFromBit {
-    public static xRTViewFromBitToBoolean INSTANCE;
-
     public xRTViewFromBitToBoolean(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -73,7 +67,7 @@ public class xRTViewFromBitToBoolean
         if (tSource instanceof BitView tView) {
             byte[] abBits = tView.getBytes(hSource, ofStart, cSize, fReverse);
 
-            return xRTBooleanDelegate.INSTANCE.makeHandle(abBits, cSize, mutability);
+            return nativeTemplates().get(xRTBooleanDelegate.class).makeHandle(abBits, cSize, mutability);
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToByte.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToByte.java
@@ -26,14 +26,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
  */
 public class xRTViewFromBitToByte
         extends xRTViewFromBit {
-    public static xRTViewFromBitToByte INSTANCE;
-
     public xRTViewFromBitToByte(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -86,7 +80,7 @@ public class xRTViewFromBitToByte
         if (tSource instanceof ByteView tView) {
             byte[] abBits = tView.getBytes(hSource, ofStart, cSize, fReverse);
 
-            return xRTUInt8Delegate.INSTANCE.makeHandle(abBits, cSize, mutability);
+            return nativeTemplates().get(xRTUInt8Delegate.class).makeHandle(abBits, cSize, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -101,7 +95,7 @@ public class xRTViewFromBitToByte
         if (tSource instanceof ByteView tView) {
             // the underlying delegate is a BitView, which is a ByteView
             return frame.assignValue(iReturn,
-                    xUInt8.INSTANCE.makeJavaLong(tView.extractByte(hSource, lIndex)));
+                    nativeTemplates().get(xUInt8.class).makeJavaLong(tView.extractByte(hSource, lIndex)));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToByte.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToByte.java
@@ -80,7 +80,7 @@ public class xRTViewFromBitToByte
         if (tSource instanceof ByteView tView) {
             byte[] abBits = tView.getBytes(hSource, ofStart, cSize, fReverse);
 
-            return nativeTemplates().get(xRTUInt8Delegate.class).makeHandle(abBits, cSize, mutability);
+            return f_container.nativeTemplate(xRTUInt8Delegate.class).makeHandle(abBits, cSize, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -95,7 +95,7 @@ public class xRTViewFromBitToByte
         if (tSource instanceof ByteView tView) {
             // the underlying delegate is a BitView, which is a ByteView
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xUInt8.class).makeJavaLong(tView.extractByte(hSource, lIndex)));
+                    f_container.nativeTemplate(xUInt8.class).makeJavaLong(tView.extractByte(hSource, lIndex)));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToByte.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToByte.java
@@ -26,7 +26,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
  */
 public class xRTViewFromBitToByte
         extends xRTViewFromBit {
-    public xRTViewFromBitToByte(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromBitToByte(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToNibble.java
@@ -26,7 +26,7 @@ import org.xvm.runtime.template.numbers.xNibble;
  */
 public class xRTViewFromBitToNibble
         extends xRTViewFromBit {
-    public xRTViewFromBitToNibble(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromBitToNibble(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToNibble.java
@@ -64,7 +64,7 @@ public class xRTViewFromBitToNibble
         if (tSource instanceof BitView tView) {
             byte[] abBits = tView.getBytes(hSource, ofStart/2, cSize/2, fReverse);
 
-            return nativeTemplates().get(xRTNibbleDelegate.class).packHandle(abBits, mutability);
+            return f_container.nativeTemplate(xRTNibbleDelegate.class).packHandle(abBits, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -84,7 +84,7 @@ public class xRTViewFromBitToNibble
             } else {
                 nNibble = nNibble & 0x0F;
             }
-            return frame.assignValue(iReturn, nativeTemplates().get(xNibble.class).makeJavaLong(nNibble));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xNibble.class).makeJavaLong(nNibble));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromBitToNibble.java
@@ -26,14 +26,8 @@ import org.xvm.runtime.template.numbers.xNibble;
  */
 public class xRTViewFromBitToNibble
         extends xRTViewFromBit {
-    public static xRTViewFromBitToNibble INSTANCE;
-
     public xRTViewFromBitToNibble(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -70,7 +64,7 @@ public class xRTViewFromBitToNibble
         if (tSource instanceof BitView tView) {
             byte[] abBits = tView.getBytes(hSource, ofStart/2, cSize/2, fReverse);
 
-            return xRTNibbleDelegate.INSTANCE.packHandle(abBits, mutability);
+            return nativeTemplates().get(xRTNibbleDelegate.class).packHandle(abBits, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -90,7 +84,7 @@ public class xRTViewFromBitToNibble
             } else {
                 nNibble = nNibble & 0x0F;
             }
-            return frame.assignValue(iReturn, xNibble.INSTANCE.makeJavaLong(nNibble));
+            return frame.assignValue(iReturn, nativeTemplates().get(xNibble.class).makeJavaLong(nNibble));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByte.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByte.java
@@ -17,7 +17,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
  */
 public class xRTViewFromByte
         extends xRTView {
-    public xRTViewFromByte(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromByte(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByte.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByte.java
@@ -17,19 +17,13 @@ import org.xvm.runtime.template._native.collections.arrays.xRTSlicingDelegate.Sl
  */
 public class xRTViewFromByte
         extends xRTView {
-    public static xRTViewFromByte INSTANCE;
-
     public xRTViewFromByte(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTViewFromByte.class)) {
             registerNativeTemplate(new xRTViewFromByteToInt8   (f_container, f_struct, true));
             registerNativeTemplate(new xRTViewFromByteToInt16  (f_container, f_struct, true));
             registerNativeTemplate(new xRTViewFromByteToInt64  (f_container, f_struct, true));

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToFloat64.java
@@ -24,14 +24,8 @@ import org.xvm.util.Handy;
  */
 public class xRTViewFromByteToFloat64
         extends xRTViewFromByte {
-    public static xRTViewFromByteToFloat64 INSTANCE;
-
     public xRTViewFromByteToFloat64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -59,7 +53,7 @@ public class xRTViewFromByteToFloat64
                 adValue[i] = Double.longBitsToDouble(Handy.byteArrayToLong(ab, 0));
             }
 
-            return xRTFloat64Delegate.INSTANCE.makeHandle(adValue, adValue.length, mutability);
+            return nativeTemplates().get(xRTFloat64Delegate.class).makeHandle(adValue, adValue.length, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -75,7 +69,7 @@ public class xRTViewFromByteToFloat64
             byte[] ab = tView.getBytes(hSource, lIndex*8, 8, false);
             double d  = Double.longBitsToDouble(Handy.byteArrayToLong(ab, 0));
 
-            return frame.assignValue(iReturn, xFloat64.INSTANCE.makeHandle(d));
+            return frame.assignValue(iReturn, nativeTemplates().get(xFloat64.class).makeHandle(d));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToFloat64.java
@@ -24,7 +24,7 @@ import org.xvm.util.Handy;
  */
 public class xRTViewFromByteToFloat64
         extends xRTViewFromByte {
-    public xRTViewFromByteToFloat64(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromByteToFloat64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToFloat64.java
@@ -53,7 +53,7 @@ public class xRTViewFromByteToFloat64
                 adValue[i] = Double.longBitsToDouble(Handy.byteArrayToLong(ab, 0));
             }
 
-            return nativeTemplates().get(xRTFloat64Delegate.class).makeHandle(adValue, adValue.length, mutability);
+            return f_container.nativeTemplate(xRTFloat64Delegate.class).makeHandle(adValue, adValue.length, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -69,7 +69,7 @@ public class xRTViewFromByteToFloat64
             byte[] ab = tView.getBytes(hSource, lIndex*8, 8, false);
             double d  = Double.longBitsToDouble(Handy.byteArrayToLong(ab, 0));
 
-            return frame.assignValue(iReturn, nativeTemplates().get(xFloat64.class).makeHandle(d));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xFloat64.class).makeHandle(d));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt16.java
@@ -23,14 +23,8 @@ import org.xvm.runtime.template.numbers.xInt16;
  */
 public class xRTViewFromByteToInt16
         extends xRTViewFromByte {
-    public static xRTViewFromByteToInt16 INSTANCE;
-
     public xRTViewFromByteToInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -61,7 +55,7 @@ public class xRTViewFromByteToInt16
                 anValue[i] = (short) (((short) bValue0) << 8 | (bValue1 & 0xFF));
             }
 
-            return xRTInt16Delegate.INSTANCE.packHandle(anValue, mutability);
+            return nativeTemplates().get(xRTInt16Delegate.class).packHandle(anValue, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -79,7 +73,7 @@ public class xRTViewFromByteToInt16
 
             // using a "short" intermediary takes care of the sign handling
             short nValue = (short) (((short) bValue0) << 8 | (bValue1 & 0xFF));
-            return frame.assignValue(iReturn, xInt16.INSTANCE.makeJavaLong(nValue));
+            return frame.assignValue(iReturn, nativeTemplates().get(xInt16.class).makeJavaLong(nValue));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt16.java
@@ -55,7 +55,7 @@ public class xRTViewFromByteToInt16
                 anValue[i] = (short) (((short) bValue0) << 8 | (bValue1 & 0xFF));
             }
 
-            return nativeTemplates().get(xRTInt16Delegate.class).packHandle(anValue, mutability);
+            return f_container.nativeTemplate(xRTInt16Delegate.class).packHandle(anValue, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -73,7 +73,7 @@ public class xRTViewFromByteToInt16
 
             // using a "short" intermediary takes care of the sign handling
             short nValue = (short) (((short) bValue0) << 8 | (bValue1 & 0xFF));
-            return frame.assignValue(iReturn, nativeTemplates().get(xInt16.class).makeJavaLong(nValue));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xInt16.class).makeJavaLong(nValue));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt16.java
@@ -23,7 +23,7 @@ import org.xvm.runtime.template.numbers.xInt16;
  */
 public class xRTViewFromByteToInt16
         extends xRTViewFromByte {
-    public xRTViewFromByteToInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromByteToInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt64.java
@@ -25,7 +25,7 @@ import org.xvm.util.Handy;
  */
 public class xRTViewFromByteToInt64
         extends xRTViewFromByte {
-    public xRTViewFromByteToInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromByteToInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt64.java
@@ -54,7 +54,7 @@ public class xRTViewFromByteToInt64
                 alValue[i] = Handy.byteArrayToLong(ab, 0);
             }
 
-            return nativeTemplates().get(xRTInt64Delegate.class).makeHandle(alValue, alValue.length, mutability);
+            return f_container.nativeTemplate(xRTInt64Delegate.class).makeHandle(alValue, alValue.length, mutability);
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt64.java
@@ -25,14 +25,8 @@ import org.xvm.util.Handy;
  */
 public class xRTViewFromByteToInt64
         extends xRTViewFromByte {
-    public static xRTViewFromByteToInt64 INSTANCE;
-
     public xRTViewFromByteToInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -60,7 +54,7 @@ public class xRTViewFromByteToInt64
                 alValue[i] = Handy.byteArrayToLong(ab, 0);
             }
 
-            return xRTInt64Delegate.INSTANCE.makeHandle(alValue, alValue.length, mutability);
+            return nativeTemplates().get(xRTInt64Delegate.class).makeHandle(alValue, alValue.length, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -76,7 +70,7 @@ public class xRTViewFromByteToInt64
             byte[] ab = tView.getBytes(hSource, lIndex*8, 8, false);
             long   l  = Handy.byteArrayToLong(ab, 0);
 
-            return frame.assignValue(iReturn, xInt64.makeHandle(l));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, l));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt8.java
@@ -48,7 +48,7 @@ public class xRTViewFromByteToInt8
         if (tSource instanceof ByteView tView) {
             byte[] abValue = tView.getBytes(hSource, ofStart, cSize, fReverse);
 
-            return nativeTemplates().get(xRTInt8Delegate.class).makeHandle(abValue, cSize, mutability);
+            return f_container.nativeTemplate(xRTInt8Delegate.class).makeHandle(abValue, cSize, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -63,7 +63,7 @@ public class xRTViewFromByteToInt8
         if (tSource instanceof ByteView tView) {
             byte bValue = tView.extractByte(hSource, lIndex);
 
-            return frame.assignValue(iReturn, nativeTemplates().get(xInt8.class).makeJavaLong(bValue));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xInt8.class).makeJavaLong(bValue));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt8.java
@@ -23,14 +23,8 @@ import org.xvm.runtime.template.numbers.xInt8;
  */
 public class xRTViewFromByteToInt8
         extends xRTViewFromByte {
-    public static xRTViewFromByteToInt8 INSTANCE;
-
     public xRTViewFromByteToInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -54,7 +48,7 @@ public class xRTViewFromByteToInt8
         if (tSource instanceof ByteView tView) {
             byte[] abValue = tView.getBytes(hSource, ofStart, cSize, fReverse);
 
-            return xRTInt8Delegate.INSTANCE.makeHandle(abValue, cSize, mutability);
+            return nativeTemplates().get(xRTInt8Delegate.class).makeHandle(abValue, cSize, mutability);
         }
 
         throw new UnsupportedOperationException();
@@ -69,7 +63,7 @@ public class xRTViewFromByteToInt8
         if (tSource instanceof ByteView tView) {
             byte bValue = tView.extractByte(hSource, lIndex);
 
-            return frame.assignValue(iReturn, xInt8.INSTANCE.makeJavaLong(bValue));
+            return frame.assignValue(iReturn, nativeTemplates().get(xInt8.class).makeJavaLong(bValue));
         }
 
         throw new UnsupportedOperationException();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewFromByteToInt8.java
@@ -23,7 +23,7 @@ import org.xvm.runtime.template.numbers.xInt8;
  */
 public class xRTViewFromByteToInt8
         extends xRTViewFromByte {
-    public xRTViewFromByteToInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewFromByteToInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBit.java
@@ -20,19 +20,13 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
  */
 public class xRTViewToBit
         extends xRTView {
-    public static xRTViewToBit INSTANCE;
-
     public xRTViewToBit(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTViewToBit.class)) {
             registerNativeTemplate(new xRTViewToBitFromNibble(f_container, f_struct, true));
 
             registerNativeTemplate(new xRTViewToBitFromInt8   (f_container, f_struct, true));
@@ -52,26 +46,26 @@ public class xRTViewToBit
     }
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTViewToBit.class)) {
             // register native views
             ConstantPool                    pool     = pool();
             Map<TypeConstant, xRTViewToBit> mapViews = new HashMap<>();
 
-            mapViews.put(pool.typeNibble(), xRTViewToBitFromNibble.INSTANCE);
+            mapViews.put(pool.typeNibble(), nativeTemplates().get(xRTViewToBitFromNibble.class));
 
-            mapViews.put(pool.typeInt8()   , xRTViewToBitFromInt8   .INSTANCE);
-            mapViews.put(pool.typeInt16()  , xRTViewToBitFromInt16  .INSTANCE);
-            mapViews.put(pool.typeInt32()  , xRTViewToBitFromInt32  .INSTANCE);
-            mapViews.put(pool.typeInt64()  , xRTViewToBitFromInt64  .INSTANCE);
-            mapViews.put(pool.typeInt128() , xRTViewToBitFromInt128 .INSTANCE);
+            mapViews.put(pool.typeInt8()   , nativeTemplates().get(xRTViewToBitFromInt8.class));
+            mapViews.put(pool.typeInt16()  , nativeTemplates().get(xRTViewToBitFromInt16.class));
+            mapViews.put(pool.typeInt32()  , nativeTemplates().get(xRTViewToBitFromInt32.class));
+            mapViews.put(pool.typeInt64()  , nativeTemplates().get(xRTViewToBitFromInt64.class));
+            mapViews.put(pool.typeInt128() , nativeTemplates().get(xRTViewToBitFromInt128.class));
 
-            mapViews.put(pool.typeUInt8()  , xRTViewToBitFromUInt8  .INSTANCE);
-            mapViews.put(pool.typeUInt16() , xRTViewToBitFromUInt16 .INSTANCE);
-            mapViews.put(pool.typeUInt32() , xRTViewToBitFromUInt32 .INSTANCE);
-            mapViews.put(pool.typeUInt64() , xRTViewToBitFromUInt64 .INSTANCE);
-            mapViews.put(pool.typeUInt128(), xRTViewToBitFromUInt128.INSTANCE);
+            mapViews.put(pool.typeUInt8()  , nativeTemplates().get(xRTViewToBitFromUInt8.class));
+            mapViews.put(pool.typeUInt16() , nativeTemplates().get(xRTViewToBitFromUInt16.class));
+            mapViews.put(pool.typeUInt32() , nativeTemplates().get(xRTViewToBitFromUInt32.class));
+            mapViews.put(pool.typeUInt64() , nativeTemplates().get(xRTViewToBitFromUInt64.class));
+            mapViews.put(pool.typeUInt128(), nativeTemplates().get(xRTViewToBitFromUInt128.class));
 
-            mapViews.put(pool.typeFloat64(), xRTViewToBitFromFloat64.INSTANCE);
+            mapViews.put(pool.typeFloat64(), nativeTemplates().get(xRTViewToBitFromFloat64.class));
 
             VIEWS = mapViews;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBit.java
@@ -20,7 +20,7 @@ import org.xvm.runtime.template.collections.xArray.Mutability;
  */
 public class xRTViewToBit
         extends xRTView {
-    public xRTViewToBit(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBit(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBit.java
@@ -51,21 +51,21 @@ public class xRTViewToBit
             ConstantPool                    pool     = pool();
             Map<TypeConstant, xRTViewToBit> mapViews = new HashMap<>();
 
-            mapViews.put(pool.typeNibble(), nativeTemplates().get(xRTViewToBitFromNibble.class));
+            mapViews.put(pool.typeNibble(), f_container.nativeTemplate(xRTViewToBitFromNibble.class));
 
-            mapViews.put(pool.typeInt8()   , nativeTemplates().get(xRTViewToBitFromInt8.class));
-            mapViews.put(pool.typeInt16()  , nativeTemplates().get(xRTViewToBitFromInt16.class));
-            mapViews.put(pool.typeInt32()  , nativeTemplates().get(xRTViewToBitFromInt32.class));
-            mapViews.put(pool.typeInt64()  , nativeTemplates().get(xRTViewToBitFromInt64.class));
-            mapViews.put(pool.typeInt128() , nativeTemplates().get(xRTViewToBitFromInt128.class));
+            mapViews.put(pool.typeInt8()   , f_container.nativeTemplate(xRTViewToBitFromInt8.class));
+            mapViews.put(pool.typeInt16()  , f_container.nativeTemplate(xRTViewToBitFromInt16.class));
+            mapViews.put(pool.typeInt32()  , f_container.nativeTemplate(xRTViewToBitFromInt32.class));
+            mapViews.put(pool.typeInt64()  , f_container.nativeTemplate(xRTViewToBitFromInt64.class));
+            mapViews.put(pool.typeInt128() , f_container.nativeTemplate(xRTViewToBitFromInt128.class));
 
-            mapViews.put(pool.typeUInt8()  , nativeTemplates().get(xRTViewToBitFromUInt8.class));
-            mapViews.put(pool.typeUInt16() , nativeTemplates().get(xRTViewToBitFromUInt16.class));
-            mapViews.put(pool.typeUInt32() , nativeTemplates().get(xRTViewToBitFromUInt32.class));
-            mapViews.put(pool.typeUInt64() , nativeTemplates().get(xRTViewToBitFromUInt64.class));
-            mapViews.put(pool.typeUInt128(), nativeTemplates().get(xRTViewToBitFromUInt128.class));
+            mapViews.put(pool.typeUInt8()  , f_container.nativeTemplate(xRTViewToBitFromUInt8.class));
+            mapViews.put(pool.typeUInt16() , f_container.nativeTemplate(xRTViewToBitFromUInt16.class));
+            mapViews.put(pool.typeUInt32() , f_container.nativeTemplate(xRTViewToBitFromUInt32.class));
+            mapViews.put(pool.typeUInt64() , f_container.nativeTemplate(xRTViewToBitFromUInt64.class));
+            mapViews.put(pool.typeUInt128(), f_container.nativeTemplate(xRTViewToBitFromUInt128.class));
 
-            mapViews.put(pool.typeFloat64(), nativeTemplates().get(xRTViewToBitFromFloat64.class));
+            mapViews.put(pool.typeFloat64(), f_container.nativeTemplate(xRTViewToBitFromFloat64.class));
 
             VIEWS = mapViews;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromFloat64.java
@@ -34,7 +34,7 @@ import static org.xvm.runtime.template._native.collections.arrays.LongBasedDeleg
 public class xRTViewToBitFromFloat64
         extends xRTViewToBit
         implements BitView {
-    public xRTViewToBitFromFloat64(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromFloat64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromFloat64.java
@@ -34,14 +34,8 @@ import static org.xvm.runtime.template._native.collections.arrays.LongBasedDeleg
 public class xRTViewToBitFromFloat64
         extends xRTViewToBit
         implements BitView {
-    public static xRTViewToBitFromFloat64 INSTANCE;
-
     public xRTViewToBitFromFloat64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -82,7 +76,7 @@ public class xRTViewToBitFromFloat64
 
         byte[] abBits = getBits(hView, ofStart, cSize, fReverse);
 
-        return xRTBitDelegate.INSTANCE.makeHandle(abBits, cSize, mutability);
+        return nativeTemplates().get(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromFloat64.java
@@ -76,7 +76,7 @@ public class xRTViewToBitFromFloat64
 
         byte[] abBits = getBits(hView, ofStart, cSize, fReverse);
 
-        return nativeTemplates().get(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
+        return f_container.nativeTemplate(xRTBitDelegate.class).makeHandle(abBits, cSize, mutability);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt128.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt128
         extends LongBasedBitView {
-    public static xRTViewToBitFromInt128 INSTANCE;
-
     public xRTViewToBitFromInt128(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 128);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt128.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt128
         extends LongBasedBitView {
-    public xRTViewToBitFromInt128(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromInt128(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 128);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt16.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt16
         extends LongBasedBitView {
-    public static xRTViewToBitFromInt16 INSTANCE;
-
     public xRTViewToBitFromInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 16);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt16.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt16
         extends LongBasedBitView {
-    public xRTViewToBitFromInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 16);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt32.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt32
         extends LongBasedBitView {
-    public static xRTViewToBitFromInt32 INSTANCE;
-
     public xRTViewToBitFromInt32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 32);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt32.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt32
         extends LongBasedBitView {
-    public xRTViewToBitFromInt32(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromInt32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 32);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt64.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt64
         extends LongBasedBitView {
-    public static xRTViewToBitFromInt64 INSTANCE;
-
     public xRTViewToBitFromInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 64);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt64.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt64
         extends LongBasedBitView {
-    public xRTViewToBitFromInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 64);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt8.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt8
         extends ByteBasedBitView {
-    public static xRTViewToBitFromInt8 INSTANCE;
-
     public xRTViewToBitFromInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromInt8.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromInt8
         extends ByteBasedBitView {
-    public xRTViewToBitFromInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromNibble.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromNibble
         extends LongBasedBitView {
-    public xRTViewToBitFromNibble(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromNibble(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 4);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromNibble.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromNibble
         extends LongBasedBitView {
-    public static xRTViewToBitFromNibble INSTANCE;
-
     public xRTViewToBitFromNibble(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 4);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt128.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt128
         extends LongBasedBitView {
-    public xRTViewToBitFromUInt128(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromUInt128(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 128);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt128.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt128
         extends LongBasedBitView {
-    public static xRTViewToBitFromUInt128 INSTANCE;
-
     public xRTViewToBitFromUInt128(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 128);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt16.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt16
         extends LongBasedBitView {
-    public xRTViewToBitFromUInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromUInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 16);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt16.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt16
         extends LongBasedBitView {
-    public static xRTViewToBitFromUInt16 INSTANCE;
-
     public xRTViewToBitFromUInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 16);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt32.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt32
         extends LongBasedBitView {
-    public static xRTViewToBitFromUInt32 INSTANCE;
-
     public xRTViewToBitFromUInt32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 32);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt32.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt32
         extends LongBasedBitView {
-    public xRTViewToBitFromUInt32(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromUInt32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 32);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt64.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt64
         extends LongBasedBitView {
-    public static xRTViewToBitFromUInt64 INSTANCE;
-
     public xRTViewToBitFromUInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 64);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt64.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt64
         extends LongBasedBitView {
-    public xRTViewToBitFromUInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromUInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 64);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt8.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt8
         extends ByteBasedBitView {
-    public xRTViewToBitFromUInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTViewToBitFromUInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/arrays/xRTViewToBitFromUInt8.java
@@ -14,14 +14,8 @@ import org.xvm.runtime.Container;
  */
 public class xRTViewToBitFromUInt8
         extends ByteBasedBitView {
-    public static xRTViewToBitFromUInt8 INSTANCE;
-
     public xRTViewToBitFromUInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/xBasicHashCollector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/xBasicHashCollector.java
@@ -25,7 +25,7 @@ public class xBasicHashCollector
 
     private static final String[] TYPE_HASH_COLLECTOR = { "collections.HashCollector" };
 
-    public xBasicHashCollector(Container container, ClassStructure structure, boolean fInstance) {
+    public xBasicHashCollector(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/collections/xBasicHashCollector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/collections/xBasicHashCollector.java
@@ -23,16 +23,10 @@ import org.xvm.util.ByteHashCollector;
 public class xBasicHashCollector
         extends ClassTemplate {
 
-    public static xBasicHashCollector INSTANCE;
-
     private static final String[] TYPE_HASH_COLLECTOR = { "collections.HashCollector" };
 
     public xBasicHashCollector(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -60,7 +54,7 @@ public class xBasicHashCollector
                 return frame.assignValue(iReturn, hTarget);
             }
             case "compute": {
-                JavaLong hHash = xInt64.makeHandle(hCollector.collector.compute());
+                JavaLong hHash = xInt64.makeHandle(frame, hCollector.collector.compute());
                 return frame.assignValue(iReturn, hHash);
             }
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
@@ -54,14 +54,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTUInt8Delegate;
  */
 public class xRTAlgorithms
         extends xService {
-    public static xRTAlgorithms INSTANCE;
-
     public xRTAlgorithms(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -143,7 +137,7 @@ public class xRTAlgorithms
                 MessageDigest digest = MessageDigest.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new DigestHandle(digest);
+                hImpl      = new DigestHandle(frame.f_context.f_container, digest);
                 break;
             }
 
@@ -152,7 +146,7 @@ public class xRTAlgorithms
                 Cipher cipher = Cipher.getInstance(sName);
 
                 nBlockSize = cipher.getBlockSize();
-                hImpl      = new CipherHandle(cipher);
+                hImpl      = new CipherHandle(frame.f_context.f_container, cipher);
                 break;
             }
 
@@ -160,7 +154,7 @@ public class xRTAlgorithms
                 Mac mac = Mac.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new MacHandle(mac);
+                hImpl      = new MacHandle(frame.f_context.f_container, mac);
                 break;
             }
 
@@ -168,7 +162,7 @@ public class xRTAlgorithms
                 Signature sig = Signature.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new SignatureHandle(sig);
+                hImpl      = new SignatureHandle(frame.f_context.f_container, sig);
                 break;
             }
 
@@ -176,7 +170,7 @@ public class xRTAlgorithms
                 KeyGenerator generator = KeyGenerator.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new KeyGenHandle(generator);
+                hImpl      = new KeyGenHandle(frame.f_context.f_container, generator);
                 break;
             }
 
@@ -185,7 +179,7 @@ public class xRTAlgorithms
             }
 
             List<ObjectHandle> list = new ArrayList<>(9);
-            list.add(xInt64.makeHandle(nBlockSize));
+            list.add(xInt64.makeHandle(frame, nBlockSize));
             list.add(hImpl);
             return frame.assignValues(aiReturn, list.toArray(Utils.OBJECTS_NONE));
 
@@ -288,8 +282,8 @@ public class xRTAlgorithms
      */
     public static class DigestHandle
             extends ObjectHandle {
-        protected DigestHandle(MessageDigest digest) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        protected DigestHandle(Container container, MessageDigest digest) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_digest = digest;
         }
@@ -305,8 +299,8 @@ public class xRTAlgorithms
      */
     public static class CipherHandle
             extends ObjectHandle {
-        protected CipherHandle(Cipher cipher) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        protected CipherHandle(Container container, Cipher cipher) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_cipher = cipher;
         }
@@ -322,8 +316,8 @@ public class xRTAlgorithms
      */
     public static class SignatureHandle
             extends ObjectHandle {
-        protected SignatureHandle(Signature signature) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        protected SignatureHandle(Container container, Signature signature) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_signature = signature;
         }
@@ -339,8 +333,8 @@ public class xRTAlgorithms
      */
     public static class MacHandle
             extends ObjectHandle {
-        protected MacHandle(Mac mac) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        protected MacHandle(Container container, Mac mac) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_mac = mac;
         }
@@ -356,8 +350,8 @@ public class xRTAlgorithms
      */
     public static class SecretHandle
             extends ObjectHandle {
-        protected SecretHandle(Key key) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        protected SecretHandle(Container container, Key key) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_key = key;
         }
@@ -378,8 +372,8 @@ public class xRTAlgorithms
          */
         public final KeyGenerator f_generator;
 
-        protected KeyGenHandle(KeyGenerator generator) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        protected KeyGenHandle(Container container, KeyGenerator generator) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_generator = generator;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
@@ -54,7 +54,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTUInt8Delegate;
  */
 public class xRTAlgorithms
         extends xService {
-    public xRTAlgorithms(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTAlgorithms(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTAlgorithms.java
@@ -137,7 +137,7 @@ public class xRTAlgorithms
                 MessageDigest digest = MessageDigest.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new DigestHandle(frame.f_context.f_container, digest);
+                hImpl      = new DigestHandle(frame.container(), digest);
                 break;
             }
 
@@ -146,7 +146,7 @@ public class xRTAlgorithms
                 Cipher cipher = Cipher.getInstance(sName);
 
                 nBlockSize = cipher.getBlockSize();
-                hImpl      = new CipherHandle(frame.f_context.f_container, cipher);
+                hImpl      = new CipherHandle(frame.container(), cipher);
                 break;
             }
 
@@ -154,7 +154,7 @@ public class xRTAlgorithms
                 Mac mac = Mac.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new MacHandle(frame.f_context.f_container, mac);
+                hImpl      = new MacHandle(frame.container(), mac);
                 break;
             }
 
@@ -162,7 +162,7 @@ public class xRTAlgorithms
                 Signature sig = Signature.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new SignatureHandle(frame.f_context.f_container, sig);
+                hImpl      = new SignatureHandle(frame.container(), sig);
                 break;
             }
 
@@ -170,7 +170,7 @@ public class xRTAlgorithms
                 KeyGenerator generator = KeyGenerator.getInstance(sName);
 
                 nBlockSize = 0;
-                hImpl      = new KeyGenHandle(frame.f_context.f_container, generator);
+                hImpl      = new KeyGenHandle(frame.container(), generator);
                 break;
             }
 
@@ -283,7 +283,7 @@ public class xRTAlgorithms
     public static class DigestHandle
             extends ObjectHandle {
         protected DigestHandle(Container container, MessageDigest digest) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_digest = digest;
         }
@@ -300,7 +300,7 @@ public class xRTAlgorithms
     public static class CipherHandle
             extends ObjectHandle {
         protected CipherHandle(Container container, Cipher cipher) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_cipher = cipher;
         }
@@ -317,7 +317,7 @@ public class xRTAlgorithms
     public static class SignatureHandle
             extends ObjectHandle {
         protected SignatureHandle(Container container, Signature signature) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_signature = signature;
         }
@@ -334,7 +334,7 @@ public class xRTAlgorithms
     public static class MacHandle
             extends ObjectHandle {
         protected MacHandle(Container container, Mac mac) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_mac = mac;
         }
@@ -351,7 +351,7 @@ public class xRTAlgorithms
     public static class SecretHandle
             extends ObjectHandle {
         protected SecretHandle(Container container, Key key) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_key = key;
         }
@@ -373,7 +373,7 @@ public class xRTAlgorithms
         public final KeyGenerator f_generator;
 
         protected KeyGenHandle(Container container, KeyGenerator generator) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_generator = generator;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
@@ -527,7 +527,7 @@ public class xRTCertificateManager
     private int invokeKeystoreFor(Frame frame, ObjectHandle[] ahArg, int iReturn) {
         ArrayHandle  hContent  = (ArrayHandle) ahArg[0];
         StringHandle hPwd      = xRTKeyStore.getPassword(frame, ahArg[1]);
-        ObjectHandle hKeyStore = nativeTemplates().get(xRTKeyStore.class).ensureKeyStore(frame, hContent, hPwd);
+        ObjectHandle hKeyStore = f_container.nativeTemplate(xRTKeyStore.class).ensureKeyStore(frame, hContent, hPwd);
 
         return frame.assignDeferredValue(iReturn, hKeyStore);
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
@@ -74,7 +74,7 @@ import org.xvm.runtime.template._native.crypto.xRTKeyStore.KeyStoreHandle;
 public class xRTCertificateManager
         extends xService {
 
-    public xRTCertificateManager(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTCertificateManager(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTCertificateManager.java
@@ -74,14 +74,8 @@ import org.xvm.runtime.template._native.crypto.xRTKeyStore.KeyStoreHandle;
 public class xRTCertificateManager
         extends xService {
 
-    public static xRTCertificateManager INSTANCE;
-
     public xRTCertificateManager(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -113,7 +107,7 @@ public class xRTCertificateManager
      * Injection support method.
      */
     public ObjectHandle ensureManager(Frame frame, ObjectHandle hOpts) {
-        StringHandle     hProvider = hOpts instanceof StringHandle hS ? hS : xString.makeHandle("self");
+        StringHandle     hProvider = hOpts instanceof StringHandle hS ? hS : xString.makeHandle(frame, "self");
         ClassComposition clz       = getCanonicalClass();
         ServiceHandle    hMgr      = createServiceHandle(
                 f_container.createServiceContext("CertificateManager"), clz, getCanonicalType());
@@ -533,7 +527,7 @@ public class xRTCertificateManager
     private int invokeKeystoreFor(Frame frame, ObjectHandle[] ahArg, int iReturn) {
         ArrayHandle  hContent  = (ArrayHandle) ahArg[0];
         StringHandle hPwd      = xRTKeyStore.getPassword(frame, ahArg[1]);
-        ObjectHandle hKeyStore = xRTKeyStore.INSTANCE.ensureKeyStore(frame, hContent, hPwd);
+        ObjectHandle hKeyStore = nativeTemplates().get(xRTKeyStore.class).ensureKeyStore(frame, hContent, hPwd);
 
         return frame.assignDeferredValue(iReturn, hKeyStore);
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTDecryptor.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTDecryptor.java
@@ -32,7 +32,7 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.KeyForm;
  */
 public class xRTDecryptor
         extends xService {
-    public xRTDecryptor(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTDecryptor(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTDecryptor.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTDecryptor.java
@@ -32,14 +32,8 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.KeyForm;
  */
 public class xRTDecryptor
         extends xService {
-    public static xRTDecryptor INSTANCE;
-
     public xRTDecryptor(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTHasher.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTHasher.java
@@ -27,14 +27,8 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.DigestHandle;
  */
 public class xRTHasher
         extends xService {
-    public static xRTHasher INSTANCE;
-
     public xRTHasher(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTHasher.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTHasher.java
@@ -27,7 +27,7 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.DigestHandle;
  */
 public class xRTHasher
         extends xService {
-    public xRTHasher(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTHasher(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyGenerator.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyGenerator.java
@@ -54,6 +54,6 @@ public class xRTKeyGenerator
         int       nSize = key.getEncoded().length;
 
         return frame.assignValues(aiReturn, xInt64.makeHandle(frame, nSize),
-                new SecretHandle(frame.f_context.f_container, key));
+                new SecretHandle(frame.container(), key));
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyGenerator.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyGenerator.java
@@ -23,14 +23,8 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.SecretHandle;
  */
 public class xRTKeyGenerator
         extends xService {
-    public static xRTKeyGenerator INSTANCE;
-
     public xRTKeyGenerator(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -59,6 +53,7 @@ public class xRTKeyGenerator
         SecretKey key   = hKeyGen.f_generator.generateKey();
         int       nSize = key.getEncoded().length;
 
-        return frame.assignValues(aiReturn, xInt64.makeHandle(nSize), new SecretHandle(key));
+        return frame.assignValues(aiReturn, xInt64.makeHandle(frame, nSize),
+                new SecretHandle(frame.f_context.f_container, key));
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyGenerator.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyGenerator.java
@@ -23,7 +23,7 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.SecretHandle;
  */
 public class xRTKeyGenerator
         extends xService {
-    public xRTKeyGenerator(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTKeyGenerator(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
@@ -82,14 +82,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTBooleanDelegate;
  */
 public class xRTKeyStore
         extends xService {
-    public static xRTKeyStore INSTANCE;
-
     public xRTKeyStore(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -214,7 +208,7 @@ public class xRTKeyStore
             try {
                 ArrayList<String> listNames = Collections.list(hStore.f_keyStore.aliases());
                 return frame.assignValue(iReturn,
-                        xString.makeArrayHandle(listNames.toArray(Utils.NO_NAMES)));
+                        xString.makeArrayHandle(frame.f_context.f_container, listNames.toArray(Utils.NO_NAMES)));
             } catch (KeyStoreException e) {
                 return frame.raiseException(xException.makeObscure(frame, e.getMessage()));
             }
@@ -337,18 +331,18 @@ public class xRTKeyStore
             // create the arguments
             List<ObjectHandle> list = new ArrayList<>(9);
             list.add(xBoolean.TRUE);
-            list.add(xString.makeHandle(sIssuer));
-            list.add(xString.makeHandle(sSubject));
-            list.add(xInt64.makeHandle(nVersion));
-            addDate(dateNotBefore, list);
-            addDate(dateNotAfter, list);
+            list.add(xString.makeHandle(frame, sIssuer));
+            list.add(xString.makeHandle(frame, sSubject));
+            list.add(xInt64.makeHandle(frame, nVersion));
+            addDate(frame, dateNotBefore, list);
+            addDate(frame, dateNotAfter, list);
             list.add(xArray.makeBooleanArrayHandle(abUsage, cUsage, Mutability.Constant));
-            list.add(xString.makeHandle(sSigAlgName));
+            list.add(xString.makeHandle(frame, sSigAlgName));
             list.add(xByteArray.makeByteArrayHandle(abSignature, Mutability.Constant));
-            list.add(xString.makeHandle(sAlgorithm));
-            list.add(xInt64.makeHandle(cKeyBits >>> 3));
+            list.add(xString.makeHandle(frame, sAlgorithm));
+            list.add(xInt64.makeHandle(frame, cKeyBits >>> 3));
             list.add(xByteArray.makeByteArrayHandle(abPublic, Mutability.Constant));
-            list.add(new SecretHandle(publicKey));
+            list.add(new SecretHandle(frame.f_context.f_container, publicKey));
             list.add(xByteArray.makeByteArrayHandle(abDer, Mutability.Constant));
 
             return frame.assignValues(aiReturn, list.toArray(Utils.OBJECTS_NONE));
@@ -357,13 +351,13 @@ public class xRTKeyStore
         }
     }
 
-    private static void addDate(Date date, List<ObjectHandle> list) {
+    private static void addDate(Frame frame, Date date, List<ObjectHandle> list) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
 
-        list.add(xInt64.makeHandle(cal.get(Calendar.YEAR)));
-        list.add(xInt64.makeHandle(cal.get(Calendar.MONTH) + 1));
-        list.add(xInt64.makeHandle(cal.get(Calendar.DAY_OF_MONTH)));
+        list.add(xInt64.makeHandle(frame, cal.get(Calendar.YEAR)));
+        list.add(xInt64.makeHandle(frame, cal.get(Calendar.MONTH) + 1));
+        list.add(xInt64.makeHandle(frame, cal.get(Calendar.DAY_OF_MONTH)));
     }
 
     private static int getPublicKeyLength(PublicKey puk)
@@ -409,10 +403,10 @@ public class xRTKeyStore
                 } else {
                     nType = 1; // Pair
                 }
-                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(nType));
+                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, nType));
             }
             if (keyStore.isCertificateEntry(sName)) {
-                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(1)); // Certificate
+                return frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, 1)); // Certificate
             }
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
         } catch (GeneralSecurityException e) {
@@ -456,14 +450,14 @@ public class xRTKeyStore
 
                 List<ObjectHandle> list = new ArrayList<>(9);
                 list.add(xBoolean.TRUE);
-                list.add(xString.makeHandle(sAlgorithm));
-                list.add(xInt64.makeHandle(cKeyBits >>> 3));
-                list.add(new SecretHandle(key));
+                list.add(xString.makeHandle(frame, sAlgorithm));
+                list.add(xInt64.makeHandle(frame, cKeyBits >>> 3));
+                list.add(new SecretHandle(frame.f_context.f_container, key));
                 if (publicKey == null) {
                     list.add(xNullable.NULL);
                     list.add(xArray.ensureEmptyByteArray());
                 } else {
-                    list.add(new SecretHandle(publicKey));
+                    list.add(new SecretHandle(frame.f_context.f_container, publicKey));
                     list.add(xArray.makeByteArrayHandle(abPublic, Mutability.Constant));
                 }
                 return frame.assignValues(aiReturn, list.toArray(Utils.OBJECTS_NONE));
@@ -485,13 +479,13 @@ public class xRTKeyStore
             Key key = hStore.getKey(sName);
             if (key instanceof PBEKey keyPwd) {
                 return frame.assignValues(aiReturn,
-                        xBoolean.TRUE, xString.makeHandle(keyPwd.getPassword()));
+                        xBoolean.TRUE, xString.makeHandle(frame, keyPwd.getPassword()));
             }
 
             // unfortunately com.sun.crypto.provider.PBEKey is not public
             if ("PBEKey".equals(key.getClass().getSimpleName())) {
                 return frame.assignValues(aiReturn, xBoolean.TRUE,
-                        xString.makeHandle(new String(key.getEncoded(), StandardCharsets.UTF_8)));
+                        xString.makeHandle(frame, new String(key.getEncoded(), StandardCharsets.UTF_8)));
             }
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
         } catch (GeneralSecurityException e) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
@@ -208,7 +208,7 @@ public class xRTKeyStore
             try {
                 ArrayList<String> listNames = Collections.list(hStore.f_keyStore.aliases());
                 return frame.assignValue(iReturn,
-                        xString.makeArrayHandle(frame.f_context.f_container, listNames.toArray(Utils.NO_NAMES)));
+                        xString.makeArrayHandle(frame.container(), listNames.toArray(Utils.NO_NAMES)));
             } catch (KeyStoreException e) {
                 return frame.raiseException(xException.makeObscure(frame, e.getMessage()));
             }
@@ -342,7 +342,7 @@ public class xRTKeyStore
             list.add(xString.makeHandle(frame, sAlgorithm));
             list.add(xInt64.makeHandle(frame, cKeyBits >>> 3));
             list.add(xByteArray.makeByteArrayHandle(abPublic, Mutability.Constant));
-            list.add(new SecretHandle(frame.f_context.f_container, publicKey));
+            list.add(new SecretHandle(frame.container(), publicKey));
             list.add(xByteArray.makeByteArrayHandle(abDer, Mutability.Constant));
 
             return frame.assignValues(aiReturn, list.toArray(Utils.OBJECTS_NONE));
@@ -452,12 +452,12 @@ public class xRTKeyStore
                 list.add(xBoolean.TRUE);
                 list.add(xString.makeHandle(frame, sAlgorithm));
                 list.add(xInt64.makeHandle(frame, cKeyBits >>> 3));
-                list.add(new SecretHandle(frame.f_context.f_container, key));
+                list.add(new SecretHandle(frame.container(), key));
                 if (publicKey == null) {
                     list.add(xNullable.NULL);
                     list.add(xArray.ensureEmptyByteArray());
                 } else {
-                    list.add(new SecretHandle(frame.f_context.f_container, publicKey));
+                    list.add(new SecretHandle(frame.container(), publicKey));
                     list.add(xArray.makeByteArrayHandle(abPublic, Mutability.Constant));
                 }
                 return frame.assignValues(aiReturn, list.toArray(Utils.OBJECTS_NONE));

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTKeyStore.java
@@ -82,7 +82,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTBooleanDelegate;
  */
 public class xRTKeyStore
         extends xService {
-    public xRTKeyStore(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTKeyStore(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
@@ -38,14 +38,8 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.SignatureHandle;
  */
 public class xRTSigner
         extends xService {
-    public static xRTSigner INSTANCE;
-
     public xRTSigner(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/crypto/xRTSigner.java
@@ -38,7 +38,7 @@ import org.xvm.runtime.template._native.crypto.xRTAlgorithms.SignatureHandle;
  */
 public class xRTSigner
         extends xService {
-    public xRTSigner(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTSigner(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPDirectory.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPDirectory.java
@@ -26,7 +26,7 @@ import org.xvm.runtime.template.xConst;
  */
 public class xCPDirectory
         extends xConst {
-    public xCPDirectory(Container container, ClassStructure structure, boolean fInstance) {
+    public xCPDirectory(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPFile.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPFile.java
@@ -26,7 +26,7 @@ import org.xvm.runtime.template.xConst;
  */
 public class xCPFile
         extends xConst {
-    public xCPFile(Container container, ClassStructure structure, boolean fInstance) {
+    public xCPFile(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPFileStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPFileStore.java
@@ -37,7 +37,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xCPFileStore
         extends xConst {
-    public xCPFileStore(Container container, ClassStructure structure, boolean fInstance) {
+    public xCPFileStore(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPFileStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xCPFileStore.java
@@ -62,7 +62,7 @@ public class xCPFileStore
 
             GenericHandle   hStruct = new GenericHandle(clz.ensureAccess(Access.STRUCT));
             ObjectHandle[]  ahVar   = Utils.ensureSize(Utils.OBJECTS_NONE, s_constructor.getMaxVars());
-            ahVar[0] = xString.makeHandle(constStore.getPath());
+            ahVar[0] = xString.makeHandle(frame, constStore.getPath());
             ahVar[1] = new ConstantHandle(constStore.getValue());
 
             return proceedConstruction(frame, s_constructor, true, hStruct, ahVar, Op.A_STACK);
@@ -99,10 +99,10 @@ public class xCPFileStore
 
             ObjectHandle[] ahValue = new ObjectHandle[5];
             ahValue[0] = xBoolean.makeHandle(constNode.getFormat() == Format.FSDir);
-            ahValue[1] = xString.makeHandle(constNode.getName());
+            ahValue[1] = xString.makeHandle(frame, constNode.getName());
             ahValue[2] = frame.getConstHandle(constNode.getCreatedConstant());
             ahValue[3] = frame.getConstHandle(constNode.getModifiedConstant());
-            ahValue[4] = xInt64.makeHandle(calcSize(constNode));
+            ahValue[4] = xInt64.makeHandle(frame, calcSize(constNode));
             return new Utils.AssignValues(aiReturn, ahValue).proceed(frame);
         }
 
@@ -117,7 +117,7 @@ public class xCPFileStore
             ObjectHandle[]   ahCookies = new ObjectHandle[cNodes];
             for (int i = 0; i < cNodes; ++i) {
                 FSNodeConstant constEach = aNodes[i];
-                ahNames  [i] = xString.makeHandle(constEach.getName());
+                ahNames  [i] = xString.makeHandle(frame, constEach.getName());
                 ahCookies[i] = new ConstantHandle(constEach);
             }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSDirectory.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSDirectory.java
@@ -30,7 +30,7 @@ import org.xvm.runtime.template.xBoolean;
  */
 public class xOSDirectory
         extends xOSFileNode {
-    public xOSDirectory(Container container, ClassStructure structure, boolean fInstance) {
+    public xOSDirectory(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSDirectory.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSDirectory.java
@@ -30,14 +30,8 @@ import org.xvm.runtime.template.xBoolean;
  */
 public class xOSDirectory
         extends xOSFileNode {
-    public static xOSDirectory INSTANCE;
-
     public xOSDirectory(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFile.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFile.java
@@ -481,7 +481,7 @@ public class xOSFile
         Path path = hFile.f_path;
         try {
             FileChannel channel = FileChannel.open(path, aOpenOpt);
-            return nativeTemplates().get(xRawOSFileChannel.class).createHandle(frame, channel, path, iReturn);
+            return f_container.nativeTemplate(xRawOSFileChannel.class).createHandle(frame, channel, path, iReturn);
         } catch (IOException e) {
             return raisePathException(frame, e, path);
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFile.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFile.java
@@ -53,7 +53,7 @@ import org.xvm.util.Handy;
  */
 public class xOSFile
         extends xOSFileNode {
-    public xOSFile(Container container, ClassStructure structure, boolean fInstance) {
+    public xOSFile(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFile.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFile.java
@@ -53,14 +53,8 @@ import org.xvm.util.Handy;
  */
 public class xOSFile
         extends xOSFileNode {
-    public static xOSFile INSTANCE;
-
     public xOSFile(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -487,7 +481,7 @@ public class xOSFile
         Path path = hFile.f_path;
         try {
             FileChannel channel = FileChannel.open(path, aOpenOpt);
-            return xRawOSFileChannel.INSTANCE.createHandle(frame, channel, path, iReturn);
+            return nativeTemplates().get(xRawOSFileChannel.class).createHandle(frame, channel, path, iReturn);
         } catch (IOException e) {
             return raisePathException(frame, e, path);
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileNode.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileNode.java
@@ -33,7 +33,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xOSFileNode
         extends xConst {
-    public xOSFileNode(Container container, ClassStructure structure, boolean fInstance) {
+    public xOSFileNode(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileNode.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileNode.java
@@ -121,9 +121,9 @@ public class xOSFileNode
      */
     static int createHandle(Frame frame, ObjectHandle hOSStore, Path path, boolean fDir, int iReturn) {
         return fDir
-            ? frame.f_context.f_container.nativeTemplates().get(xOSDirectory.class).
+            ? frame.nativeTemplate(xOSDirectory.class).
                     createHandle(frame, hOSStore, path, iReturn)
-            : frame.f_context.f_container.nativeTemplates().get(xOSFile.class).
+            : frame.nativeTemplate(xOSFile.class).
                     createHandle(frame, hOSStore, path, iReturn);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileNode.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileNode.java
@@ -56,7 +56,7 @@ public class xOSFileNode
         NodeHandle hNode = (NodeHandle) hTarget;
         switch (sPropName) {
         case "pathString":
-            return frame.assignValue(iReturn, xString.makeHandle(hNode.f_path.toString()));
+            return frame.assignValue(iReturn, xString.makeHandle(frame, hNode.f_path.toString()));
 
         case "exists":
             return frame.assignValue(iReturn, xBoolean.makeHandle(hNode.f_path.toFile().exists()));
@@ -70,7 +70,7 @@ public class xOSFileNode
         case "createdMillis":
             try {
                 BasicFileAttributes attr = Files.readAttributes(hNode.f_path, BasicFileAttributes.class);
-                return frame.assignValue(iReturn, xInt64.makeHandle(attr.creationTime().toMillis()));
+                return frame.assignValue(iReturn, xInt64.makeHandle(frame, attr.creationTime().toMillis()));
             } catch (IOException e) {
                 return raisePathException(frame, e, hNode.f_path);
             }
@@ -78,7 +78,7 @@ public class xOSFileNode
         case "accessedMillis":
             try {
                 BasicFileAttributes attr = Files.readAttributes(hNode.f_path, BasicFileAttributes.class);
-                return frame.assignValue(iReturn, xInt64.makeHandle(attr.lastAccessTime().toMillis()));
+                return frame.assignValue(iReturn, xInt64.makeHandle(frame, attr.lastAccessTime().toMillis()));
             } catch (IOException e) {
                 return raisePathException(frame, e, hNode.f_path);
             }
@@ -86,7 +86,7 @@ public class xOSFileNode
         case "modifiedMillis":
             try {
                 BasicFileAttributes attr = Files.readAttributes(hNode.f_path, BasicFileAttributes.class);
-                return frame.assignValue(iReturn, xInt64.makeHandle(attr.lastModifiedTime().toMillis()));
+                return frame.assignValue(iReturn, xInt64.makeHandle(frame, attr.lastModifiedTime().toMillis()));
             } catch (IOException e) {
                 return raisePathException(frame, e, hNode.f_path);
             }
@@ -96,9 +96,9 @@ public class xOSFileNode
                 Path path = hNode.f_path;
                 if (Files.exists(path)) {
                     BasicFileAttributes attr = Files.readAttributes(path, BasicFileAttributes.class);
-                    return frame.assignValue(iReturn, xInt64.makeHandle(attr.size()));
+                    return frame.assignValue(iReturn, xInt64.makeHandle(frame, attr.size()));
                 } else {
-                    return frame.assignValue(iReturn, xInt64.makeHandle(0));
+                    return frame.assignValue(iReturn, xInt64.makeHandle(frame, 0));
                 }
             } catch (IOException e) {
                 return raisePathException(frame, e, hNode.f_path);
@@ -121,8 +121,10 @@ public class xOSFileNode
      */
     static int createHandle(Frame frame, ObjectHandle hOSStore, Path path, boolean fDir, int iReturn) {
         return fDir
-            ? xOSDirectory.INSTANCE.createHandle(frame, hOSStore, path, iReturn)
-            : xOSFile     .INSTANCE.createHandle(frame, hOSStore, path, iReturn);
+            ? frame.f_context.f_container.nativeTemplates().get(xOSDirectory.class).
+                    createHandle(frame, hOSStore, path, iReturn)
+            : frame.f_context.f_container.nativeTemplates().get(xOSFile.class).
+                    createHandle(frame, hOSStore, path, iReturn);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileStore.java
@@ -35,7 +35,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xOSFileStore
         extends ClassTemplate {
-    public xOSFileStore(Container container, ClassStructure structure, boolean fInstance) {
+    public xOSFileStore(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileStore.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSFileStore.java
@@ -69,13 +69,13 @@ public class xOSFileStore
     public int invokeNativeGet(Frame frame, String sPropName, ObjectHandle hTarget, int iReturn) {
         switch (sPropName) {
         case "capacity":
-            return frame.assignValue(iReturn, xInt64.makeHandle(ROOT.getTotalSpace()));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, ROOT.getTotalSpace()));
 
         case "bytesFree":
-            return frame.assignValue(iReturn, xInt64.makeHandle(ROOT.getFreeSpace()));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, ROOT.getFreeSpace()));
 
         case "bytesUsed":
-            return frame.assignValue(iReturn, xInt64.makeHandle(ROOT.getTotalSpace() - ROOT.getFreeSpace()));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, ROOT.getTotalSpace() - ROOT.getFreeSpace()));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
@@ -89,15 +89,15 @@ public class xOSStorage
         // the handles below are cached by the Container.initResources()
         switch (sPropName) {
         case "homeDir":
-            return nativeTemplates().get(xOSDirectory.class).createHandle(frame, hStore,
+            return f_container.nativeTemplate(xOSDirectory.class).createHandle(frame, hStore,
                 Paths.get(System.getProperty("user.home")), iReturn);
 
         case "curDir":
-            return nativeTemplates().get(xOSDirectory.class).createHandle(frame, hStore,
+            return f_container.nativeTemplate(xOSDirectory.class).createHandle(frame, hStore,
                 Paths.get(System.getProperty("user.dir")), iReturn);
 
         case "tmpDir":
-            return nativeTemplates().get(xOSDirectory.class).createHandle(frame, hStore,
+            return f_container.nativeTemplate(xOSDirectory.class).createHandle(frame, hStore,
                 Paths.get(System.getProperty("java.io.tmpdir")), iReturn);
         }
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -109,7 +109,7 @@ public class xOSStorage
         ServiceHandle hStorage = (ServiceHandle) hTarget;
 
         if (frame.f_context != hStorage.f_context) {
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                 call1(frame, hTarget, new ObjectHandle[] {hArg}, iReturn);
         }
 
@@ -124,7 +124,7 @@ public class xOSStorage
 
                 return cNames == 0
                          ? frame.assignValue(iReturn, xString.ensureEmptyArray())
-                         : frame.assignValue(iReturn, xString.makeArrayHandle(frame.f_context.f_container, asName));
+                         : frame.assignValue(iReturn, xString.makeArrayHandle(frame.container(), asName));
             } catch (InvalidPathException e) {
                 return frame.raiseException(xException.ioException(frame, e.getMessage()));
             }
@@ -205,7 +205,7 @@ public class xOSStorage
 
         if (hStorage != null && frame.f_context != hStorage.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     call1(frame, hTarget, ahArg, iReturn);
         }
 
@@ -224,7 +224,7 @@ public class xOSStorage
 
         if (frame.f_context != hStorage.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     callN(frame, hTarget, ahArg, aiReturn);
         }
 
@@ -320,17 +320,17 @@ public class xOSStorage
                 Path pathRelative = (Path) event.context();
                 Path pathAbsolute = pathDir.resolve(pathRelative);
 
-                FunctionHandle hfnOnEvent = xRTFunction.makeInternalHandle(
-                        context.hStorage.f_context.f_container, s_methodOnEvent).
+                Container      container  = context.hStorage.f_context.f_container;
+                FunctionHandle hfnOnEvent = xRTFunction.
+                        makeInternalHandle(container, s_methodOnEvent).
                                 bindTarget(null, context.hStorage);
 
-                Container    container = context.hStorage.f_context.f_container;
                 StringHandle hPathDir  = xString.makeHandle(container, pathDir.toString());
                 StringHandle hPathNode = xString.makeHandle(container, pathAbsolute.toString());
 
                 ObjectHandle[] ahArg = new ObjectHandle[] {
                     hPathDir, hPathNode, xBoolean.TRUE,
-                    xInt64.makeHandle(context.hStorage.f_context.f_container, iKind)
+                    xInt64.makeHandle(container, iKind)
                 };
                 context.hStorage.f_context.callLater(hfnOnEvent, ahArg);
             }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
@@ -46,7 +46,7 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
  */
 public class xOSStorage
         extends xService {
-    public xOSStorage(Container container, ClassStructure structure, boolean fInstance) {
+    public xOSStorage(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xOSStorage.java
@@ -89,15 +89,15 @@ public class xOSStorage
         // the handles below are cached by the Container.initResources()
         switch (sPropName) {
         case "homeDir":
-            return xOSDirectory.INSTANCE.createHandle(frame, hStore,
+            return nativeTemplates().get(xOSDirectory.class).createHandle(frame, hStore,
                 Paths.get(System.getProperty("user.home")), iReturn);
 
         case "curDir":
-            return xOSDirectory.INSTANCE.createHandle(frame, hStore,
+            return nativeTemplates().get(xOSDirectory.class).createHandle(frame, hStore,
                 Paths.get(System.getProperty("user.dir")), iReturn);
 
         case "tmpDir":
-            return xOSDirectory.INSTANCE.createHandle(frame, hStore,
+            return nativeTemplates().get(xOSDirectory.class).createHandle(frame, hStore,
                 Paths.get(System.getProperty("java.io.tmpdir")), iReturn);
         }
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -109,7 +109,7 @@ public class xOSStorage
         ServiceHandle hStorage = (ServiceHandle) hTarget;
 
         if (frame.f_context != hStorage.f_context) {
-            return xRTFunction.makeAsyncNativeHandle(method).
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
                 call1(frame, hTarget, new ObjectHandle[] {hArg}, iReturn);
         }
 
@@ -124,7 +124,7 @@ public class xOSStorage
 
                 return cNames == 0
                          ? frame.assignValue(iReturn, xString.ensureEmptyArray())
-                         : frame.assignValue(iReturn, xString.makeArrayHandle(asName));
+                         : frame.assignValue(iReturn, xString.makeArrayHandle(frame.f_context.f_container, asName));
             } catch (InvalidPathException e) {
                 return frame.raiseException(xException.ioException(frame, e.getMessage()));
             }
@@ -205,7 +205,8 @@ public class xOSStorage
 
         if (hStorage != null && frame.f_context != hStorage.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).call1(frame, hTarget, ahArg, iReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    call1(frame, hTarget, ahArg, iReturn);
         }
 
         switch (method.getName()) {
@@ -223,7 +224,8 @@ public class xOSStorage
 
         if (frame.f_context != hStorage.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).callN(frame, hTarget, ahArg, aiReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    callN(frame, hTarget, ahArg, aiReturn);
         }
 
         switch (method.getName()) {
@@ -318,14 +320,17 @@ public class xOSStorage
                 Path pathRelative = (Path) event.context();
                 Path pathAbsolute = pathDir.resolve(pathRelative);
 
-                FunctionHandle hfnOnEvent =
-                        xRTFunction.makeInternalHandle(null, s_methodOnEvent).bindTarget(null, context.hStorage);
+                FunctionHandle hfnOnEvent = xRTFunction.makeInternalHandle(
+                        context.hStorage.f_context.f_container, s_methodOnEvent).
+                                bindTarget(null, context.hStorage);
 
-                StringHandle hPathDir  = xString.makeHandle(pathDir.toString());
-                StringHandle hPathNode = xString.makeHandle(pathAbsolute.toString());
+                Container    container = context.hStorage.f_context.f_container;
+                StringHandle hPathDir  = xString.makeHandle(container, pathDir.toString());
+                StringHandle hPathNode = xString.makeHandle(container, pathAbsolute.toString());
 
                 ObjectHandle[] ahArg = new ObjectHandle[] {
-                    hPathDir, hPathNode, xBoolean.TRUE, xInt64.makeHandle(iKind)
+                    hPathDir, hPathNode, xBoolean.TRUE,
+                    xInt64.makeHandle(context.hStorage.f_context.f_container, iKind)
                 };
                 context.hStorage.f_context.callLater(hfnOnEvent, ahArg);
             }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xRawOSFileChannel.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xRawOSFileChannel.java
@@ -47,14 +47,8 @@ import org.xvm.runtime.template._native.io.xRawChannel;
  */
 public class xRawOSFileChannel
         extends xRawChannel {
-    public static xRawOSFileChannel INSTANCE;
-
     public xRawOSFileChannel(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -84,14 +78,14 @@ public class xRawOSFileChannel
         switch (sPropName) {
         case "size":
             try {
-                return frame.assignValue(iReturn, xInt64.makeHandle(hChannel.f_channel.size()));
+                return frame.assignValue(iReturn, xInt64.makeHandle(frame, hChannel.f_channel.size()));
             } catch (IOException e) {
                 return xOSFileNode.raisePathException(frame, e, hChannel.f_path);
             }
 
         case "position":
             try {
-                return frame.assignValue(iReturn, xInt64.makeHandle(hChannel.f_channel.position()));
+                return frame.assignValue(iReturn, xInt64.makeHandle(frame, hChannel.f_channel.position()));
             } catch (IOException e) {
                 return xOSFileNode.raisePathException(frame, e, hChannel.f_path);
             }
@@ -198,7 +192,7 @@ public class xRawOSFileChannel
             try {
                 int cbRead = cfRead.get().intValue();
                 return frameCaller.assignValue(iReturn, cbRead < 0
-                        ? xInt64.makeHandle(-1)
+                        ? xInt64.makeHandle(frame, -1)
                         : xArray.makeByteArrayHandle(buffer.array(), cbRead, Mutability.Constant));
             } catch (InterruptedException | ExecutionException e) {
                 return xOSFileNode.raisePathException(frameCaller, e, hChannel.f_path);
@@ -213,7 +207,7 @@ public class xRawOSFileChannel
      */
     protected int invokeSubmit(Frame frame, ChannelHandle hChannel, ObjectHandle[] ahArg, int iReturn) {
         if (!hChannel.f_channel.isOpen()) {
-            return frame.assignValue(iReturn, xInt64.makeHandle(-1)); // closed
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, -1)); // closed
         }
 
         ArrayHandle hArray = (ArrayHandle) ahArg[0];
@@ -232,7 +226,7 @@ public class xRawOSFileChannel
 
         frame.f_context.f_container.scheduleIO(task); // don't wait
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(0)); // OK
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, 0)); // OK
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xRawOSFileChannel.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/fs/xRawOSFileChannel.java
@@ -47,7 +47,7 @@ import org.xvm.runtime.template._native.io.xRawChannel;
  */
 public class xRawOSFileChannel
         extends xRawChannel {
-    public xRawOSFileChannel(Container container, ClassStructure structure, boolean fInstance) {
+    public xRawOSFileChannel(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/io/xRTBuffer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/io/xRTBuffer.java
@@ -23,14 +23,8 @@ import org.xvm.runtime.template.collections.xByteArray;
  */
 public class xRTBuffer
         extends ClassTemplate {
-    public static xRTBuffer INSTANCE;
-
     public xRTBuffer(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/io/xRTBuffer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/io/xRTBuffer.java
@@ -23,7 +23,7 @@ import org.xvm.runtime.template.collections.xByteArray;
  */
 public class xRTBuffer
         extends ClassTemplate {
-    public xRTBuffer(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTBuffer(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/io/xTerminalConsole.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/io/xTerminalConsole.java
@@ -46,14 +46,8 @@ import org.xvm.util.ConsoleLog;
  */
 public class xTerminalConsole
         extends xService {
-    public static xTerminalConsole INSTANCE;
-
     public xTerminalConsole(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -139,19 +133,19 @@ public class xTerminalConsole
                     String sLine = CONSOLE_IN.readLine();
                     hLine = sLine == null
                         ? xString.EMPTY_STRING
-                        : xString.makeHandle(sLine);
+                        : xString.makeHandle(frame, sLine);
                 } else {
                     char[] achLine = CONSOLE.readPassword();
                     hLine = achLine == null
                         ? xString.EMPTY_STRING
-                        : xString.makeHandle(achLine);
+                        : xString.makeHandle(frame, achLine);
                 }
             } catch (IOException e) {
                 return frame.raiseException(xException.obscureIoException(frame, e.getMessage()));
             }
         } else {
             try {
-                hLine = xString.makeHandle(READER.readLine(sPrompt, fEcho ? null : '\0'));
+                hLine = xString.makeHandle(frame, READER.readLine(sPrompt, fEcho ? null : '\0'));
             } catch (UserInterruptException e) {
                 System.exit(0);
                 return 0; // not reachable

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/io/xTerminalConsole.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/io/xTerminalConsole.java
@@ -46,7 +46,7 @@ import org.xvm.util.ConsoleLog;
  */
 public class xTerminalConsole
         extends xService {
-    public xTerminalConsole(Container container, ClassStructure structure, boolean fInstance) {
+    public xTerminalConsole(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
@@ -64,14 +64,8 @@ import org.xvm.util.Severity;
  */
 public class xRTCompiler
         extends xService {
-    public static xRTCompiler INSTANCE;
-
     public xRTCompiler(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -164,7 +158,7 @@ public class xRTCompiler
                     return completeWithError(frame, compiler, sMissing, aiReturn);
                 }
                 CallChain chain = computeGetModuleChain(frame, hRepo);
-                switch (chain.invoke(frame, hRepo, xString.makeHandle(sMissing), STACK_2)) {
+                switch (chain.invoke(frame, hRepo, xString.makeHandle(frame, sMissing), STACK_2)) {
                 case Op.R_NEXT:
                     return popModuleStructure(frame, compiler)
                         ? doCompile(frame, compiler, hRepo, sMissing, aiReturn)
@@ -265,7 +259,7 @@ public class xRTCompiler
             haErrors    = xString.ensureEmptyArray();
         } else {
             haTemplates = xArray.makeArrayHandle(clzArray, 0, Utils.OBJECTS_NONE, Mutability.Constant);
-            haErrors    = xString.makeArrayHandle(listErrors.toArray(Utils.NO_NAMES));
+            haErrors    = xString.makeArrayHandle(frame.f_context.f_container, listErrors.toArray(Utils.NO_NAMES));
         }
 
         compiler.reset();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
@@ -64,7 +64,7 @@ import org.xvm.util.Severity;
  */
 public class xRTCompiler
         extends xService {
-    public xRTCompiler(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTCompiler(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/lang/src/xRTCompiler.java
@@ -259,7 +259,7 @@ public class xRTCompiler
             haErrors    = xString.ensureEmptyArray();
         } else {
             haTemplates = xArray.makeArrayHandle(clzArray, 0, Utils.OBJECTS_NONE, Mutability.Constant);
-            haErrors    = xString.makeArrayHandle(frame.f_context.f_container, listErrors.toArray(Utils.NO_NAMES));
+            haErrors    = xString.makeArrayHandle(frame.container(), listErrors.toArray(Utils.NO_NAMES));
         }
 
         compiler.reset();

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerControl.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerControl.java
@@ -38,14 +38,8 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
  */
 public class xContainerControl
         extends xRTServiceControl {
-    public static xContainerControl INSTANCE;
-
     public xContainerControl(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerControl.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerControl.java
@@ -38,7 +38,7 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.FunctionHandle;
  */
 public class xContainerControl
         extends xRTServiceControl {
-    public xContainerControl(Container container, ClassStructure structure, boolean fInstance) {
+    public xContainerControl(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
@@ -50,14 +50,8 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xContainerLinker
         extends xService {
-    public static xContainerLinker INSTANCE;
-
     public xContainerLinker(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -159,7 +153,7 @@ public class xContainerLinker
         TypeHandle[]   ahType    = new TypeHandle[cInjects];
         int            ix        = 0;
         for (InjectionKey key : setInjections) {
-            ahName[ix  ] = xString.makeHandle(key.f_sName);
+            ahName[ix  ] = xString.makeHandle(frame, key.f_sName);
             ahType[ix++] = key.f_type.ensureTypeHandle(container);
         }
         ArrayHandle haNames = xArray.makeStringArrayHandle(ahName);
@@ -214,7 +208,7 @@ public class xContainerLinker
             return frame.raiseException(e);
         }
 
-        switch (xRTFileTemplate.INSTANCE.invokeResolve(frame, file, hRepo,
+        switch (nativeTemplates().get(xRTFileTemplate.class).invokeResolve(frame, file, hRepo,
                     ahShared, ahAdditional, Op.A_STACK)) {
         case Op.R_NEXT:
             return completeResolveAndLink(frame, container, popModule(frame),
@@ -278,7 +272,7 @@ public class xContainerLinker
             while (++index < aKeys.length) {
                 InjectionKey key   = aKeys[index];
                 TypeHandle   hType = key.f_type.ensureTypeHandle(container);
-                StringHandle hName = xString.makeHandle(key.f_sName);
+                StringHandle hName = xString.makeHandle(frameCaller, key.f_sName);
                 CallChain    chain = hProvider.getComposition().getMethodCallChain(GET_RESOURCE);
 
                 ObjectHandle[] ahArg = new ObjectHandle[chain.getMaxVars()];
@@ -304,7 +298,8 @@ public class xContainerLinker
             }
 
             return frameCaller.assignValue(iReturn,
-                xContainerControl.INSTANCE.makeHandle(container));
+                frameCaller.f_context.f_container.nativeTemplates().
+                        get(xContainerControl.class).makeHandle(container));
         }
 
         private final NestedContainer container;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
@@ -50,7 +50,7 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xContainerLinker
         extends xService {
-    public xContainerLinker(Container container, ClassStructure structure, boolean fInstance) {
+    public xContainerLinker(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xContainerLinker.java
@@ -208,7 +208,7 @@ public class xContainerLinker
             return frame.raiseException(e);
         }
 
-        switch (nativeTemplates().get(xRTFileTemplate.class).invokeResolve(frame, file, hRepo,
+        switch (f_container.nativeTemplate(xRTFileTemplate.class).invokeResolve(frame, file, hRepo,
                     ahShared, ahAdditional, Op.A_STACK)) {
         case Op.R_NEXT:
             return completeResolveAndLink(frame, container, popModule(frame),
@@ -298,8 +298,7 @@ public class xContainerLinker
             }
 
             return frameCaller.assignValue(iReturn,
-                frameCaller.f_context.f_container.nativeTemplates().
-                        get(xContainerControl.class).makeHandle(container));
+                frameCaller.nativeTemplate(xContainerControl.class).makeHandle(container));
         }
 
         private final NestedContainer container;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
@@ -33,7 +33,7 @@ import org.xvm.runtime.template._native.reflect.xRTModuleTemplate;
  */
 public class xCoreRepository
         extends ClassTemplate {
-    public xCoreRepository(Container container, ClassStructure structure, boolean fInstance) {
+    public xCoreRepository(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
@@ -33,14 +33,8 @@ import org.xvm.runtime.template._native.reflect.xRTModuleTemplate;
  */
 public class xCoreRepository
         extends ClassTemplate {
-    public static xCoreRepository INSTANCE;
-
     public xCoreRepository(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -68,7 +62,7 @@ public class xCoreRepository
             ModuleRepository repo     = f_container.getModuleRepository();
             Set<String>      setNames = repo.getModuleNames();
 
-            ArrayHandle hArray = xString.makeArrayHandle(setNames.toArray(Utils.NO_NAMES));
+            ArrayHandle hArray = xString.makeArrayHandle(frame.f_context.f_container, setNames.toArray(Utils.NO_NAMES));
             return xArray.createListSet(frame, hArray, iReturn);
         }
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/mgmt/xCoreRepository.java
@@ -62,7 +62,7 @@ public class xCoreRepository
             ModuleRepository repo     = f_container.getModuleRepository();
             Set<String>      setNames = repo.getModuleNames();
 
-            ArrayHandle hArray = xString.makeArrayHandle(frame.f_context.f_container, setNames.toArray(Utils.NO_NAMES));
+            ArrayHandle hArray = xString.makeArrayHandle(frame.container(), setNames.toArray(Utils.NO_NAMES));
             return xArray.createListSet(frame, hArray, iReturn);
         }
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNameService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNameService.java
@@ -50,7 +50,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xRTNameService
         extends xService {
-    public xRTNameService(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTNameService(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNameService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNameService.java
@@ -86,7 +86,7 @@ public class xRTNameService
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     call1(frame, hTarget, ahArg, iReturn);
         }
 
@@ -101,7 +101,7 @@ public class xRTNameService
                 Frame.Continuation continuation = frameCaller -> {
                     try {
                         return frameCaller.assignValue(iReturn,
-                                xString.makeArrayHandle(frame.f_context.f_container, cfRecords.get()));
+                                xString.makeArrayHandle(frame.container(), cfRecords.get()));
                     } catch (Throwable e) {
                         return frameCaller.raiseException(
                             xException.obscureIoException(frameCaller, exceptionMessage(e)));
@@ -121,7 +121,7 @@ public class xRTNameService
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     callN(frame, hTarget, ahArg, aiReturn);
         }
 
@@ -192,7 +192,7 @@ public class xRTNameService
     // -----  helpers ------------------------------------------------------------------------------
 
     static TypeComposition ensureByteArrayArrayComposition(Container container) {
-        return container.ensureClassComposition(BYTE_ARRAY_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
+        return container.ensureClassComposition(BYTE_ARRAY_ARRAY_TYPE, container.nativeTemplate(xArray.class));
     }
 
     static String[] getAllRecords(String sName)

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNameService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNameService.java
@@ -50,14 +50,8 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xRTNameService
         extends xService {
-    public static xRTNameService INSTANCE;
-
     public xRTNameService(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -92,7 +86,8 @@ public class xRTNameService
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).call1(frame, hTarget, ahArg, iReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    call1(frame, hTarget, ahArg, iReturn);
         }
 
         switch (method.getName()) {
@@ -106,7 +101,7 @@ public class xRTNameService
                 Frame.Continuation continuation = frameCaller -> {
                     try {
                         return frameCaller.assignValue(iReturn,
-                                xString.makeArrayHandle(cfRecords.get()));
+                                xString.makeArrayHandle(frame.f_context.f_container, cfRecords.get()));
                     } catch (Throwable e) {
                         return frameCaller.raiseException(
                             xException.obscureIoException(frameCaller, exceptionMessage(e)));
@@ -126,7 +121,8 @@ public class xRTNameService
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).callN(frame, hTarget, ahArg, aiReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    callN(frame, hTarget, ahArg, aiReturn);
         }
 
         switch (method.getName()) {
@@ -176,7 +172,7 @@ public class xRTNameService
                     String      sNotName = addr.getHostAddress();
                     if (sName != null && !sName.isEmpty() && !sName.equals(sNotName)) {
                         return frameCaller.assignValues(aiReturn,
-                                xBoolean.TRUE, xString.makeHandle(sName));
+                                xBoolean.TRUE, xString.makeHandle(frame, sName));
                     }
                 } catch (Exception ignore) {
                     // REVIEW CP: do we want to report the reason somehow?
@@ -196,7 +192,7 @@ public class xRTNameService
     // -----  helpers ------------------------------------------------------------------------------
 
     static TypeComposition ensureByteArrayArrayComposition(Container container) {
-        return container.ensureClassComposition(BYTE_ARRAY_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(BYTE_ARRAY_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
     }
 
     static String[] getAllRecords(String sName)

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
@@ -85,7 +85,7 @@ public class xRTNetwork
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     call1(frame, hTarget, ahArg, iReturn);
         }
 
@@ -104,7 +104,7 @@ public class xRTNetwork
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     callN(frame, hTarget, ahArg, aiReturn);
         }
 
@@ -195,7 +195,7 @@ public class xRTNetwork
      * @return one of Op.R_NEXT, Op.R_CALL or Op.R_EXCEPTION values
      */
     protected int instantiateNameService(Frame frame, ServiceHandle hNetwork, int iReturn) {
-        ClassTemplate    templateSvc  = nativeTemplates().get(xRTNameService.class);
+        ClassTemplate    templateSvc  = f_container.nativeTemplate(xRTNameService.class);
         ClassComposition clz          = templateSvc.getCanonicalClass();
         MethodStructure  constructor  = templateSvc.getStructure().findConstructor(getCanonicalType());
         ObjectHandle[]   ahParams     = new ObjectHandle[constructor.getMaxVars()];

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
@@ -36,7 +36,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTNetwork
         extends xService {
-    public xRTNetwork(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTNetwork(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetwork.java
@@ -36,14 +36,8 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTNetwork
         extends xService {
-    public static xRTNetwork INSTANCE;
-
     public xRTNetwork(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -91,7 +85,8 @@ public class xRTNetwork
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).call1(frame, hTarget, ahArg, iReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    call1(frame, hTarget, ahArg, iReturn);
         }
 
         switch (method.getName()) {
@@ -109,7 +104,8 @@ public class xRTNetwork
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).callN(frame, hTarget, ahArg, aiReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    callN(frame, hTarget, ahArg, aiReturn);
         }
 
         switch (method.getName()) {
@@ -199,7 +195,7 @@ public class xRTNetwork
      * @return one of Op.R_NEXT, Op.R_CALL or Op.R_EXCEPTION values
      */
     protected int instantiateNameService(Frame frame, ServiceHandle hNetwork, int iReturn) {
-        ClassTemplate    templateSvc  = xRTNameService.INSTANCE;
+        ClassTemplate    templateSvc  = nativeTemplates().get(xRTNameService.class);
         ClassComposition clz          = templateSvc.getCanonicalClass();
         MethodStructure  constructor  = templateSvc.getStructure().findConstructor(getCanonicalType());
         ObjectHandle[]   ahParams     = new ObjectHandle[constructor.getMaxVars()];

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
@@ -28,14 +28,8 @@ import org.xvm.runtime.template.collections.xByteArray;
  */
 public class xRTNetworkInterface
         extends xService {
-    public static xRTNetworkInterface INSTANCE;
-
     public xRTNetworkInterface(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -78,7 +72,8 @@ public class xRTNetworkInterface
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(method).callN(frame, hTarget, ahArg, aiReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    callN(frame, hTarget, ahArg, aiReturn);
         }
 
         switch (method.getName()) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
@@ -72,7 +72,7 @@ public class xRTNetworkInterface
 
         if (frame.f_context != hService.f_context) {
             // for now let's make sure all the calls are processed on the service fibers
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     callN(frame, hTarget, ahArg, aiReturn);
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTNetworkInterface.java
@@ -28,7 +28,7 @@ import org.xvm.runtime.template.collections.xByteArray;
  */
 public class xRTNetworkInterface
         extends xService {
-    public xRTNetworkInterface(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTNetworkInterface(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
@@ -51,16 +51,10 @@ import org.xvm.runtime.template.numbers.xUInt16;
  */
 public class xRTSocket
         extends xService {
-    public static xRTSocket INSTANCE;
-
     public static final int CONNECT_TIMEOUT_MS = 15_000;
 
     public xRTSocket(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -108,7 +102,7 @@ public class xRTSocket
         }
 
         if (frame.f_context != hSocket.f_context) {
-            return xRTFunction.makeAsyncNativeHandle(method).
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
                     call1(frame, hTarget, new ObjectHandle[] {hArg}, iReturn);
         }
 
@@ -129,7 +123,8 @@ public class xRTSocket
         }
 
         if (frame.f_context != hSocket.f_context) {
-            return xRTFunction.makeAsyncNativeHandle(method).call1(frame, hTarget, ahArg, iReturn);
+            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    call1(frame, hTarget, ahArg, iReturn);
         }
 
         switch (method.getName()) {
@@ -175,7 +170,8 @@ public class xRTSocket
                 InetAddress local   = socket.getLocalAddress();
                 byte[]      abLocal = local == null ? new byte[0] : local.getAddress();
                 int         nLocal  = socket.getLocalPort();
-                return INSTANCE.constructSocket(frameCaller, socket, abLocal, nLocal,
+                return frame.f_context.f_container.nativeTemplates().get(xRTSocket.class).
+                        constructSocket(frameCaller, socket, abLocal, nLocal,
                         abRemoteIP, nRemotePort, aiReturn);
             } catch (Throwable e) {
                 Throwable cause = unwrap(e);
@@ -228,9 +224,9 @@ public class xRTSocket
                 pool.typeByteArray(), pool.typeUInt16());
         ObjectHandle[]   ahParams     = new ObjectHandle[constructor.getMaxVars()];
         ahParams[0] = xArray.makeByteArrayHandle(abLocal, Mutability.Constant);
-        ahParams[1] = xUInt16.INSTANCE.makeJavaLong(nLocalPort);
+        ahParams[1] = nativeTemplates().get(xUInt16.class).makeJavaLong(nLocalPort);
         ahParams[2] = xArray.makeByteArrayHandle(abRemote, Mutability.Constant);
-        ahParams[3] = xUInt16.INSTANCE.makeJavaLong(nRemotePort);
+        ahParams[3] = nativeTemplates().get(xUInt16.class).makeJavaLong(nRemotePort);
 
         switch (template.construct(frame, constructor, clz, null, ahParams, Op.A_STACK)) {
         case Op.R_NEXT:
@@ -358,13 +354,13 @@ public class xRTSocket
     private static int invokeAvailableImpl(Frame frame, SocketHandle hSocket, int iReturn) {
         Socket socket = hSocket.socket;
         if (socket == null || socket.isClosed()) {
-            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(0));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 0));
         }
         try {
             int n = socket.getInputStream().available();
-            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(Math.max(n, 0)));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, Math.max(n, 0)));
         } catch (IOException e) {
-            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(0));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 0));
         }
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
@@ -102,7 +102,7 @@ public class xRTSocket
         }
 
         if (frame.f_context != hSocket.f_context) {
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     call1(frame, hTarget, new ObjectHandle[] {hArg}, iReturn);
         }
 
@@ -123,7 +123,7 @@ public class xRTSocket
         }
 
         if (frame.f_context != hSocket.f_context) {
-            return xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+            return xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                     call1(frame, hTarget, ahArg, iReturn);
         }
 
@@ -170,7 +170,7 @@ public class xRTSocket
                 InetAddress local   = socket.getLocalAddress();
                 byte[]      abLocal = local == null ? new byte[0] : local.getAddress();
                 int         nLocal  = socket.getLocalPort();
-                return frame.f_context.f_container.nativeTemplates().get(xRTSocket.class).
+                return frame.nativeTemplate(xRTSocket.class).
                         constructSocket(frameCaller, socket, abLocal, nLocal,
                         abRemoteIP, nRemotePort, aiReturn);
             } catch (Throwable e) {
@@ -224,9 +224,9 @@ public class xRTSocket
                 pool.typeByteArray(), pool.typeUInt16());
         ObjectHandle[]   ahParams     = new ObjectHandle[constructor.getMaxVars()];
         ahParams[0] = xArray.makeByteArrayHandle(abLocal, Mutability.Constant);
-        ahParams[1] = nativeTemplates().get(xUInt16.class).makeJavaLong(nLocalPort);
+        ahParams[1] = f_container.nativeTemplate(xUInt16.class).makeJavaLong(nLocalPort);
         ahParams[2] = xArray.makeByteArrayHandle(abRemote, Mutability.Constant);
-        ahParams[3] = nativeTemplates().get(xUInt16.class).makeJavaLong(nRemotePort);
+        ahParams[3] = f_container.nativeTemplate(xUInt16.class).makeJavaLong(nRemotePort);
 
         switch (template.construct(frame, constructor, clz, null, ahParams, Op.A_STACK)) {
         case Op.R_NEXT:

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/net/xRTSocket.java
@@ -53,7 +53,7 @@ public class xRTSocket
         extends xService {
     public static final int CONNECT_TIMEOUT_MS = 15_000;
 
-    public xRTSocket(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTSocket(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/numbers/xRTRandom.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/numbers/xRTRandom.java
@@ -148,46 +148,46 @@ public class xRTRandom
             return frame.assignValue(iReturn, xNibble.makeHandle(frame, rnd(hTarget).nextInt()));
 
         case "int8":
-            return frame.assignValue(iReturn, nativeTemplates().get(xInt8.class).makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xInt8.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "int16":
-            return frame.assignValue(iReturn, nativeTemplates().get(xInt16.class).makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xInt16.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "int32":
-            return frame.assignValue(iReturn, nativeTemplates().get(xInt32.class).makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xInt32.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "int64":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xInt64.class).makeJavaLong(rnd(hTarget).nextLong()));
+                    f_container.nativeTemplate(xInt64.class).makeJavaLong(rnd(hTarget).nextLong()));
 
         case "uint8":
-            return frame.assignValue(iReturn, nativeTemplates().get(xUInt8.class).makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xUInt8.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "uint16":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xUInt16.class).makeJavaLong(rnd(hTarget).nextInt()));
+                    f_container.nativeTemplate(xUInt16.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "uint32":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xUInt32.class).makeJavaLong(rnd(hTarget).nextInt()));
+                    f_container.nativeTemplate(xUInt32.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "uint64":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xUInt64.class).makeJavaLong(rnd(hTarget).nextLong()));
+                    f_container.nativeTemplate(xUInt64.class).makeJavaLong(rnd(hTarget).nextLong()));
 
         case "dec64":
             // Float64 has more precision than Dec64, so this should work fine, although there
             // won't be as solid of a guarantee on a perfect distribution of random values
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xDec64.class).makeHandle(rnd(hTarget).nextDouble()));
+                    f_container.nativeTemplate(xDec64.class).makeHandle(rnd(hTarget).nextDouble()));
 
         case "float32":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xFloat32.class).makeHandle(rnd(hTarget).nextFloat()));
+                    f_container.nativeTemplate(xFloat32.class).makeHandle(rnd(hTarget).nextFloat()));
 
         case "float64":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xFloat64.class).makeHandle(rnd(hTarget).nextDouble()));
+                    f_container.nativeTemplate(xFloat64.class).makeHandle(rnd(hTarget).nextDouble()));
         }
 
         return super.invokeNativeN(frame, method, hTarget, ahArg, iReturn);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/numbers/xRTRandom.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/numbers/xRTRandom.java
@@ -48,14 +48,8 @@ import org.xvm.runtime.template.numbers.xUInt64;
  */
 public class xRTRandom
         extends xService {
-    public static xRTRandom INSTANCE;
-
     public xRTRandom(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -151,42 +145,49 @@ public class xRTRandom
             return frame.assignValue(iReturn, xBit.makeHandle(rnd(hTarget).nextBoolean()));
 
         case "nibble":
-            return frame.assignValue(iReturn, xNibble.makeHandle(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, xNibble.makeHandle(frame, rnd(hTarget).nextInt()));
 
         case "int8":
-            return frame.assignValue(iReturn, xInt8.INSTANCE.makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, nativeTemplates().get(xInt8.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "int16":
-            return frame.assignValue(iReturn, xInt16.INSTANCE.makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, nativeTemplates().get(xInt16.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "int32":
-            return frame.assignValue(iReturn, xInt32.INSTANCE.makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, nativeTemplates().get(xInt32.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "int64":
-            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(rnd(hTarget).nextLong()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xInt64.class).makeJavaLong(rnd(hTarget).nextLong()));
 
         case "uint8":
-            return frame.assignValue(iReturn, xUInt8.INSTANCE.makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn, nativeTemplates().get(xUInt8.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "uint16":
-            return frame.assignValue(iReturn, xUInt16.INSTANCE.makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xUInt16.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "uint32":
-            return frame.assignValue(iReturn, xUInt32.INSTANCE.makeJavaLong(rnd(hTarget).nextInt()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xUInt32.class).makeJavaLong(rnd(hTarget).nextInt()));
 
         case "uint64":
-            return frame.assignValue(iReturn, xUInt64.INSTANCE.makeJavaLong(rnd(hTarget).nextLong()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xUInt64.class).makeJavaLong(rnd(hTarget).nextLong()));
 
         case "dec64":
             // Float64 has more precision than Dec64, so this should work fine, although there
             // won't be as solid of a guarantee on a perfect distribution of random values
-            return frame.assignValue(iReturn, xDec64.INSTANCE.makeHandle(rnd(hTarget).nextDouble()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xDec64.class).makeHandle(rnd(hTarget).nextDouble()));
 
         case "float32":
-            return frame.assignValue(iReturn, xFloat32.INSTANCE.makeHandle(rnd(hTarget).nextFloat()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xFloat32.class).makeHandle(rnd(hTarget).nextFloat()));
 
         case "float64":
-            return frame.assignValue(iReturn, xFloat64.INSTANCE.makeHandle(rnd(hTarget).nextDouble()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xFloat64.class).makeHandle(rnd(hTarget).nextDouble()));
         }
 
         return super.invokeNativeN(frame, method, hTarget, ahArg, iReturn);
@@ -242,7 +243,7 @@ public class xRTRandom
                     "Illegal exclusive maximum (" + lMax +"); maximum must be > 0"));
         }
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(computeRandom(rnd, lMax)));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, computeRandom(rnd, lMax)));
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/numbers/xRTRandom.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/numbers/xRTRandom.java
@@ -48,7 +48,7 @@ import org.xvm.runtime.template.numbers.xUInt64;
  */
 public class xRTRandom
         extends xService {
-    public xRTRandom(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTRandom(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
@@ -398,13 +398,13 @@ public class xRTClassTemplate
         List<ComponentTemplateHandle> listProps = new ArrayList<>();
         for (Component child : clz.children()) {
             if (child instanceof PropertyStructure prop) {
-                listProps.add(xRTPropertyTemplate.makePropertyHandle(frame.f_context.f_container, prop));
+                listProps.add(xRTPropertyTemplate.makePropertyHandle(frame.container(), prop));
             }
         }
 
         ComponentTemplateHandle[] ahProp = listProps.toArray(NO_TEMPLATES);
         ArrayHandle hArray = xArray.createImmutableArray(
-                xRTPropertyTemplate.ensureArrayComposition(frame.f_context.f_container), ahProp);
+                xRTPropertyTemplate.ensureArrayComposition(frame.container()), ahProp);
         return frame.assignValue(iReturn, hArray);
     }
 
@@ -513,7 +513,7 @@ public class xRTClassTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, ClassStructure struct) {
         // note: no need to initialize the struct because there are no natural fields
-        xRTClassTemplate template = container.nativeTemplates().get(xRTClassTemplate.class);
+        xRTClassTemplate template = container.nativeTemplate(xRTClassTemplate.class);
         TypeComposition   clz      = template.ensureClass(container, template.getCanonicalType(),
                 CLASS_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clz, struct);
@@ -523,7 +523,7 @@ public class xRTClassTemplate
      * @return the ClassComposition for an Array of Contributions
      */
     public static TypeComposition ensureContribArrayComposition(Container container) {
-        return container.ensureClassComposition(CONTRIBUTION_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
+        return container.ensureClassComposition(CONTRIBUTION_ARRAY_TYPE, container.nativeTemplate(xArray.class));
     }
 
     /**
@@ -531,28 +531,28 @@ public class xRTClassTemplate
      */
     public static TypeComposition ensureClassTemplateArrayComposition(Container container) {
         return container.ensureClassComposition(CLASS_TEMPLATE_ARRAY_TYPE,
-                container.nativeTemplates().get(xArray.class));
+                container.nativeTemplate(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of MultiMethodTemplates
      */
     public static TypeComposition ensureMultiMethodTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(MULTI_METHOD_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
+        return container.ensureClassComposition(MULTI_METHOD_ARRAY_TYPE, container.nativeTemplate(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of MethodTemplates
      */
     public static TypeComposition ensureMethodTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(METHOD_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
+        return container.ensureClassComposition(METHOD_ARRAY_TYPE, container.nativeTemplate(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of AnnotationTemplates
      */
     public static TypeComposition ensureAnnotationTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(ANNOTATION_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
+        return container.ensureClassComposition(ANNOTATION_ARRAY_TYPE, container.nativeTemplate(xArray.class));
     }
 
     /**
@@ -563,7 +563,7 @@ public class xRTClassTemplate
         if (haEmpty == null) {
             haEmpty = xArray.createImmutableArray(
                         container.ensureClassComposition(EMPTY_PARAMETER_ARRAY.getType(),
-                                nativeTemplates().get(xArray.class)),
+                                f_container.nativeTemplate(xArray.class)),
                         Utils.OBJECTS_NONE);
             container.f_heap.saveConstHandle(EMPTY_PARAMETER_ARRAY, haEmpty);
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
@@ -49,7 +49,7 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xRTClassTemplate
         extends xRTComponentTemplate {
-    public xRTClassTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTClassTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTClassTemplate.java
@@ -49,19 +49,13 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xRTClassTemplate
         extends xRTComponentTemplate {
-    public static xRTClassTemplate INSTANCE;
-
     public xRTClassTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTClassTemplate.class)) {
             ConstantPool pool = f_container.getConstantPool();
 
             ACTION_TEMPLATE = (xEnum) f_container.getTemplate("reflect.ClassTemplate.Composition.Action");
@@ -183,7 +177,7 @@ public class xRTClassTemplate
         if (id instanceof ClassConstant idClz) {
             String sAlias = idClz.getImplicitImportName();
             if (sAlias != null) {
-                return frame.assignValue(iReturn, xString.makeHandle(sAlias));
+                return frame.assignValue(iReturn, xString.makeHandle(frame, sAlias));
             }
         }
         return frame.assignValue(iReturn, xNullable.NULL);
@@ -277,7 +271,7 @@ public class xRTClassTemplate
                     for (int i = 0; i < cParams; i++) {
                         Parameter param = ctor.getParam(i);
 
-                        ahNames[i] = xString.makeHandle(param.getName());
+                        ahNames[i] = xString.makeHandle(container, param.getName());
                         if (ahParam[i] == null) {
                             if (!param.hasDefaultValue()) {
                                 return frameCaller.raiseException(
@@ -332,7 +326,7 @@ public class xRTClassTemplate
                         TypeConstant type  = entry.getValue();
 
                         // use Type<Object> as an indicator of a non-constrained formal type
-                        ahNames[i] = xString.makeHandle(sName);
+                        ahNames[i] = xString.makeHandle(container, sName);
                         ahTypes[i] = (type == null ? pool().typeObject() : type).
                                         ensureTypeHandle(container);
                         i++;
@@ -404,13 +398,13 @@ public class xRTClassTemplate
         List<ComponentTemplateHandle> listProps = new ArrayList<>();
         for (Component child : clz.children()) {
             if (child instanceof PropertyStructure prop) {
-                listProps.add(xRTPropertyTemplate.makePropertyHandle(prop));
+                listProps.add(xRTPropertyTemplate.makePropertyHandle(frame.f_context.f_container, prop));
             }
         }
 
         ComponentTemplateHandle[] ahProp = listProps.toArray(NO_TEMPLATES);
         ArrayHandle hArray = xArray.createImmutableArray(
-                xRTPropertyTemplate.ensureArrayComposition(), ahProp);
+                xRTPropertyTemplate.ensureArrayComposition(frame.f_context.f_container), ahProp);
         return frame.assignValue(iReturn, hArray);
     }
 
@@ -467,7 +461,7 @@ public class xRTClassTemplate
 
         int i = 0;
         for (Map.Entry<StringConstant, TypeConstant> entry : listParams) {
-            ahName[i]   = xString.makeHandle(entry.getKey().getValue());
+            ahName[i]   = xString.makeHandle(container, entry.getKey().getValue());
             ahType[i++] = xRTTypeTemplate.makeHandle(container, entry.getValue());
         }
 
@@ -519,8 +513,9 @@ public class xRTClassTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, ClassStructure struct) {
         // note: no need to initialize the struct because there are no natural fields
-        TypeComposition clz = INSTANCE.ensureClass(container,
-                                INSTANCE.getCanonicalType(), CLASS_TEMPLATE_TYPE);
+        xRTClassTemplate template = container.nativeTemplates().get(xRTClassTemplate.class);
+        TypeComposition   clz      = template.ensureClass(container, template.getCanonicalType(),
+                CLASS_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clz, struct);
     }
 
@@ -528,35 +523,36 @@ public class xRTClassTemplate
      * @return the ClassComposition for an Array of Contributions
      */
     public static TypeComposition ensureContribArrayComposition(Container container) {
-        return container.ensureClassComposition(CONTRIBUTION_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(CONTRIBUTION_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of ClassTemplates
      */
     public static TypeComposition ensureClassTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(CLASS_TEMPLATE_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(CLASS_TEMPLATE_ARRAY_TYPE,
+                container.nativeTemplates().get(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of MultiMethodTemplates
      */
     public static TypeComposition ensureMultiMethodTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(MULTI_METHOD_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(MULTI_METHOD_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of MethodTemplates
      */
     public static TypeComposition ensureMethodTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(METHOD_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(METHOD_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
     }
 
     /**
      * @return the ClassComposition for an Array of AnnotationTemplates
      */
     public static TypeComposition ensureAnnotationTemplateArrayComposition(Container container) {
-        return container.ensureClassComposition(ANNOTATION_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(ANNOTATION_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
     }
 
     /**
@@ -566,7 +562,8 @@ public class xRTClassTemplate
         ArrayHandle haEmpty = (ArrayHandle) container.f_heap.getConstHandle(EMPTY_PARAMETER_ARRAY);
         if (haEmpty == null) {
             haEmpty = xArray.createImmutableArray(
-                        container.ensureClassComposition(EMPTY_PARAMETER_ARRAY.getType(), xArray.INSTANCE),
+                        container.ensureClassComposition(EMPTY_PARAMETER_ARRAY.getType(),
+                                nativeTemplates().get(xArray.class)),
                         Utils.OBJECTS_NONE);
             container.f_heap.saveConstHandle(EMPTY_PARAMETER_ARRAY, haEmpty);
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
@@ -237,8 +237,7 @@ public class xRTComponentTemplate
     public static TypeConstant ensureComponentArrayType(Container container) {
         TypeConstant type = COMPONENT_ARRAY_TYPE;
         if (type == null) {
-            ConstantPool pool = container.nativeTemplates().
-                    get(xRTComponentTemplate.class).pool();
+            ConstantPool pool = container.nativeTemplate(xRTComponentTemplate.class).pool();
             COMPONENT_ARRAY_TYPE = type = pool.ensureArrayType(
                     pool.ensureEcstasyTypeConstant("reflect.ComponentTemplate"));
         }
@@ -272,7 +271,7 @@ public class xRTComponentTemplate
      * @return the handle to the appropriate Ecstasy {@code ComponentTemplate.Format} enum value
      */
     protected static EnumHandle makeFormatHandle(Frame frame, Component.Format format) {
-        xEnum enumForm = frame.f_context.f_container.getTemplate(
+        xEnum enumForm = frame.container().getTemplate(
                 "reflect.ComponentTemplate.Format", xEnum.class);
 
         switch (format) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
@@ -51,7 +51,7 @@ public class xRTComponentTemplate
     public void registerNativeTemplates() {
         if (this == INSTANCE) {
             ClassStructure struct = f_container.getClassStructure("_native.reflect.RTMultiMethodTemplate");
-            registerNativeTemplate(new xRTComponentTemplate(f_container, struct, false));
+            registerAuxiliaryTemplate(new xRTComponentTemplate(f_container, struct, false));
         }
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
@@ -37,19 +37,13 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTComponentTemplate
         extends ClassTemplate {
-    public static xRTComponentTemplate INSTANCE;
-
     public xRTComponentTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTComponentTemplate.class)) {
             ClassStructure struct = f_container.getClassStructure("_native.reflect.RTMultiMethodTemplate");
             registerAuxiliaryTemplate(new xRTComponentTemplate(f_container, struct, false));
         }
@@ -153,7 +147,7 @@ public class xRTComponentTemplate
         String    sDoc      = component.getDocumentation();
         return frame.assignValue(iReturn, sDoc == null
                 ? xNullable.NULL
-                : xString.makeHandle(sDoc));
+                : xString.makeHandle(frame, sDoc));
     }
 
     /**
@@ -186,7 +180,7 @@ public class xRTComponentTemplate
      */
     protected int getPropertyName(Frame frame, ComponentTemplateHandle hComponent, int iReturn) {
         Component component = hComponent.getComponent();
-        return frame.assignValue(iReturn, xString.makeHandle(component.getSimpleName()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, component.getSimpleName()));
     }
 
     /**
@@ -229,7 +223,7 @@ public class xRTComponentTemplate
         // the only possible child type of MultiMethodTemplate is the MethodTemplate
         TypeComposition clzArray = component instanceof MultiMethodStructure
                 ? xRTClassTemplate.ensureMethodTemplateArrayComposition(container)
-                : container.resolveClass(ensureComponentArrayType());
+                : container.resolveClass(ensureComponentArrayType(container));
 
         return frame.assignValue(iReturn, xArray.createImmutableArray(clzArray, ahChildren));
     }
@@ -240,10 +234,11 @@ public class xRTComponentTemplate
     /**
      * @return the TypeConstant for an Array of ComponentTemplate
      */
-    public static TypeConstant ensureComponentArrayType() {
+    public static TypeConstant ensureComponentArrayType(Container container) {
         TypeConstant type = COMPONENT_ARRAY_TYPE;
         if (type == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().
+                    get(xRTComponentTemplate.class).pool();
             COMPONENT_ARRAY_TYPE = type = pool.ensureArrayType(
                     pool.ensureEcstasyTypeConstant("reflect.ComponentTemplate"));
         }
@@ -257,7 +252,7 @@ public class xRTComponentTemplate
         ClassTemplate templateRT = MULTI_METHOD_TEMPLATE;
         if (templateRT == null) {
             MULTI_METHOD_TEMPLATE = templateRT =
-                INSTANCE.f_container.getTemplate("_native.reflect.RTMultiMethodTemplate");
+                container.getTemplate("_native.reflect.RTMultiMethodTemplate");
         }
 
         ConstantPool pool         = container.getConstantPool();
@@ -277,7 +272,8 @@ public class xRTComponentTemplate
      * @return the handle to the appropriate Ecstasy {@code ComponentTemplate.Format} enum value
      */
     protected static EnumHandle makeFormatHandle(Frame frame, Component.Format format) {
-        xEnum enumForm = INSTANCE.f_container.getTemplate("reflect.ComponentTemplate.Format", xEnum.class);
+        xEnum enumForm = frame.f_context.f_container.getTemplate(
+                "reflect.ComponentTemplate.Format", xEnum.class);
 
         switch (format) {
         case INTERFACE:
@@ -352,10 +348,10 @@ public class xRTComponentTemplate
             return new ComponentTemplateHandle(getMultiMethodTemplateComposition(container), component);
 
         case METHOD:
-            return xRTMethodTemplate.makeHandle((MethodStructure) component);
+            return xRTMethodTemplate.makeHandle(container, (MethodStructure) component);
 
         case PROPERTY:
-            return xRTPropertyTemplate.makePropertyHandle((PropertyStructure) component);
+            return xRTPropertyTemplate.makePropertyHandle(container, (PropertyStructure) component);
 
         default:
             throw new UnsupportedOperationException("unsupported format " + component.getFormat());

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTComponentTemplate.java
@@ -37,7 +37,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTComponentTemplate
         extends ClassTemplate {
-    public xRTComponentTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTComponentTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
@@ -92,7 +92,7 @@ public class xRTFileTemplate
                     iReturn);
 
         case "moduleNames":
-            return frame.assignValue(iReturn, xString.makeArrayHandle(frame.f_context.f_container,
+            return frame.assignValue(iReturn, xString.makeArrayHandle(frame.container(),
                     fileStruct.buildFileInfo().modules().keySet().toArray(new String[0])));
 
         case "resolved":
@@ -316,7 +316,7 @@ public class xRTFileTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, FileStructure fileStruct) {
         // note: no need to initialize the struct because there are no natural fields
-        xRTFileTemplate template = container.nativeTemplates().get(xRTFileTemplate.class);
+        xRTFileTemplate template = container.nativeTemplate(xRTFileTemplate.class);
         TypeComposition clzFile  = template.ensureClass(container, template.getCanonicalType(),
                 FILE_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clzFile, fileStruct);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
@@ -52,14 +52,8 @@ import org.xvm.runtime.template._native.mgmt.xCoreRepository;
  */
 public class xRTFileTemplate
         extends xRTComponentTemplate {
-    public static xRTFileTemplate INSTANCE;
-
     public xRTFileTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -93,12 +87,12 @@ public class xRTFileTemplate
 
         case "kind":
             return Utils.assignInitializedEnum(frame,
-                    INSTANCE.f_container.getTemplate("reflect.FileTemplate.Kind", xEnum.class)
-                            .getEnumByName(fileStruct.getFileKind().name()),
+                    f_container.getTemplate("reflect.FileTemplate.Kind", xEnum.class).
+                            getEnumByName(fileStruct.getFileKind().name()),
                     iReturn);
 
         case "moduleNames":
-            return frame.assignValue(iReturn, xString.makeArrayHandle(
+            return frame.assignValue(iReturn, xString.makeArrayHandle(frame.f_context.f_container,
                     fileStruct.buildFileInfo().modules().keySet().toArray(new String[0])));
 
         case "resolved":
@@ -114,10 +108,10 @@ public class xRTFileTemplate
                     BasicFileAttributes attr =
                             Files.readAttributes(fileOS.toPath(), BasicFileAttributes.class);
                     return frame.assignValue(iReturn,
-                            xInt64.makeHandle(attr.lastModifiedTime().toMillis()));
+                            xInt64.makeHandle(frame, attr.lastModifiedTime().toMillis()));
                 } catch (IOException ignore) {}
             }
-            return frame.assignValue(iReturn, xInt64.makeHandle(0L));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 0L));
         }
         }
 
@@ -296,7 +290,8 @@ public class xRTFileTemplate
         }
         assert index == cModules;
 
-        TypeComposition clzArray = container.resolveClass(ensureComponentArrayType());
+        TypeComposition clzArray = container.resolveClass(
+                ensureComponentArrayType(container));
         return frame.assignValue(iReturn,
                 xArray.createImmutableArray(clzArray, ahModule));
 
@@ -305,7 +300,7 @@ public class xRTFileTemplate
     @Override
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
         FileStructure module = componentTemplateHandle(hTarget).getFileStructure();
-        return frame.assignValue(iReturn, xString.makeHandle(module.getModuleId().getName()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, module.getModuleId().getName()));
     }
 
 
@@ -321,8 +316,9 @@ public class xRTFileTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, FileStructure fileStruct) {
         // note: no need to initialize the struct because there are no natural fields
-        TypeComposition clzFile = INSTANCE.ensureClass(container,
-                INSTANCE.getCanonicalType(), FILE_TEMPLATE_TYPE);
+        xRTFileTemplate template = container.nativeTemplates().get(xRTFileTemplate.class);
+        TypeComposition clzFile  = template.ensureClass(container, template.getCanonicalType(),
+                FILE_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clzFile, fileStruct);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFileTemplate.java
@@ -52,7 +52,7 @@ import org.xvm.runtime.template._native.mgmt.xCoreRepository;
  */
 public class xRTFileTemplate
         extends xRTComponentTemplate {
-    public xRTFileTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTFileTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
@@ -46,14 +46,8 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xRTFunction
         extends xRTSignature {
-    public static xRTFunction INSTANCE;
-
     public xRTFunction(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -298,7 +292,7 @@ public class xRTFunction
 
             // TODO: what if any of the assigns below return a deferred handle?
             frame.assignValue(aiReturn[0], xBoolean.TRUE);
-            frame.assignValue(aiReturn[1], xRTMethodTemplate.makeHandle(method));
+            frame.assignValue(aiReturn[1], xRTMethodTemplate.makeHandle(frame.f_context.f_container, method));
             frame.assignValue(aiReturn[2], makeHandle(frame, method));
 
             Frame.Continuation stepNext = frameCaller ->
@@ -311,11 +305,13 @@ public class xRTFunction
 
     private int constructListMap(Frame frame,
                                  ObjectHandle[] ahParam, ObjectHandle[] ahValue, int iReturn) {
-        ObjectHandle haParams = xArray.createImmutableArray(xRTSignature.ensureParamArray(), ahParam);
+        ObjectHandle haParams = xArray.createImmutableArray(
+                xRTSignature.ensureParamArray(frame.f_context.f_container), ahParam);
         ObjectHandle haValues = xArray.makeObjectArrayHandle(ahValue, Mutability.Constant);
 
         return Utils.constructListMap(frame,
-                frame.f_context.f_container.resolveClass(ensureListMapType()),
+                frame.f_context.f_container.resolveClass(
+                        ensureListMapType(frame.f_context.f_container)),
                 haParams, haValues, iReturn);
     }
 
@@ -383,8 +379,9 @@ public class xRTFunction
          * Instantiate an immutable FunctionHandle for a method.
          */
         protected FunctionHandle(Container container, CallChain chain, int nDepth) {
-            super(INSTANCE.ensureClass(container, chain.getMethod(nDepth).getIdentityConstant().
-                    getSignature().asFunctionType()), chain, nDepth);
+            super(container.nativeTemplates().get(xRTFunction.class).ensureClass(container,
+                    chain.getMethod(nDepth).getIdentityConstant().getSignature().asFunctionType()),
+                    chain, nDepth);
 
             m_fMutable = false;
         }
@@ -393,7 +390,8 @@ public class xRTFunction
          * Instantiate a mutable FunctionHandle for a method or function.
          */
         protected FunctionHandle(Container container, TypeConstant type, MethodStructure function) {
-            this(INSTANCE.ensureClass(container, type), type, function);
+            this(container.nativeTemplates().get(xRTFunction.class).ensureClass(container, type),
+                    type, function);
         }
 
         /**
@@ -718,8 +716,9 @@ public class xRTFunction
      */
     public static class NativeFunctionHandle
             extends FunctionHandle {
-        public NativeFunctionHandle(xService.NativeOperation op) {
-            super(INSTANCE.f_container, INSTANCE.getCanonicalType(), null);
+        public NativeFunctionHandle(Container container, xService.NativeOperation op) {
+            super(container, container.nativeTemplates().get(xRTFunction.class).getCanonicalType(),
+                    null);
 
             f_op       = op;
             m_fMutable = false;
@@ -867,7 +866,9 @@ public class xRTFunction
         protected FullyBoundHandle m_next;
 
         protected FullyBoundHandle(Container container, FunctionHandle hDelegate, ObjectHandle[] ahArg) {
-            super(container, hDelegate == null ? INSTANCE.getCanonicalType() : hDelegate.getType(), hDelegate);
+            super(container, hDelegate == null
+                    ? container.nativeTemplates().get(xRTFunction.class).getCanonicalType()
+                    : hDelegate.getType(), hDelegate);
 
             f_ahArg = ahArg;
         }
@@ -949,23 +950,49 @@ public class xRTFunction
             return frameThis;
         }
 
-        public static FullyBoundHandle NO_OP =
-                new FullyBoundHandle(INSTANCE.f_container, null, Utils.OBJECTS_NONE) {
-            @Override
-            public int callChain(Frame frame, ObjectHandle hTarget, Frame.Continuation continuation) {
-                return continuation.proceed(frame);
-            }
+        /**
+         * The no-op finalizer anchor. A single process-wide sentinel, compared by identity and
+         * never invoked, so the container it is built against is inert - but one is needed to
+         * construct it, so it is created on first use rather than at class initialization.
+         */
+        private static volatile FullyBoundHandle NO_OP;
 
-            @Override
-            public FullyBoundHandle chain(FullyBoundHandle handle) {
-                return handle;
+        /**
+         * @return the no-op finalizer anchor, creating it against the specified container if this
+         *         is the first call
+         */
+        public static FullyBoundHandle ensureNoOp(Container container) {
+            FullyBoundHandle handle = NO_OP;
+            if (handle == null) {
+                synchronized (FullyBoundHandle.class) {
+                    handle = NO_OP;
+                    if (handle == null) {
+                        NO_OP = handle = createNoOp(container);
+                    }
+                }
             }
+            return handle;
+        }
 
-            @Override
-            public String toString() {
-                return "NO_OP";
-            }
-        };
+        private static FullyBoundHandle createNoOp(Container container) {
+            return new FullyBoundHandle(container, null, Utils.OBJECTS_NONE) {
+                @Override
+                public int callChain(Frame frame, ObjectHandle hTarget,
+                                     Frame.Continuation continuation) {
+                    return continuation.proceed(frame);
+                }
+
+                @Override
+                public FullyBoundHandle chain(FullyBoundHandle handle) {
+                    return handle;
+                }
+
+                @Override
+                public String toString() {
+                    return "NO_OP";
+                }
+            };
+        }
     }
 
     /**
@@ -1257,10 +1284,10 @@ public class xRTFunction
      *
      * @return the corresponding function handle
      */
-    public static AsyncHandle makeAsyncNativeHandle(MethodStructure method) {
+    public static AsyncHandle makeAsyncNativeHandle(Container container, MethodStructure method) {
         assert method.isNative();
 
-        return new AsyncHandle(INSTANCE.f_container, method);
+        return new AsyncHandle(container, method);
     }
 
     /**
@@ -1275,8 +1302,7 @@ public class xRTFunction
      *
      * The returned handle will not carry any annotations
      */
-    public static FunctionHandle makeInternalHandle(Frame frame, MethodStructure function) {
-        Container container = frame == null ? INSTANCE.f_container : frame.f_context.f_container;
+    public static FunctionHandle makeInternalHandle(Container container, MethodStructure function) {
         return new FunctionHandle(container, function);
     }
 
@@ -1286,7 +1312,7 @@ public class xRTFunction
      * The returned handle could be deferred.
      */
     public static ObjectHandle makeHandle(Frame frame, MethodStructure function) {
-        Container container = frame == null ? INSTANCE.f_container : frame.f_context.f_container;
+        Container container = frame.f_context.f_container;
 
         Annotation[] aAnno = function.getAnnotations();
 
@@ -1294,7 +1320,8 @@ public class xRTFunction
             TypeConstant type = function.getIdentityConstant().getSignature().asFunctionType();
             type = container.getConstantPool().ensureAnnotatedTypeConstant(type, aAnno);
 
-            TypeComposition clzFunction = INSTANCE.ensureClass(container, function);
+            TypeComposition clzFunction = container.nativeTemplates().
+                    get(xRTFunction.class).ensureClass(container, function);
             FunctionHandle  hStruct     = new FunctionHandle(clzFunction.
                                             ensureAccess(Constants.Access.STRUCT), type, function);
 
@@ -1318,14 +1345,16 @@ public class xRTFunction
         TypeComposition clzConstruct;
 
         if (constructor == null) {
-            clzConstruct = INSTANCE.ensureClass(container, typeConstructor);
+            clzConstruct = container.nativeTemplates().
+                    get(xRTFunction.class).ensureClass(container, typeConstructor);
         } else {
             Annotation[] aAnno = constructor.getAnnotations();
             if (aAnno.length > 0) {
                 typeConstructor = container.getConstantPool().
                         ensureAnnotatedTypeConstant(typeConstructor, aAnno);
 
-                TypeComposition clzConstructor = INSTANCE.ensureClass(container, constructor).
+                TypeComposition clzConstructor = container.nativeTemplates().
+                        get(xRTFunction.class).ensureClass(container, constructor).
                         ensureAccess(Constants.Access.STRUCT);
 
                 ConstructorHandle hConstructor = new ConstructorHandle(
@@ -1335,7 +1364,8 @@ public class xRTFunction
                                     frame, null, true, hConstructor, Utils.OBJECTS_NONE, Op.A_STACK);
                 return frame.popResultImmutable(iResult);
             } else {
-                clzConstruct = INSTANCE.ensureClass(container, constructor);
+                clzConstruct = container.nativeTemplates().
+                        get(xRTFunction.class).ensureClass(container, constructor);
             }
         }
 
@@ -1369,7 +1399,9 @@ public class xRTFunction
         @Override
         protected int callTImpl(Frame frame, ObjectHandle hTarget, ObjectHandle[] ahVar, int iReturn) {
             TypeConstant    typeTuple = frame.poolContext().ensureTupleType(f_clzTarget.getType());
-            TypeComposition clzTuple  = xTuple.INSTANCE.ensureClass(frame.f_context.f_container, typeTuple);
+            Container       container = frame.f_context.f_container;
+            TypeComposition clzTuple  = container.nativeTemplates().
+                    get(xTuple.class).ensureClass(container, typeTuple);
 
             switch (callImpl(frame, ahVar, Op.A_STACK)) {
             case Op.R_NEXT:
@@ -1463,7 +1495,8 @@ public class xRTFunction
      * @return the TypeComposition for an Array of Function
      */
     public static TypeComposition ensureArrayComposition(Container container) {
-        return container.ensureClassComposition(FUNCTION_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(FUNCTION_ARRAY_TYPE,
+                container.nativeTemplates().get(xArray.class));
     }
 
     /**
@@ -1481,10 +1514,10 @@ public class xRTFunction
     /**
      * @return the TypeConstant for a ListMap<Parameter, Object>
      */
-    public static TypeConstant ensureListMapType() {
+    public static TypeConstant ensureListMapType(Container container) {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().get(xRTFunction.class).pool();
             LISTMAP_TYPE = type = pool.ensureParameterizedTypeConstant(
                     pool.ensureEcstasyTypeConstant("maps.ListMap"),
                     pool.typeParameter(), pool.typeObject());

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
@@ -292,7 +292,7 @@ public class xRTFunction
 
             // TODO: what if any of the assigns below return a deferred handle?
             frame.assignValue(aiReturn[0], xBoolean.TRUE);
-            frame.assignValue(aiReturn[1], xRTMethodTemplate.makeHandle(frame.f_context.f_container, method));
+            frame.assignValue(aiReturn[1], xRTMethodTemplate.makeHandle(frame.container(), method));
             frame.assignValue(aiReturn[2], makeHandle(frame, method));
 
             Frame.Continuation stepNext = frameCaller ->
@@ -306,12 +306,12 @@ public class xRTFunction
     private int constructListMap(Frame frame,
                                  ObjectHandle[] ahParam, ObjectHandle[] ahValue, int iReturn) {
         ObjectHandle haParams = xArray.createImmutableArray(
-                xRTSignature.ensureParamArray(frame.f_context.f_container), ahParam);
+                xRTSignature.ensureParamArray(frame.container()), ahParam);
         ObjectHandle haValues = xArray.makeObjectArrayHandle(ahValue, Mutability.Constant);
 
         return Utils.constructListMap(frame,
-                frame.f_context.f_container.resolveClass(
-                        ensureListMapType(frame.f_context.f_container)),
+                frame.container().resolveClass(
+                        ensureListMapType(frame.container())),
                 haParams, haValues, iReturn);
     }
 
@@ -379,7 +379,7 @@ public class xRTFunction
          * Instantiate an immutable FunctionHandle for a method.
          */
         protected FunctionHandle(Container container, CallChain chain, int nDepth) {
-            super(container.nativeTemplates().get(xRTFunction.class).ensureClass(container,
+            super(container.nativeTemplate(xRTFunction.class).ensureClass(container,
                     chain.getMethod(nDepth).getIdentityConstant().getSignature().asFunctionType()),
                     chain, nDepth);
 
@@ -390,7 +390,7 @@ public class xRTFunction
          * Instantiate a mutable FunctionHandle for a method or function.
          */
         protected FunctionHandle(Container container, TypeConstant type, MethodStructure function) {
-            this(container.nativeTemplates().get(xRTFunction.class).ensureClass(container, type),
+            this(container.nativeTemplate(xRTFunction.class).ensureClass(container, type),
                     type, function);
         }
 
@@ -717,7 +717,7 @@ public class xRTFunction
     public static class NativeFunctionHandle
             extends FunctionHandle {
         public NativeFunctionHandle(Container container, xService.NativeOperation op) {
-            super(container, container.nativeTemplates().get(xRTFunction.class).getCanonicalType(),
+            super(container, container.nativeTemplate(xRTFunction.class).getCanonicalType(),
                     null);
 
             f_op       = op;
@@ -867,7 +867,7 @@ public class xRTFunction
 
         protected FullyBoundHandle(Container container, FunctionHandle hDelegate, ObjectHandle[] ahArg) {
             super(container, hDelegate == null
-                    ? container.nativeTemplates().get(xRTFunction.class).getCanonicalType()
+                    ? container.nativeTemplate(xRTFunction.class).getCanonicalType()
                     : hDelegate.getType(), hDelegate);
 
             f_ahArg = ahArg;
@@ -1312,7 +1312,7 @@ public class xRTFunction
      * The returned handle could be deferred.
      */
     public static ObjectHandle makeHandle(Frame frame, MethodStructure function) {
-        Container container = frame.f_context.f_container;
+        Container container = frame.container();
 
         Annotation[] aAnno = function.getAnnotations();
 
@@ -1320,8 +1320,7 @@ public class xRTFunction
             TypeConstant type = function.getIdentityConstant().getSignature().asFunctionType();
             type = container.getConstantPool().ensureAnnotatedTypeConstant(type, aAnno);
 
-            TypeComposition clzFunction = container.nativeTemplates().
-                    get(xRTFunction.class).ensureClass(container, function);
+            TypeComposition clzFunction = container.nativeTemplate(xRTFunction.class).ensureClass(container, function);
             FunctionHandle  hStruct     = new FunctionHandle(clzFunction.
                                             ensureAccess(Constants.Access.STRUCT), type, function);
 
@@ -1345,16 +1344,14 @@ public class xRTFunction
         TypeComposition clzConstruct;
 
         if (constructor == null) {
-            clzConstruct = container.nativeTemplates().
-                    get(xRTFunction.class).ensureClass(container, typeConstructor);
+            clzConstruct = container.nativeTemplate(xRTFunction.class).ensureClass(container, typeConstructor);
         } else {
             Annotation[] aAnno = constructor.getAnnotations();
             if (aAnno.length > 0) {
                 typeConstructor = container.getConstantPool().
                         ensureAnnotatedTypeConstant(typeConstructor, aAnno);
 
-                TypeComposition clzConstructor = container.nativeTemplates().
-                        get(xRTFunction.class).ensureClass(container, constructor).
+                TypeComposition clzConstructor = container.nativeTemplate(xRTFunction.class).ensureClass(container, constructor).
                         ensureAccess(Constants.Access.STRUCT);
 
                 ConstructorHandle hConstructor = new ConstructorHandle(
@@ -1364,8 +1361,7 @@ public class xRTFunction
                                     frame, null, true, hConstructor, Utils.OBJECTS_NONE, Op.A_STACK);
                 return frame.popResultImmutable(iResult);
             } else {
-                clzConstruct = container.nativeTemplates().
-                        get(xRTFunction.class).ensureClass(container, constructor);
+                clzConstruct = container.nativeTemplate(xRTFunction.class).ensureClass(container, constructor);
             }
         }
 
@@ -1400,8 +1396,7 @@ public class xRTFunction
         protected int callTImpl(Frame frame, ObjectHandle hTarget, ObjectHandle[] ahVar, int iReturn) {
             TypeConstant    typeTuple = frame.poolContext().ensureTupleType(f_clzTarget.getType());
             Container       container = frame.f_context.f_container;
-            TypeComposition clzTuple  = container.nativeTemplates().
-                    get(xTuple.class).ensureClass(container, typeTuple);
+            TypeComposition clzTuple  = container.nativeTemplate(xTuple.class).ensureClass(container, typeTuple);
 
             switch (callImpl(frame, ahVar, Op.A_STACK)) {
             case Op.R_NEXT:
@@ -1496,7 +1491,7 @@ public class xRTFunction
      */
     public static TypeComposition ensureArrayComposition(Container container) {
         return container.ensureClassComposition(FUNCTION_ARRAY_TYPE,
-                container.nativeTemplates().get(xArray.class));
+                container.nativeTemplate(xArray.class));
     }
 
     /**
@@ -1517,7 +1512,7 @@ public class xRTFunction
     public static TypeConstant ensureListMapType(Container container) {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null) {
-            ConstantPool pool = container.nativeTemplates().get(xRTFunction.class).pool();
+            ConstantPool pool = container.nativeTemplate(xRTFunction.class).pool();
             LISTMAP_TYPE = type = pool.ensureParameterizedTypeConstant(
                     pool.ensureEcstasyTypeConstant("maps.ListMap"),
                     pool.typeParameter(), pool.typeObject());

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTFunction.java
@@ -46,7 +46,7 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xRTFunction
         extends xRTSignature {
-    public xRTFunction(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTFunction(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
@@ -38,14 +38,8 @@ import org.xvm.runtime.template.collections.xTuple.TupleHandle;
  */
 public class xRTMethod
         extends xRTSignature {
-    public static xRTMethod INSTANCE;
-
     public xRTMethod(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -261,7 +255,8 @@ public class xRTMethod
         if (aAnno != null && aAnno.length > 0) {
             type = pool.ensureAnnotatedTypeConstant(type, aAnno);
 
-            TypeComposition clzMethod = INSTANCE.ensureClass(container, type);
+            TypeComposition clzMethod = container.nativeTemplates().
+                get(xRTMethod.class).ensureClass(container, type);
             MethodHandle    hStruct   = new MethodHandle(clzMethod.ensureAccess(Access.STRUCT),
                                             type, method, typeTarget);
 
@@ -270,7 +265,8 @@ public class xRTMethod
             return frame.popResultImmutable(iResult);
         }
 
-        return new MethodHandle(INSTANCE.ensureClass(container, type), type, method, typeTarget);
+        return new MethodHandle(container.nativeTemplates().
+                get(xRTMethod.class).ensureClass(container, type), type, method, typeTarget);
     }
 
     /**
@@ -344,10 +340,10 @@ public class xRTMethod
     /**
      * @return the ArrayConstant for an empty Array of Method
      */
-    public static ArrayConstant ensureEmptyArrayConstant() {
+    public static ArrayConstant ensureEmptyArrayConstant(Container container) {
         ArrayConstant constant = EMPTY_ARRAY;
         if (constant == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().get(xRTMethod.class).pool();
             EMPTY_ARRAY = constant = new ArrayConstant(pool, Constant.Format.Array,
                                             pool.ensureArrayType(pool.typeMethod()));
         }
@@ -358,7 +354,7 @@ public class xRTMethod
      * @return the handle for an empty Array of Method
      */
     public static ObjectHandle ensureEmptyArray(Container container) {
-        ArrayConstant constArray = ensureEmptyArrayConstant();
+        ArrayConstant constArray = ensureEmptyArrayConstant(container);
         ObjectHandle hArray = container.f_heap.getConstHandle(constArray);
         if (hArray == null) {
             TypeComposition clzArray = container.resolveClass(constArray.getType());

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
@@ -255,8 +255,7 @@ public class xRTMethod
         if (aAnno != null && aAnno.length > 0) {
             type = pool.ensureAnnotatedTypeConstant(type, aAnno);
 
-            TypeComposition clzMethod = container.nativeTemplates().
-                get(xRTMethod.class).ensureClass(container, type);
+            TypeComposition clzMethod = container.nativeTemplate(xRTMethod.class).ensureClass(container, type);
             MethodHandle    hStruct   = new MethodHandle(clzMethod.ensureAccess(Access.STRUCT),
                                             type, method, typeTarget);
 
@@ -265,8 +264,7 @@ public class xRTMethod
             return frame.popResultImmutable(iResult);
         }
 
-        return new MethodHandle(container.nativeTemplates().
-                get(xRTMethod.class).ensureClass(container, type), type, method, typeTarget);
+        return new MethodHandle(container.nativeTemplate(xRTMethod.class).ensureClass(container, type), type, method, typeTarget);
     }
 
     /**
@@ -343,7 +341,7 @@ public class xRTMethod
     public static ArrayConstant ensureEmptyArrayConstant(Container container) {
         ArrayConstant constant = EMPTY_ARRAY;
         if (constant == null) {
-            ConstantPool pool = container.nativeTemplates().get(xRTMethod.class).pool();
+            ConstantPool pool = container.nativeTemplate(xRTMethod.class).pool();
             EMPTY_ARRAY = constant = new ArrayConstant(pool, Constant.Format.Array,
                                             pool.ensureArrayType(pool.typeMethod()));
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethod.java
@@ -38,7 +38,7 @@ import org.xvm.runtime.template.collections.xTuple.TupleHandle;
  */
 public class xRTMethod
         extends xRTSignature {
-    public xRTMethod(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTMethod(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethodTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethodTemplate.java
@@ -31,7 +31,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTMethodTemplate
         extends xRTComponentTemplate {
-    public xRTMethodTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTMethodTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethodTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethodTemplate.java
@@ -31,14 +31,8 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTMethodTemplate
         extends xRTComponentTemplate {
-    public static xRTMethodTemplate INSTANCE;
-
     public xRTMethodTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -66,11 +60,13 @@ public class xRTMethodTemplate
 
         case "parameterCount":
             return frame.assignValue(iReturn,
-                                     xInt64.makeHandle(((MethodStructure) hMethod.getComponent()).getParamCount()));
+                                     xInt64.makeHandle(frame,
+                                             ((MethodStructure) hMethod.getComponent()).getParamCount()));
 
         case "returnCount":
             return frame.assignValue(iReturn,
-                                     xInt64.makeHandle(((MethodStructure) hMethod.getComponent()).getReturnCount()));
+                                     xInt64.makeHandle(frame,
+                                             ((MethodStructure) hMethod.getComponent()).getReturnCount()));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -133,7 +129,7 @@ public class xRTMethodTemplate
 
         ObjectHandle[] ahReturn = new ObjectHandle[5];
 
-        ahReturn[0] = sName == null ? xNullable.NULL : xString.makeHandle(sName);
+        ahReturn[0] = sName == null ? xNullable.NULL : xString.makeHandle(frame, sName);
         ahReturn[1] = xRTTypeTemplate.makeHandle(frame.f_context.f_container, parameter.getType());
         ahReturn[2] = xBoolean.makeHandle(parameter.isTypeParameter());
         ahReturn[3] = xBoolean.makeHandle(fDefault);
@@ -168,7 +164,7 @@ public class xRTMethodTemplate
 
         ObjectHandle[] ahReturn = new ObjectHandle[3];
 
-        ahReturn[0] = sName == null ? xNullable.NULL : xString.makeHandle(sName);
+        ahReturn[0] = sName == null ? xNullable.NULL : xString.makeHandle(frame, sName);
         ahReturn[1] = xRTTypeTemplate.makeHandle(frame.f_context.f_container, parameter.getType());
         ahReturn[2] = xBoolean.makeHandle(parameter.isConditionalReturn());
 
@@ -181,10 +177,12 @@ public class xRTMethodTemplate
     /**
      * @return the TypeComposition for an RTMethodTemplate
      */
-    public static TypeComposition ensureMethodTemplateComposition() { // TODO: use the container
+    // TODO: use the container - this still caches one composition process-wide
+    public static TypeComposition ensureMethodTemplateComposition(Container container) {
         TypeComposition clz = METHOD_TEMPLATE_COMP;
         if (clz == null) {
-            ClassTemplate templateRT   = INSTANCE;
+            ClassTemplate templateRT   = container.nativeTemplates().
+                    get(xRTMethodTemplate.class);
             ConstantPool  pool         = templateRT.pool();
             TypeConstant  typeTemplate = pool.ensureEcstasyTypeConstant("reflect.MethodTemplate");
             METHOD_TEMPLATE_COMP = clz = templateRT.ensureClass(templateRT.f_container, typeTemplate);
@@ -202,8 +200,8 @@ public class xRTMethodTemplate
      *
      * @return the newly created handle
      */
-    static ComponentTemplateHandle makeHandle(MethodStructure method) {
-        return new ComponentTemplateHandle(ensureMethodTemplateComposition(), method);
+    static ComponentTemplateHandle makeHandle(Container container, MethodStructure method) {
+        return new ComponentTemplateHandle(ensureMethodTemplateComposition(container), method);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethodTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTMethodTemplate.java
@@ -181,8 +181,7 @@ public class xRTMethodTemplate
     public static TypeComposition ensureMethodTemplateComposition(Container container) {
         TypeComposition clz = METHOD_TEMPLATE_COMP;
         if (clz == null) {
-            ClassTemplate templateRT   = container.nativeTemplates().
-                    get(xRTMethodTemplate.class);
+            ClassTemplate templateRT   = container.nativeTemplate(xRTMethodTemplate.class);
             ConstantPool  pool         = templateRT.pool();
             TypeConstant  typeTemplate = pool.ensureEcstasyTypeConstant("reflect.MethodTemplate");
             METHOD_TEMPLATE_COMP = clz = templateRT.ensureClass(templateRT.f_container, typeTemplate);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTModuleTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTModuleTemplate.java
@@ -33,7 +33,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xRTModuleTemplate
         extends xRTClassTemplate {
-    public xRTModuleTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTModuleTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTModuleTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTModuleTemplate.java
@@ -135,7 +135,7 @@ public class xRTModuleTemplate
     private static TypeConstant ensureListMapType(Container container) {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null) {
-            ConstantPool pool = container.nativeTemplates().get(xRTModuleTemplate.class).pool();
+            ConstantPool pool = container.nativeTemplate(xRTModuleTemplate.class).pool();
             LISTMAP_TYPE = type = pool.ensureParameterizedTypeConstant(
                     pool.ensureEcstasyTypeConstant("maps.ListMap"),
                     pool.typeString(), MODULE_TEMPLATE_TYPE);
@@ -146,7 +146,7 @@ public class xRTModuleTemplate
     private static ArrayHandle makeTemplateArrayHandle(Container container, ObjectHandle[] ahTemplate) {
         TypeComposition clzArray = container.ensureClassComposition(
                 container.getConstantPool().ensureArrayType(MODULE_TEMPLATE_TYPE),
-                        container.nativeTemplates().get(xArray.class));
+                        container.nativeTemplate(xArray.class));
         return xArray.makeArrayHandle(clzArray, ahTemplate.length, ahTemplate, Mutability.Constant);
     }
 
@@ -161,7 +161,7 @@ public class xRTModuleTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, ModuleStructure module) {
         // note: no need to initialize the struct because there are no natural fields
-        xRTModuleTemplate template = container.nativeTemplates().get(xRTModuleTemplate.class);
+        xRTModuleTemplate template = container.nativeTemplate(xRTModuleTemplate.class);
         TypeComposition  clz      = template.ensureClass(container, template.getCanonicalType(),
                 MODULE_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clz, module);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTModuleTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTModuleTemplate.java
@@ -33,14 +33,8 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xRTModuleTemplate
         extends xRTClassTemplate {
-    public static xRTModuleTemplate INSTANCE;
-
     public xRTModuleTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -65,7 +59,7 @@ public class xRTModuleTemplate
         case "qualifiedName": {
             ModuleStructure module = hTemplate.getModuleStructure();
             return frame.assignValue(iReturn,
-                xString.makeHandle(module.getIdentityConstant().getName()));
+                xString.makeHandle(frame, module.getIdentityConstant().getName()));
         }
 
         case "versionString": {
@@ -79,7 +73,7 @@ public class xRTModuleTemplate
             } else {
                 sVersion = module.getVersionString();
             }
-            return frame.assignValue(iReturn, makeNullableStringHandle(sVersion));
+            return frame.assignValue(iReturn, makeNullableStringHandle(frame, sVersion));
         }
 
         case "modulesByPath":
@@ -106,7 +100,7 @@ public class xRTModuleTemplate
         // TODO GG: how to cache the result?
         ModuleStructure module    = hTemplate.getModuleStructure();
         Container       container = frame.f_context.f_container;
-        TypeComposition clzMap    = container.resolveClass(ensureListMapType());
+        TypeComposition clzMap    = container.resolveClass(ensureListMapType(container));
 
         // starting with this module, find all module dependencies, and the shortest path to each
         Map<ModuleConstant, String> mapModulePaths = module.collectDependencies();
@@ -120,7 +114,7 @@ public class xRTModuleTemplate
             if (!idDep.equals(module.getIdentityConstant())) {
                 ModuleStructure moduleDep = module.getFileStructure().getModule(idDep);
 
-                ahPaths[index]    = xString.makeHandle(entry.getValue());
+                ahPaths[index]    = xString.makeHandle(container, entry.getValue());
                 ahTemplate[index] = makeHandle(container, moduleDep);
                 ++index;
             }
@@ -131,17 +125,17 @@ public class xRTModuleTemplate
         return Utils.constructListMap(frame, clzMap, haPaths, haTemplates, iReturn);
     }
 
-    private static ObjectHandle makeNullableStringHandle(String sValue) {
-        return sValue == null ? xNullable.NULL : xString.makeHandle(sValue);
+    private static ObjectHandle makeNullableStringHandle(Frame frame, String sValue) {
+        return sValue == null ? xNullable.NULL : xString.makeHandle(frame, sValue);
     }
 
     /**
      * @return the TypeConstant for ListMap<String, ModuleTemplate>
      */
-    private static TypeConstant ensureListMapType() {
+    private static TypeConstant ensureListMapType(Container container) {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().get(xRTModuleTemplate.class).pool();
             LISTMAP_TYPE = type = pool.ensureParameterizedTypeConstant(
                     pool.ensureEcstasyTypeConstant("maps.ListMap"),
                     pool.typeString(), MODULE_TEMPLATE_TYPE);
@@ -151,7 +145,8 @@ public class xRTModuleTemplate
 
     private static ArrayHandle makeTemplateArrayHandle(Container container, ObjectHandle[] ahTemplate) {
         TypeComposition clzArray = container.ensureClassComposition(
-                container.getConstantPool().ensureArrayType(MODULE_TEMPLATE_TYPE), xArray.INSTANCE);
+                container.getConstantPool().ensureArrayType(MODULE_TEMPLATE_TYPE),
+                        container.nativeTemplates().get(xArray.class));
         return xArray.makeArrayHandle(clzArray, ahTemplate.length, ahTemplate, Mutability.Constant);
     }
 
@@ -166,8 +161,9 @@ public class xRTModuleTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, ModuleStructure module) {
         // note: no need to initialize the struct because there are no natural fields
-        TypeComposition clz = INSTANCE.ensureClass(container,
-                                INSTANCE.getCanonicalType(), MODULE_TEMPLATE_TYPE);
+        xRTModuleTemplate template = container.nativeTemplates().get(xRTModuleTemplate.class);
+        TypeComposition  clz      = template.ensureClass(container, template.getCanonicalType(),
+                MODULE_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clz, module);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPackageTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPackageTemplate.java
@@ -16,14 +16,8 @@ import org.xvm.runtime.TypeComposition;
  */
 public class xRTPackageTemplate
         extends xRTClassTemplate {
-    public static xRTPackageTemplate INSTANCE;
-
     public xRTPackageTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -45,8 +39,9 @@ public class xRTPackageTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, PackageStructure pkg) {
         // note: no need to initialize the struct because there are no natural fields
-        TypeComposition clz = INSTANCE.ensureClass(container,
-                                INSTANCE.getCanonicalType(), PACKAGE_TEMPLATE_TYPE);
+        xRTPackageTemplate template = container.nativeTemplates().get(xRTPackageTemplate.class);
+        TypeComposition clz      = template.ensureClass(container, template.getCanonicalType(),
+                PACKAGE_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clz, pkg);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPackageTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPackageTemplate.java
@@ -16,7 +16,7 @@ import org.xvm.runtime.TypeComposition;
  */
 public class xRTPackageTemplate
         extends xRTClassTemplate {
-    public xRTPackageTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTPackageTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPackageTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPackageTemplate.java
@@ -39,7 +39,7 @@ public class xRTPackageTemplate
      */
     public static ComponentTemplateHandle makeHandle(Container container, PackageStructure pkg) {
         // note: no need to initialize the struct because there are no natural fields
-        xRTPackageTemplate template = container.nativeTemplates().get(xRTPackageTemplate.class);
+        xRTPackageTemplate template = container.nativeTemplate(xRTPackageTemplate.class);
         TypeComposition clz      = template.ensureClass(container, template.getCanonicalType(),
                 PACKAGE_TEMPLATE_TYPE);
         return new ComponentTemplateHandle(clz, pkg);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTProperty.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTProperty.java
@@ -38,14 +38,8 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTProperty
         extends xConst {
-    public static xRTProperty INSTANCE;
-
     public xRTProperty(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -177,21 +171,24 @@ public class xRTProperty
      * @return the resulting {@link PropertyHandle} or a {@link DeferredCallHandle}
      */
     public static ObjectHandle makeHandle(Frame frame, TypeConstant typeTarget, PropertyInfo infoProp) {
-        Annotation[] aAnno    = infoProp.getPropertyAnnotations();
-        TypeConstant typeProp = infoProp.getIdentity().getValueType(frame.poolContext(), typeTarget);
+        Container    container = frame.f_context.f_container;
+        Annotation[] aAnno     = infoProp.getPropertyAnnotations();
+        TypeConstant typeProp  = infoProp.getIdentity().getValueType(frame.poolContext(), typeTarget);
 
         if (aAnno != null && aAnno.length > 0) {
             typeProp = frame.poolContext().ensureAnnotatedTypeConstant(typeProp, aAnno);
 
-            TypeComposition clzProp = INSTANCE.ensureClass(frame.f_context.f_container, typeProp);
+            TypeComposition clzProp = container.nativeTemplates().
+                    get(xRTProperty.class).ensureClass(container, typeProp);
             PropertyHandle  hStruct = new PropertyHandle(clzProp.ensureAccess(Access.STRUCT));
 
-            int iResult = INSTANCE.proceedConstruction(
+            int iResult = container.nativeTemplates().get(xRTProperty.class).proceedConstruction(
                                 frame, null, true, hStruct, Utils.OBJECTS_NONE, Op.A_STACK);
             return frame.popResultImmutable(iResult);
         }
 
-        return new PropertyHandle(INSTANCE.ensureClass(frame.f_context.f_container, typeProp));
+        return new PropertyHandle(container.nativeTemplates().
+                get(xRTProperty.class).ensureClass(container, typeProp));
     }
 
     /**
@@ -301,7 +298,7 @@ public class xRTProperty
      * Implements property: name.get()
      */
     public int getPropertyName(Frame frame, PropertyHandle hProp, int iReturn) {
-        return frame.assignValue(iReturn, xString.makeHandle(hProp.getPropertyConstant().getName()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, hProp.getPropertyConstant().getName()));
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTProperty.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTProperty.java
@@ -171,24 +171,22 @@ public class xRTProperty
      * @return the resulting {@link PropertyHandle} or a {@link DeferredCallHandle}
      */
     public static ObjectHandle makeHandle(Frame frame, TypeConstant typeTarget, PropertyInfo infoProp) {
-        Container    container = frame.f_context.f_container;
+        Container    container = frame.container();
         Annotation[] aAnno     = infoProp.getPropertyAnnotations();
         TypeConstant typeProp  = infoProp.getIdentity().getValueType(frame.poolContext(), typeTarget);
 
         if (aAnno != null && aAnno.length > 0) {
             typeProp = frame.poolContext().ensureAnnotatedTypeConstant(typeProp, aAnno);
 
-            TypeComposition clzProp = container.nativeTemplates().
-                    get(xRTProperty.class).ensureClass(container, typeProp);
+            TypeComposition clzProp = container.nativeTemplate(xRTProperty.class).ensureClass(container, typeProp);
             PropertyHandle  hStruct = new PropertyHandle(clzProp.ensureAccess(Access.STRUCT));
 
-            int iResult = container.nativeTemplates().get(xRTProperty.class).proceedConstruction(
+            int iResult = container.nativeTemplate(xRTProperty.class).proceedConstruction(
                                 frame, null, true, hStruct, Utils.OBJECTS_NONE, Op.A_STACK);
             return frame.popResultImmutable(iResult);
         }
 
-        return new PropertyHandle(container.nativeTemplates().
-                get(xRTProperty.class).ensureClass(container, typeProp));
+        return new PropertyHandle(container.nativeTemplate(xRTProperty.class).ensureClass(container, typeProp));
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTProperty.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTProperty.java
@@ -38,7 +38,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTProperty
         extends xConst {
-    public xRTProperty(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTProperty(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
@@ -32,19 +32,13 @@ import org.xvm.runtime.template.collections.xArray;
  */
 public class xRTPropertyClassTemplate
         extends xRTComponentTemplate {
-    public static xRTPropertyClassTemplate INSTANCE;
-
     public xRTPropertyClassTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRTPropertyClassTemplate.class)) {
             TypeConstant typeMask = pool().ensureEcstasyTypeConstant("reflect.ClassTemplate");
 
             PROPERTY_CLASS_TEMPLATE_COMP = ensureClass(f_container, getCanonicalType(), typeMask);
@@ -202,13 +196,14 @@ public class xRTPropertyClassTemplate
         List<ComponentTemplateHandle> listProps = new ArrayList<>();
         for (Component child : prop.children()) {
             if (child instanceof PropertyStructure) {
-                listProps.add(xRTPropertyTemplate.makePropertyHandle((PropertyStructure) child));
+                listProps.add(xRTPropertyTemplate.makePropertyHandle(
+                        frame.f_context.f_container, (PropertyStructure) child));
             }
         }
 
         ComponentTemplateHandle[] ahProp = listProps.toArray(xRTClassTemplate.NO_TEMPLATES);
         ObjectHandle hArray = xArray.createImmutableArray(
-                xRTPropertyTemplate.ensureArrayComposition(), ahProp);
+                xRTPropertyTemplate.ensureArrayComposition(frame.f_context.f_container), ahProp);
         return frame.assignValue(iReturn, hArray);
     }
 
@@ -257,7 +252,8 @@ public class xRTPropertyClassTemplate
     protected int invokeFromProperty(Frame frame, ComponentTemplateHandle hComponent, int[] aiReturn) {
         PropertyStructure prop = (PropertyStructure) hComponent.getComponent();
         return frame.assignValues(aiReturn,
-            xBoolean.TRUE, xRTPropertyTemplate.makePropertyHandle(prop));
+            xBoolean.TRUE, xRTPropertyTemplate.makePropertyHandle(
+                        frame.f_context.f_container, prop));
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
@@ -197,13 +197,13 @@ public class xRTPropertyClassTemplate
         for (Component child : prop.children()) {
             if (child instanceof PropertyStructure) {
                 listProps.add(xRTPropertyTemplate.makePropertyHandle(
-                        frame.f_context.f_container, (PropertyStructure) child));
+                        frame.container(), (PropertyStructure) child));
             }
         }
 
         ComponentTemplateHandle[] ahProp = listProps.toArray(xRTClassTemplate.NO_TEMPLATES);
         ObjectHandle hArray = xArray.createImmutableArray(
-                xRTPropertyTemplate.ensureArrayComposition(frame.f_context.f_container), ahProp);
+                xRTPropertyTemplate.ensureArrayComposition(frame.container()), ahProp);
         return frame.assignValue(iReturn, hArray);
     }
 
@@ -253,7 +253,7 @@ public class xRTPropertyClassTemplate
         PropertyStructure prop = (PropertyStructure) hComponent.getComponent();
         return frame.assignValues(aiReturn,
             xBoolean.TRUE, xRTPropertyTemplate.makePropertyHandle(
-                        frame.f_context.f_container, prop));
+                        frame.container(), prop));
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyClassTemplate.java
@@ -32,7 +32,7 @@ import org.xvm.runtime.template.collections.xArray;
  */
 public class xRTPropertyClassTemplate
         extends xRTComponentTemplate {
-    public xRTPropertyClassTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTPropertyClassTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyTemplate.java
@@ -177,8 +177,7 @@ public class xRTPropertyTemplate
     public static TypeComposition ensurePropertyTemplateComposition(Container container) {
         TypeComposition clz = PROPERTY_TEMPLATE_COMP;
         if (clz == null) {
-            ClassTemplate templateRT   = container.nativeTemplates().
-                    get(xRTPropertyTemplate.class);
+            ClassTemplate templateRT   = container.nativeTemplate(xRTPropertyTemplate.class);
             ConstantPool  pool         = templateRT.pool();
             TypeConstant  typeTemplate = pool.ensureEcstasyTypeConstant("reflect.PropertyTemplate");
             PROPERTY_TEMPLATE_COMP = clz = templateRT.ensureClass(templateRT.f_container, typeTemplate);
@@ -193,7 +192,7 @@ public class xRTPropertyTemplate
     public static TypeComposition ensureArrayComposition(Container container) {
         TypeComposition clz = ARRAY_PROP_COMP;
         if (clz == null) {
-            ConstantPool pool = container.nativeTemplates().get(xRTPropertyTemplate.class).pool();
+            ConstantPool pool = container.nativeTemplate(xRTPropertyTemplate.class).pool();
             TypeConstant typePropertyTemplate = pool.ensureEcstasyTypeConstant("reflect.PropertyTemplate");
             TypeConstant typePropertyArray = pool.ensureArrayType(typePropertyTemplate);
             ARRAY_PROP_COMP = clz = container.getNativeContainer().

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyTemplate.java
@@ -29,7 +29,7 @@ import org.xvm.runtime.template.collections.xArray;
  */
 public class xRTPropertyTemplate
         extends xRTComponentTemplate {
-    public xRTPropertyTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTPropertyTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTPropertyTemplate.java
@@ -29,14 +29,8 @@ import org.xvm.runtime.template.collections.xArray;
  */
 public class xRTPropertyTemplate
         extends xRTComponentTemplate {
-    public static xRTPropertyTemplate INSTANCE;
-
     public xRTPropertyTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -179,10 +173,12 @@ public class xRTPropertyTemplate
     /**
      * @return the TypeComposition for an RTPropertyTemplate
      */
-    public static TypeComposition ensurePropertyTemplateComposition() {
+    // TODO: use the container - this still caches one composition process-wide
+    public static TypeComposition ensurePropertyTemplateComposition(Container container) {
         TypeComposition clz = PROPERTY_TEMPLATE_COMP;
         if (clz == null) {
-            ClassTemplate templateRT   = INSTANCE;
+            ClassTemplate templateRT   = container.nativeTemplates().
+                    get(xRTPropertyTemplate.class);
             ConstantPool  pool         = templateRT.pool();
             TypeConstant  typeTemplate = pool.ensureEcstasyTypeConstant("reflect.PropertyTemplate");
             PROPERTY_TEMPLATE_COMP = clz = templateRT.ensureClass(templateRT.f_container, typeTemplate);
@@ -194,13 +190,14 @@ public class xRTPropertyTemplate
     /**
      * @return the TypeComposition for an Array of PropertyTemplate
      */
-    public static TypeComposition ensureArrayComposition() {
+    public static TypeComposition ensureArrayComposition(Container container) {
         TypeComposition clz = ARRAY_PROP_COMP;
         if (clz == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().get(xRTPropertyTemplate.class).pool();
             TypeConstant typePropertyTemplate = pool.ensureEcstasyTypeConstant("reflect.PropertyTemplate");
             TypeConstant typePropertyArray = pool.ensureArrayType(typePropertyTemplate);
-            ARRAY_PROP_COMP = clz = INSTANCE.f_container.resolveClass(typePropertyArray);
+            ARRAY_PROP_COMP = clz = container.getNativeContainer().
+                    resolveClass(typePropertyArray);
             assert clz != null;
         }
         return clz;
@@ -216,8 +213,10 @@ public class xRTPropertyTemplate
      *
      * @return the newly created handle
      */
-    static ComponentTemplateHandle makePropertyHandle(PropertyStructure prop) {
-        return new ComponentTemplateHandle(ensurePropertyTemplateComposition(), prop);
+    static ComponentTemplateHandle makePropertyHandle(Container container,
+                                                      PropertyStructure prop) {
+        return new ComponentTemplateHandle(
+                ensurePropertyTemplateComposition(container), prop);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTSignature.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTSignature.java
@@ -36,7 +36,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTSignature
         extends ClassTemplate {
-    public xRTSignature(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTSignature(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTSignature.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTSignature.java
@@ -109,14 +109,14 @@ public class xRTSignature
      * Implements property: params.get()
      */
     protected int getPropertyParams(Frame frame, SignatureHandle hFunc, int iReturn) {
-        return new RTArrayConstructor(frame.f_context.f_container, hFunc, false, iReturn).doNext(frame);
+        return new RTArrayConstructor(frame.container(), hFunc, false, iReturn).doNext(frame);
     }
 
     /**
      * Implements property: params.get()
      */
     protected int getPropertyReturns(Frame frame, SignatureHandle hFunc, int iReturn) {
-        return new RTArrayConstructor(frame.f_context.f_container, hFunc, true, iReturn).doNext(frame);
+        return new RTArrayConstructor(frame.container(), hFunc, true, iReturn).doNext(frame);
     }
 
     /**
@@ -173,7 +173,7 @@ public class xRTSignature
         return method == null
                 ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
                 : frame.assignValues(aiReturn, xBoolean.TRUE,
-                        xRTMethodTemplate.makeHandle(frame.f_context.f_container, method));
+                        xRTMethodTemplate.makeHandle(frame.container(), method));
     }
 
 
@@ -185,7 +185,7 @@ public class xRTSignature
     public static TypeConstant ensureReturnType(Container container) {
         TypeConstant type = RETURN_TYPE;
         if (type == null) {
-            ConstantPool pool = container.nativeTemplates().get(xRTSignature.class).pool();
+            ConstantPool pool = container.nativeTemplate(xRTSignature.class).pool();
             RETURN_TYPE = type = pool.ensureEcstasyTypeConstant("reflect.Return");
         }
         return type;
@@ -209,7 +209,7 @@ public class xRTSignature
     public static TypeConstant ensureParamType(Container container) {
         TypeConstant type = PARAM_TYPE;
         if (type == null) {
-            PARAM_TYPE = type = container.nativeTemplates().get(xRTSignature.class).pool().typeParameter();
+            PARAM_TYPE = type = container.nativeTemplate(xRTSignature.class).pool().typeParameter();
         }
         return type;
     }
@@ -258,7 +258,7 @@ public class xRTSignature
     public static TypeComposition ensureRTReturn(Frame frame, TypeConstant typeValue) {
         assert typeValue != null;
 
-        Container    container = frame.f_context.f_container;
+        Container    container = frame.container();
         ConstantPool pool      = frame.poolContext();
         TypeConstant type      = pool.ensureParameterizedTypeConstant(
                                     ensureReturnType(container), typeValue);
@@ -275,7 +275,7 @@ public class xRTSignature
                                                     Annotation[] aAnno) {
         assert typeValue != null;
 
-        Container    container = frame.f_context.f_container;
+        Container    container = frame.container();
         ConstantPool pool      = frame.poolContext();
         TypeConstant type      = pool.ensureParameterizedTypeConstant(
                                     ensureParamType(container), typeValue);
@@ -296,7 +296,7 @@ public class xRTSignature
     public static TypeComposition ensureReturnArray(Container container) {
         TypeComposition clz = RETURN_ARRAY;
         if (clz == null) {
-            TypeConstant typeReturnArray = container.nativeTemplates().get(xRTSignature.class).
+            TypeConstant typeReturnArray = container.nativeTemplate(xRTSignature.class).
                     pool().ensureArrayType(ensureReturnType(container));
             RETURN_ARRAY = clz = container.getNativeContainer().resolveClass(typeReturnArray);
         }
@@ -309,7 +309,7 @@ public class xRTSignature
     public static TypeComposition ensureParamArray(Container container) {
         TypeComposition clz = PARAM_ARRAY;
         if (clz == null) {
-            TypeConstant typeParamArray = container.nativeTemplates().get(xRTSignature.class).
+            TypeConstant typeParamArray = container.nativeTemplate(xRTSignature.class).
                     pool().ensureArrayType(ensureParamType(container));
             PARAM_ARRAY = clz = container.getNativeContainer().resolveClass(typeParamArray);
         }
@@ -551,7 +551,7 @@ public class xRTSignature
                 }
             }
 
-            Container    container = frameCaller.f_context.f_container;
+            Container    container = frameCaller.container();
             ObjectHandle hArray     = xArray.createImmutableArray(fRetVals
                     ? ensureReturnArray(container)
                     : ensureParamArray(container), ahElement);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTSignature.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTSignature.java
@@ -36,14 +36,8 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xRTSignature
         extends ClassTemplate {
-    public static xRTSignature INSTANCE;
-
     public xRTSignature(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -108,21 +102,21 @@ public class xRTSignature
      * Implements property: name.get()
      */
     protected int getPropertyName(Frame frame, SignatureHandle hFunc, int iReturn) {
-        return frame.assignValue(iReturn, xString.makeHandle(hFunc.getName()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, hFunc.getName()));
     }
 
     /**
      * Implements property: params.get()
      */
     protected int getPropertyParams(Frame frame, SignatureHandle hFunc, int iReturn) {
-        return new RTArrayConstructor(hFunc, false, iReturn).doNext(frame);
+        return new RTArrayConstructor(frame.f_context.f_container, hFunc, false, iReturn).doNext(frame);
     }
 
     /**
      * Implements property: params.get()
      */
     protected int getPropertyReturns(Frame frame, SignatureHandle hFunc, int iReturn) {
-        return new RTArrayConstructor(hFunc, true, iReturn).doNext(frame);
+        return new RTArrayConstructor(frame.f_context.f_container, hFunc, true, iReturn).doNext(frame);
     }
 
     /**
@@ -178,7 +172,8 @@ public class xRTSignature
         MethodStructure method = hFunc.getMethod();
         return method == null
                 ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
-                : frame.assignValues(aiReturn, xBoolean.TRUE, xRTMethodTemplate.makeHandle(method));
+                : frame.assignValues(aiReturn, xBoolean.TRUE,
+                        xRTMethodTemplate.makeHandle(frame.f_context.f_container, method));
     }
 
 
@@ -187,10 +182,10 @@ public class xRTSignature
     /**
      * @return the TypeConstant for a Return
      */
-    public static TypeConstant ensureReturnType() {
+    public static TypeConstant ensureReturnType(Container container) {
         TypeConstant type = RETURN_TYPE;
         if (type == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().get(xRTSignature.class).pool();
             RETURN_TYPE = type = pool.ensureEcstasyTypeConstant("reflect.Return");
         }
         return type;
@@ -199,10 +194,10 @@ public class xRTSignature
     /**
      * @return the TypeConstant for an RTReturn
      */
-    public static TypeConstant ensureRTReturnType() {
+    public static TypeConstant ensureRTReturnType(Container container) {
         TypeConstant type = RTRETURN_TYPE;
         if (type == null) {
-            RTRETURN_TYPE = type = INSTANCE.f_container.getClassStructure("_native.reflect.RTReturn").
+            RTRETURN_TYPE = type = container.getClassStructure("_native.reflect.RTReturn").
                     getIdentityConstant().getType();
         }
         return type;
@@ -211,10 +206,10 @@ public class xRTSignature
     /**
      * @return the TypeConstant for a Parameter
      */
-    public static TypeConstant ensureParamType() {
+    public static TypeConstant ensureParamType(Container container) {
         TypeConstant type = PARAM_TYPE;
         if (type == null) {
-            PARAM_TYPE = type = INSTANCE.pool().typeParameter();
+            PARAM_TYPE = type = container.nativeTemplates().get(xRTSignature.class).pool().typeParameter();
         }
         return type;
     }
@@ -222,10 +217,10 @@ public class xRTSignature
     /**
      * @return the TypeConstant for an RTParameter
      */
-    public static TypeConstant ensureRTParamType() {
+    public static TypeConstant ensureRTParamType(Container container) {
         TypeConstant type = RTPARAM_TYPE;
         if (type == null) {
-            RTPARAM_TYPE = type = INSTANCE.f_container.getClassStructure("_native.reflect.RTParameter").
+            RTPARAM_TYPE = type = container.getClassStructure("_native.reflect.RTParameter").
                     getIdentityConstant().getType();
         }
         return type;
@@ -234,10 +229,12 @@ public class xRTSignature
     /**
      * @return the ClassTemplate for an RTReturn
      */
-    public static xConst ensureRTReturnTemplate() {
+    public static xConst ensureRTReturnTemplate(Container container) {
         xConst template = RTRETURN_TEMPLATE;
         if (template == null) {
-            RTRETURN_TEMPLATE = template = (xConst) INSTANCE.f_container.getTemplate(ensureRTReturnType());
+            RTRETURN_TEMPLATE = template =
+                    (xConst) container.getNativeContainer().
+                            getTemplate(ensureRTReturnType(container));
         }
         return template;
     }
@@ -245,10 +242,12 @@ public class xRTSignature
     /**
      * @return the ClassTemplate for an RTParameter
      */
-    public static xConst ensureRTParamTemplate() {
+    public static xConst ensureRTParamTemplate(Container container) {
         xConst template = RTPARAM_TEMPLATE;
         if (template == null) {
-            RTPARAM_TEMPLATE = template = (xConst) INSTANCE.f_container.getTemplate(ensureRTParamType());
+            RTPARAM_TEMPLATE = template =
+                    (xConst) container.getNativeContainer().
+                            getTemplate(ensureRTParamType(container));
         }
         return template;
     }
@@ -259,11 +258,14 @@ public class xRTSignature
     public static TypeComposition ensureRTReturn(Frame frame, TypeConstant typeValue) {
         assert typeValue != null;
 
-        ConstantPool pool   = frame.poolContext();
-        TypeConstant type   = pool.ensureParameterizedTypeConstant(ensureReturnType(), typeValue);
-        TypeConstant typeRT = pool.ensureParameterizedTypeConstant(ensureRTReturnType(), typeValue);
+        Container    container = frame.f_context.f_container;
+        ConstantPool pool      = frame.poolContext();
+        TypeConstant type      = pool.ensureParameterizedTypeConstant(
+                                    ensureReturnType(container), typeValue);
+        TypeConstant typeRT    = pool.ensureParameterizedTypeConstant(
+                                    ensureRTReturnType(container), typeValue);
 
-        return ensureRTReturnTemplate().ensureClass(frame.f_context.f_container, typeRT, type);
+        return ensureRTReturnTemplate(container).ensureClass(container, typeRT, type);
     }
 
     /**
@@ -273,26 +275,30 @@ public class xRTSignature
                                                     Annotation[] aAnno) {
         assert typeValue != null;
 
-        ConstantPool pool   = frame.poolContext();
-        TypeConstant type   = pool.ensureParameterizedTypeConstant(ensureParamType(), typeValue);
-        TypeConstant typeRT = pool.ensureParameterizedTypeConstant(ensureRTParamType(), typeValue);
+        Container    container = frame.f_context.f_container;
+        ConstantPool pool      = frame.poolContext();
+        TypeConstant type      = pool.ensureParameterizedTypeConstant(
+                                    ensureParamType(container), typeValue);
+        TypeConstant typeRT    = pool.ensureParameterizedTypeConstant(
+                                    ensureRTParamType(container), typeValue);
 
         if (aAnno.length > 0) {
             type   = pool.ensureAnnotatedTypeConstant(type, aAnno);
             typeRT = pool.ensureAnnotatedTypeConstant(typeRT, aAnno);
         }
 
-        return ensureRTParamTemplate().ensureClass(frame.f_context.f_container, typeRT, type);
+        return ensureRTParamTemplate(container).ensureClass(container, typeRT, type);
     }
 
     /**
      * @return the TypeComposition for an Array of Return
      */
-    public static TypeComposition ensureReturnArray() {
+    public static TypeComposition ensureReturnArray(Container container) {
         TypeComposition clz = RETURN_ARRAY;
         if (clz == null) {
-            TypeConstant typeReturnArray = INSTANCE.pool().ensureArrayType(ensureReturnType());
-            RETURN_ARRAY = clz = INSTANCE.f_container.resolveClass(typeReturnArray);
+            TypeConstant typeReturnArray = container.nativeTemplates().get(xRTSignature.class).
+                    pool().ensureArrayType(ensureReturnType(container));
+            RETURN_ARRAY = clz = container.getNativeContainer().resolveClass(typeReturnArray);
         }
         return clz;
     }
@@ -300,11 +306,12 @@ public class xRTSignature
     /**
      * @return the TypeComposition for an Array of Parameter
      */
-    public static TypeComposition ensureParamArray() {
+    public static TypeComposition ensureParamArray(Container container) {
         TypeComposition clz = PARAM_ARRAY;
         if (clz == null) {
-            TypeConstant typeParamArray = INSTANCE.pool().ensureArrayType(ensureParamType());
-            PARAM_ARRAY = clz = INSTANCE.f_container.resolveClass(typeParamArray);
+            TypeConstant typeParamArray = container.nativeTemplates().get(xRTSignature.class).
+                    pool().ensureArrayType(ensureParamType(container));
+            PARAM_ARRAY = clz = container.getNativeContainer().resolveClass(typeParamArray);
         }
         return clz;
     }
@@ -470,10 +477,13 @@ public class xRTSignature
      */
     static class RTArrayConstructor
             implements Frame.Continuation {
-        protected RTArrayConstructor(SignatureHandle hMethod, boolean fRetVals, int iReturn) {
+        protected RTArrayConstructor(Container container, SignatureHandle hMethod,
+                                     boolean fRetVals, int iReturn) {
             this.hMethod   = hMethod;
             this.fRetVals  = fRetVals;
-            this.template  = fRetVals ? ensureRTReturnTemplate() : ensureRTParamTemplate();
+            this.template  = fRetVals
+                    ? ensureRTReturnTemplate(container)
+                    : ensureRTParamTemplate(container);
             this.cElements = fRetVals ? hMethod.getReturnCount() : hMethod.getParamCount();
             this.ahElement = new ObjectHandle[cElements];
             this.construct = template.getStructure().findMethod("construct", fRetVals ? 2 : 5);
@@ -499,8 +509,8 @@ public class xRTSignature
                 Parameter param = fRetVals ? hMethod.getReturn(index) : hMethod.getParam(index);
                 String sName = param.getName();
 
-                ahParams[0] = xInt64.makeHandle(index);
-                ahParams[1] = sName == null ? xNullable.NULL : xString.makeHandle(sName);
+                ahParams[0] = xInt64.makeHandle(frameCaller, index);
+                ahParams[1] = sName == null ? xNullable.NULL : xString.makeHandle(frameCaller, sName);
                 if (!fRetVals) {
                     ahParams[2] = xBoolean.makeHandle(param.isTypeParameter());
                     if (param.hasDefaultValue()) {
@@ -541,8 +551,10 @@ public class xRTSignature
                 }
             }
 
-            ObjectHandle hArray = xArray.createImmutableArray(
-                    fRetVals ? ensureReturnArray() : ensureParamArray(), ahElement);
+            Container    container = frameCaller.f_context.f_container;
+            ObjectHandle hArray     = xArray.createImmutableArray(fRetVals
+                    ? ensureReturnArray(container)
+                    : ensureParamArray(container), ahElement);
             return frameCaller.assignValue(iReturn, hArray);
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -183,7 +183,7 @@ public class xRTType
                                  TypeConstant typeProxy, boolean fResponse) {
         // a proxy for a non-shareable TypeHandle is a "foreign" handle
         return frame.assignValue(Op.A_STACK,
-                makeForeignHandle(frame.f_context.f_container,
+                makeForeignHandle(frame.container(),
                         ((TypeHandle) hTarget).getUnsafeDataType()));
     }
 
@@ -607,12 +607,12 @@ public class xRTType
                     switch (getPropertyConstants(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                nativeTemplates().get(xRTFunction.class).getCanonicalClass());
+                                f_container.nativeTemplate(xRTFunction.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                nativeTemplates().get(xRTFunction.class).getCanonicalClass()));
+                                f_container.nativeTemplate(xRTFunction.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -740,12 +740,12 @@ public class xRTType
                     switch (getPropertyConstructors(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                nativeTemplates().get(xRTFunction.class).getCanonicalClass());
+                                f_container.nativeTemplate(xRTFunction.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                nativeTemplates().get(xRTFunction.class).getCanonicalClass()));
+                                f_container.nativeTemplate(xRTFunction.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -829,12 +829,12 @@ public class xRTType
                     switch (getPropertyFunctions(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                nativeTemplates().get(xRTFunction.class).getCanonicalClass());
+                                f_container.nativeTemplate(xRTFunction.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                nativeTemplates().get(xRTFunction.class).getCanonicalClass()));
+                                f_container.nativeTemplate(xRTFunction.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -899,12 +899,12 @@ public class xRTType
                     switch (getPropertyMethods(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                nativeTemplates().get(xRTMethod.class).getCanonicalClass());
+                                f_container.nativeTemplate(xRTMethod.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                nativeTemplates().get(xRTMethod.class).getCanonicalClass()));
+                                f_container.nativeTemplate(xRTMethod.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -961,12 +961,12 @@ public class xRTType
                     switch (getPropertyProperties(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                nativeTemplates().get(xRTProperty.class).getCanonicalClass());
+                                f_container.nativeTemplate(xRTProperty.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                nativeTemplates().get(xRTProperty.class).getCanonicalClass()));
+                                f_container.nativeTemplate(xRTProperty.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -1059,12 +1059,12 @@ public class xRTType
                     switch (getPropertyUnderlyingTypes(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                nativeTemplates().get(xRTProperty.class).getCanonicalClass());
+                                f_container.nativeTemplate(xRTProperty.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                nativeTemplates().get(xRTProperty.class).getCanonicalClass()));
+                                f_container.nativeTemplate(xRTProperty.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -1116,7 +1116,7 @@ public class xRTType
         if (hMixin instanceof ClassHandle hClass) {
             ArrayHandle hArgs = (ArrayHandle) hAnno.getField(frame, "arguments");
 
-            if (nativeTemplates().get(xArray.class).size(hArgs) > 0) {
+            if (f_container.nativeTemplate(xArray.class).size(hArgs) > 0) {
                 // TODO args
                 return frame.raiseException(xException.notImplemented(frame,
                     "Annotation arguments are not yet supported"));
@@ -1532,7 +1532,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Access} enum value
      */
     public static EnumHandle makeAccessHandle(Frame frame, Access access) {
-        xEnum enumAccess = (xEnum) frame.f_context.f_container.getTemplate("reflect.Access");
+        xEnum enumAccess = (xEnum) frame.container().getTemplate("reflect.Access");
         return switch (access) {
             case PUBLIC    -> enumAccess.getEnumByName("Public");
             case PROTECTED -> enumAccess.getEnumByName("Protected");
@@ -1550,7 +1550,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Form} enum value
      */
     protected static EnumHandle makeFormHandle(Frame frame, TypeConstant type) {
-        xEnum enumForm = (xEnum) frame.f_context.f_container.getTemplate("reflect.Type.Form");
+        xEnum enumForm = (xEnum) frame.container().getTemplate("reflect.Type.Form");
 
         switch (type.getFormat()) {
         case TerminalType:
@@ -1713,7 +1713,7 @@ public class xRTType
             case Op.R_NEXT:
                 ObjectHandle hElement = frame.popStack();
                 ahValue[i] = hElement instanceof TypeHandle hType
-                        ? xRTType.makeForeignHandle(frame.f_context.f_container,
+                        ? xRTType.makeForeignHandle(frame.container(),
                                 hType.getUnsafeType())
                         : Proxy.makeHandle(clzProxy, frame.f_context, hElement, false);
                 break;
@@ -1736,7 +1736,7 @@ public class xRTType
      */
     public static TypeComposition ensureTypeArrayComposition(Container container) {
         return container.ensureClassComposition(TYPE_ARRAY_TYPE,
-                container.nativeTemplates().get(xArray.class));
+                container.nativeTemplate(xArray.class));
     }
 
     /**
@@ -1781,10 +1781,8 @@ public class xRTType
         // unfortunately, "makeHandle" is called from places where we cannot easily invoke the
         // default initializer, so we need to do it by hand
         TypeHandle hType = fShared
-            ? new TypeHandle(container.nativeTemplates().
-                    get(xRTType.class).ensureClass(container, type.getType()), null)
-            : new TypeHandle(container.nativeTemplates().
-                    get(xRTType.class).getCanonicalClass(), type.getType());
+            ? new TypeHandle(container.nativeTemplate(xRTType.class).ensureClass(container, type.getType()), null)
+            : new TypeHandle(container.nativeTemplate(xRTType.class).getCanonicalClass(), type.getType());
 
         GenericHandle hMulti = (GenericHandle) hType.getField(null, "multimethods");
         hMulti.setField(null, GenericHandle.OUTER, hType);

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -76,14 +76,9 @@ import org.xvm.runtime.template._native.reflect.xRTProperty.PropertyHandle;
 public class xRTType
         extends xConst
         implements IndexSupport { // for turtle types
-    public static xRTType INSTANCE;
 
     public xRTType(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -188,7 +183,8 @@ public class xRTType
                                  TypeConstant typeProxy, boolean fResponse) {
         // a proxy for a non-shareable TypeHandle is a "foreign" handle
         return frame.assignValue(Op.A_STACK,
-                makeForeignHandle(((TypeHandle) hTarget).getUnsafeDataType()));
+                makeForeignHandle(frame.f_context.f_container,
+                        ((TypeHandle) hTarget).getUnsafeDataType()));
     }
 
     @Override
@@ -308,7 +304,7 @@ public class xRTType
         switch (method.getName()) {
         case "dump":
             return frame.assignValue(iReturn,
-                xString.makeHandle(hType.getUnsafeDataType().ensureTypeInfo().toString()));
+                xString.makeHandle(frame, hType.getUnsafeDataType().ensureTypeInfo().toString()));
         }
         return super.invokeNativeN(frame, method, hTarget, ahArg, iReturn);
     }
@@ -454,7 +450,7 @@ public class xRTType
 
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         return frame.assignValue(iReturn,
-            xInt64.makeHandle(((TypeHandle) hTarget).getUnsafeDataType().hashCode()));
+            xInt64.makeHandle(frame, ((TypeHandle) hTarget).getUnsafeDataType().hashCode()));
     }
 
 
@@ -533,7 +529,7 @@ public class xRTType
         TypeHandle[]            ahType     = new TypeHandle[cInfos];
         int                     ix         = 0;
         for (String sName : mapInfos.keySet()) {
-            ahName[ix  ] = xString.makeHandle(sName);
+            ahName[ix  ] = xString.makeHandle(frame, sName);
             ahType[ix++] = infoTarget.calculateChildType(poolCtx, sName).ensureTypeHandle(container);
         }
 
@@ -555,7 +551,7 @@ public class xRTType
                     TypeHandle[]     ahType     = (TypeHandle[])   aah[1];
 
                     for (int i = 0, c = ahType.length; i < c; i++) {
-                        ahType[i] = xRTType.makeHandle(null, ahType[i].getDataType(), false);
+                        ahType[i] = xRTType.makeHandle(container, ahType[i].getDataType(), false);
                     }
 
                     return Utils.constructListMap(frame, clzListMap,
@@ -611,12 +607,12 @@ public class xRTType
                     switch (getPropertyConstants(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                xRTFunction.INSTANCE.getCanonicalClass());
+                                nativeTemplates().get(xRTFunction.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                xRTFunction.INSTANCE.getCanonicalClass()));
+                                nativeTemplates().get(xRTFunction.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -744,12 +740,12 @@ public class xRTType
                     switch (getPropertyConstructors(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                xRTFunction.INSTANCE.getCanonicalClass());
+                                nativeTemplates().get(xRTFunction.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                xRTFunction.INSTANCE.getCanonicalClass()));
+                                nativeTemplates().get(xRTFunction.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -833,12 +829,12 @@ public class xRTType
                     switch (getPropertyFunctions(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                xRTFunction.INSTANCE.getCanonicalClass());
+                                nativeTemplates().get(xRTFunction.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                xRTFunction.INSTANCE.getCanonicalClass()));
+                                nativeTemplates().get(xRTFunction.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -903,12 +899,12 @@ public class xRTType
                     switch (getPropertyMethods(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                xRTMethod.INSTANCE.getCanonicalClass());
+                                nativeTemplates().get(xRTMethod.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                xRTMethod.INSTANCE.getCanonicalClass()));
+                                nativeTemplates().get(xRTMethod.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -965,12 +961,12 @@ public class xRTType
                     switch (getPropertyProperties(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                xRTProperty.INSTANCE.getCanonicalClass());
+                                nativeTemplates().get(xRTProperty.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                xRTProperty.INSTANCE.getCanonicalClass()));
+                                nativeTemplates().get(xRTProperty.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -1063,12 +1059,12 @@ public class xRTType
                     switch (getPropertyUnderlyingTypes(frame, hType, Op.A_STACK)) {
                     case Op.R_NEXT:
                         return createProxyArray(frame, (ArrayHandle) frame.popStack(),
-                                xRTProperty.INSTANCE.getCanonicalClass());
+                                nativeTemplates().get(xRTProperty.class).getCanonicalClass());
 
                     case Op.R_CALL:
                         frame.m_frameNext.addContinuation(frameCaller ->
                             createProxyArray(frameCaller, (ArrayHandle) frameCaller.popStack(),
-                                xRTProperty.INSTANCE.getCanonicalClass()));
+                                nativeTemplates().get(xRTProperty.class).getCanonicalClass()));
                         return Op.R_CALL;
 
                     case Op.R_EXCEPTION:
@@ -1120,7 +1116,7 @@ public class xRTType
         if (hMixin instanceof ClassHandle hClass) {
             ArrayHandle hArgs = (ArrayHandle) hAnno.getField(frame, "arguments");
 
-            if (xArray.INSTANCE.size(hArgs) > 0) {
+            if (nativeTemplates().get(xArray.class).size(hArgs) > 0) {
                 // TODO args
                 return frame.raiseException(xException.notImplemented(frame,
                     "Annotation arguments are not yet supported"));
@@ -1350,7 +1346,7 @@ public class xRTType
 
         return sName == null
             ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
-            : frame.assignValues(aiReturn, xBoolean.TRUE, xString.makeHandle(sName));
+            : frame.assignValues(aiReturn, xBoolean.TRUE, xString.makeHandle(frame, sName));
     }
 
     /**
@@ -1536,7 +1532,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Access} enum value
      */
     public static EnumHandle makeAccessHandle(Frame frame, Access access) {
-        xEnum enumAccess = (xEnum) INSTANCE.f_container.getTemplate("reflect.Access");
+        xEnum enumAccess = (xEnum) frame.f_context.f_container.getTemplate("reflect.Access");
         return switch (access) {
             case PUBLIC    -> enumAccess.getEnumByName("Public");
             case PROTECTED -> enumAccess.getEnumByName("Protected");
@@ -1554,7 +1550,7 @@ public class xRTType
      * @return the handle to the appropriate Ecstasy {@code Type.Form} enum value
      */
     protected static EnumHandle makeFormHandle(Frame frame, TypeConstant type) {
-        xEnum enumForm = (xEnum) INSTANCE.f_container.getTemplate("reflect.Type.Form");
+        xEnum enumForm = (xEnum) frame.f_context.f_container.getTemplate("reflect.Type.Form");
 
         switch (type.getFormat()) {
         case TerminalType:
@@ -1679,7 +1675,7 @@ public class xRTType
         }
 
         ObjectHandle[] ahArg = new ObjectHandle[ctor.getMaxVars()];
-        ahArg[0] = xInt64.makeHandle(nRegister);
+        ahArg[0] = xInt64.makeHandle(frame, nRegister);
 
         switch (clz.getTemplate().construct(frame, ctor, clz, null, ahArg, Op.A_STACK)) {
         case Op.R_NEXT:
@@ -1717,7 +1713,8 @@ public class xRTType
             case Op.R_NEXT:
                 ObjectHandle hElement = frame.popStack();
                 ahValue[i] = hElement instanceof TypeHandle hType
-                        ? xRTType.makeForeignHandle(hType.getUnsafeType())
+                        ? xRTType.makeForeignHandle(frame.f_context.f_container,
+                                hType.getUnsafeType())
                         : Proxy.makeHandle(clzProxy, frame.f_context, hElement, false);
                 break;
 
@@ -1738,7 +1735,8 @@ public class xRTType
      * @return the TypeComposition for an Array of Type
      */
     public static TypeComposition ensureTypeArrayComposition(Container container) {
-        return container.ensureClassComposition(TYPE_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(TYPE_ARRAY_TYPE,
+                container.nativeTemplates().get(xArray.class));
     }
 
     /**
@@ -1783,8 +1781,10 @@ public class xRTType
         // unfortunately, "makeHandle" is called from places where we cannot easily invoke the
         // default initializer, so we need to do it by hand
         TypeHandle hType = fShared
-            ? new TypeHandle(INSTANCE.ensureClass(container, type.getType()), null)
-            : new TypeHandle(INSTANCE.getCanonicalClass(), type.getType());
+            ? new TypeHandle(container.nativeTemplates().
+                    get(xRTType.class).ensureClass(container, type.getType()), null)
+            : new TypeHandle(container.nativeTemplates().
+                    get(xRTType.class).getCanonicalClass(), type.getType());
 
         GenericHandle hMulti = (GenericHandle) hType.getField(null, "multimethods");
         hMulti.setField(null, GenericHandle.OUTER, hType);
@@ -1804,8 +1804,8 @@ public class xRTType
     /**
      * @return a "foreign" {@link TypeHandle} that serves as a proxy handle for the specified type.
      */
-    public static TypeHandle makeForeignHandle(TypeConstant type) {
-        return makeHandle(null, type, false);
+    public static TypeHandle makeForeignHandle(Container container, TypeConstant type) {
+        return makeHandle(container, type, false);
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTType.java
@@ -77,7 +77,7 @@ public class xRTType
         extends xConst
         implements IndexSupport { // for turtle types
 
-    public xRTType(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTType(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
@@ -190,7 +190,7 @@ public class xRTTypeTemplate
      * @return the resulting {@link TypeTemplateHandle}
      */
     public static TypeTemplateHandle makeHandle(Container container, TypeConstant type) {
-        xRTTypeTemplate template = container.nativeTemplates().get(xRTTypeTemplate.class);
+        xRTTypeTemplate template = container.nativeTemplate(xRTTypeTemplate.class);
         ConstantPool    pool     = template.pool();
         TypeComposition clz      = template.ensureClass(container, template.getCanonicalType(),
                 pool.ensureEcstasyTypeConstant("reflect.TypeTemplate"));
@@ -576,7 +576,7 @@ public class xRTTypeTemplate
      * @return the TypeComposition for an Array of TypeTemplate
      */
     public static TypeComposition ensureArrayClassComposition(Container container) {
-        return container.ensureClassComposition(TEMPLATE_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
+        return container.ensureClassComposition(TEMPLATE_ARRAY_TYPE, container.nativeTemplate(xArray.class));
     }
 
     private static TypeConstant TEMPLATE_ARRAY_TYPE;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
@@ -50,7 +50,7 @@ import org.xvm.runtime.template._native.reflect.xRTComponentTemplate.ComponentTe
  */
 public class xRTTypeTemplate
         extends xConst {
-    public xRTTypeTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTTypeTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/reflect/xRTTypeTemplate.java
@@ -50,14 +50,8 @@ import org.xvm.runtime.template._native.reflect.xRTComponentTemplate.ComponentTe
  */
 public class xRTTypeTemplate
         extends xConst {
-    public static xRTTypeTemplate INSTANCE;
-
     public xRTTypeTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -196,8 +190,9 @@ public class xRTTypeTemplate
      * @return the resulting {@link TypeTemplateHandle}
      */
     public static TypeTemplateHandle makeHandle(Container container, TypeConstant type) {
-        ConstantPool    pool = INSTANCE.pool();
-        TypeComposition clz  = INSTANCE.ensureClass(container, INSTANCE.getCanonicalType(),
+        xRTTypeTemplate template = container.nativeTemplates().get(xRTTypeTemplate.class);
+        ConstantPool    pool     = template.pool();
+        TypeComposition clz      = template.ensureClass(container, template.getCanonicalType(),
                 pool.ensureEcstasyTypeConstant("reflect.TypeTemplate"));
         return new TypeTemplateHandle(clz, type);
     }
@@ -235,7 +230,7 @@ public class xRTTypeTemplate
     public int getPropertyDesc(Frame frame, TypeTemplateHandle hType, int iReturn) {
         TypeConstant type  = hType.getDataType();
         String       sDesc = type.getValueString();
-        return frame.assignValue(iReturn, xString.makeHandle(sDesc));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, sDesc));
     }
 
     /**
@@ -268,7 +263,7 @@ public class xRTTypeTemplate
                     : idClz.getPathString();
         }
 
-        return frame.assignValue(iReturn, sName == null ? xNullable.NULL : xString.makeHandle(sName));
+        return frame.assignValue(iReturn, sName == null ? xNullable.NULL : xString.makeHandle(frame, sName));
     }
 
     /**
@@ -581,7 +576,7 @@ public class xRTTypeTemplate
      * @return the TypeComposition for an Array of TypeTemplate
      */
     public static TypeComposition ensureArrayClassComposition(Container container) {
-        return container.ensureClassComposition(TEMPLATE_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(TEMPLATE_ARRAY_TYPE, container.nativeTemplates().get(xArray.class));
     }
 
     private static TypeConstant TEMPLATE_ARRAY_TYPE;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
@@ -125,7 +125,7 @@ public class xLocalClock
             return frame.raiseException(e.getMessage());
         }
 
-        FunctionHandle hCancel = new NativeFunctionHandle(frame.f_context.f_container,
+        FunctionHandle hCancel = new NativeFunctionHandle(frame.container(),
                 (_, _, _) -> {
                     alarm.cancel();
                     return Op.R_NEXT;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
@@ -38,7 +38,7 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.NativeFunctionHandle
  */
 public class xLocalClock
         extends xService {
-    public xLocalClock(Container container, ClassStructure structure, boolean fInstance) {
+    public xLocalClock(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xLocalClock.java
@@ -38,14 +38,8 @@ import org.xvm.runtime.template._native.reflect.xRTFunction.NativeFunctionHandle
  */
 public class xLocalClock
         extends xService {
-    public static xLocalClock INSTANCE;
-
     public xLocalClock(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -131,10 +125,11 @@ public class xLocalClock
             return frame.raiseException(e.getMessage());
         }
 
-        FunctionHandle hCancel = new NativeFunctionHandle((_, _, _) -> {
-            alarm.cancel();
-            return Op.R_NEXT;
-        });
+        FunctionHandle hCancel = new NativeFunctionHandle(frame.f_context.f_container,
+                (_, _, _) -> {
+                    alarm.cancel();
+                    return Op.R_NEXT;
+                });
 
         return frame.assignValue(iReturn, hCancel);
     }
@@ -175,11 +170,11 @@ public class xLocalClock
     // -----  helpers ------------------------------------------------------------------------------
 
     protected JavaLong epochMillis(Frame frame) {
-        return xInt64.makeHandle(System.currentTimeMillis());
+        return xInt64.makeHandle(frame, System.currentTimeMillis());
     }
 
     protected JavaLong timezoneMillis(Frame frame) {
-        return xInt64.makeHandle(TimeZone.getDefault().getOffset(System.currentTimeMillis()));
+        return xInt64.makeHandle(frame, TimeZone.getDefault().getOffset(System.currentTimeMillis()));
     }
 
     /**

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
@@ -39,14 +39,8 @@ import org.xvm.util.ListSet;
  */
 public class xNanosTimer
         extends xService {
-    public static xNanosTimer INSTANCE;
-
     public xNanosTimer(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -146,7 +140,8 @@ public class xNanosTimer
         long           cNanos  = Math.max(0, llPicos.getValue().divUnsigned(PICOS_PER_NANO).getLowValue());
 
         return frame.assignValue(iReturn,
-                hTimer.addAlarm(cNanos, new WeakCallback(frame, hAlarm), hKeepAlive.get()));
+                hTimer.addAlarm(frame.f_context.f_container, cNanos,
+                        new WeakCallback(frame, hAlarm), hKeepAlive.get()));
     }
 
 
@@ -245,7 +240,8 @@ public class xNanosTimer
                 llPicos = new LongLong(Long.MAX_VALUE);
             }
 
-            hDuration.setField(null, "picoseconds", xInt128.INSTANCE.makeHandle(llPicos));
+            hDuration.setField(null, "picoseconds", frame.f_context.f_container.
+                    nativeTemplates().get(xInt128.class).makeHandle(llPicos));
             hDuration.makeImmutable();
 
             return hDuration;
@@ -254,7 +250,8 @@ public class xNanosTimer
         /**
          * @return a "cancel" function for the alarm
          */
-        public FunctionHandle addAlarm(long cNanos, WeakCallback refCallback, boolean fKeepAlive) {
+        public FunctionHandle addAlarm(Container container, long cNanos,
+                                       WeakCallback refCallback, boolean fKeepAlive) {
             Alarm alarm = new Alarm(cNanos, refCallback, fKeepAlive);
 
             synchronized (f_setAlarms) {
@@ -265,7 +262,7 @@ public class xNanosTimer
                 alarm.start();
             }
 
-            return new NativeFunctionHandle((_frame, _ah, _iReturn) -> {
+            return new NativeFunctionHandle(container, (_frame, _ah, _iReturn) -> {
                 alarm.cancel();
                 return Op.R_NEXT;
             });

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
@@ -39,7 +39,7 @@ import org.xvm.util.ListSet;
  */
 public class xNanosTimer
         extends xService {
-    public xNanosTimer(Container container, ClassStructure structure, boolean fInstance) {
+    public xNanosTimer(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/temporal/xNanosTimer.java
@@ -140,7 +140,7 @@ public class xNanosTimer
         long           cNanos  = Math.max(0, llPicos.getValue().divUnsigned(PICOS_PER_NANO).getLowValue());
 
         return frame.assignValue(iReturn,
-                hTimer.addAlarm(frame.f_context.f_container, cNanos,
+                hTimer.addAlarm(frame.container(), cNanos,
                         new WeakCallback(frame, hAlarm), hKeepAlive.get()));
     }
 
@@ -240,8 +240,8 @@ public class xNanosTimer
                 llPicos = new LongLong(Long.MAX_VALUE);
             }
 
-            hDuration.setField(null, "picoseconds", frame.f_context.f_container.
-                    nativeTemplates().get(xInt128.class).makeHandle(llPicos));
+            hDuration.setField(null, "picoseconds",
+                    frame.nativeTemplate(xInt128.class).makeHandle(llPicos));
             hDuration.makeImmutable();
 
             return hDuration;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
@@ -68,10 +68,10 @@ import org.xvm.runtime.template._native.reflect.xRTFunction;
  */
 public class xRTConnector
         extends xService {
-    public xRTConnector(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTConnector(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
 
-        if (fInstance) {
+        if (fBaseTemplate) {
             s_sAgent = "Mozilla/5.0 (compatible; Ecstasy/"
                        + structure.getFileStructure().getModule().getVersionString()
                        + ')' ;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
@@ -133,7 +133,7 @@ public class xRTConnector
                     ? invokeSendRequest(frame, hConnector, (StringHandle) ahArg[0],
                         (StringHandle) ahArg[1], (ArrayHandle) ahArg[2],
                         (ArrayHandle) ahArg[3], (ArrayHandle) ahArg[4], aiReturn)
-                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                         callN(frame, hConnector, ahArg, aiReturn);
         }
         }
@@ -151,9 +151,9 @@ public class xRTConnector
         ArrayHandle hNames  = m_hDefaultNames;
         ArrayHandle hValues = m_hDefaultValues;
         if (hNames == null) {
-            m_hDefaultNames  = hNames  = xString.makeArrayHandle(frame.f_context.f_container,
+            m_hDefaultNames  = hNames  = xString.makeArrayHandle(frame.container(),
                     new String[] {"User-Agent"});
-            m_hDefaultValues = hValues = xString.makeArrayHandle(frame.f_context.f_container, new String[] {s_sAgent});
+            m_hDefaultValues = hValues = xString.makeArrayHandle(frame.container(), new String[] {s_sAgent});
         }
 
         return frame.assignValues(aiReturn, hNames, hValues);
@@ -258,8 +258,8 @@ public class xRTConnector
 
             return frame.assignValues(aiReturn,
                     xInt64.makeHandle(frame, nResponseCode),
-                    xString.makeArrayHandle(frame.f_context.f_container, asResponseNames),
-                    xString.makeArrayHandle(frame.f_context.f_container, asResponseValues),
+                    xString.makeArrayHandle(frame.container(), asResponseNames),
+                    xString.makeArrayHandle(frame.container(), asResponseValues),
                     hResponseBytes
                     );
         } catch (Exception e) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTConnector.java
@@ -68,13 +68,10 @@ import org.xvm.runtime.template._native.reflect.xRTFunction;
  */
 public class xRTConnector
         extends xService {
-    public static xRTConnector INSTANCE;
-
     public xRTConnector(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
 
         if (fInstance) {
-            INSTANCE = this;
             s_sAgent = "Mozilla/5.0 (compatible; Ecstasy/"
                        + structure.getFileStructure().getModule().getVersionString()
                        + ')' ;
@@ -136,7 +133,7 @@ public class xRTConnector
                     ? invokeSendRequest(frame, hConnector, (StringHandle) ahArg[0],
                         (StringHandle) ahArg[1], (ArrayHandle) ahArg[2],
                         (ArrayHandle) ahArg[3], (ArrayHandle) ahArg[4], aiReturn)
-                    : xRTFunction.makeAsyncNativeHandle(method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
                         callN(frame, hConnector, ahArg, aiReturn);
         }
         }
@@ -154,8 +151,9 @@ public class xRTConnector
         ArrayHandle hNames  = m_hDefaultNames;
         ArrayHandle hValues = m_hDefaultValues;
         if (hNames == null) {
-            m_hDefaultNames  = hNames  = xString.makeArrayHandle(new String[] {"User-Agent"});
-            m_hDefaultValues = hValues = xString.makeArrayHandle(new String[] {s_sAgent});
+            m_hDefaultNames  = hNames  = xString.makeArrayHandle(frame.f_context.f_container,
+                    new String[] {"User-Agent"});
+            m_hDefaultValues = hValues = xString.makeArrayHandle(frame.f_context.f_container, new String[] {s_sAgent});
         }
 
         return frame.assignValues(aiReturn, hNames, hValues);
@@ -259,9 +257,9 @@ public class xRTConnector
                     : xArray.makeByteArrayHandle(abResponse, Mutability.Constant);
 
             return frame.assignValues(aiReturn,
-                    xInt64.makeHandle(nResponseCode),
-                    xString.makeArrayHandle(asResponseNames),
-                    xString.makeArrayHandle(asResponseValues),
+                    xInt64.makeHandle(frame, nResponseCode),
+                    xString.makeArrayHandle(frame.f_context.f_container, asResponseNames),
+                    xString.makeArrayHandle(frame.f_context.f_container, asResponseValues),
                     hResponseBytes
                     );
         } catch (Exception e) {

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
@@ -91,7 +91,7 @@ import org.xvm.util.Handy;
  */
 public class xRTServer
         extends xService {
-    public xRTServer(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTServer(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
@@ -91,14 +91,8 @@ import org.xvm.util.Handy;
  */
 public class xRTServer
         extends xService {
-    public static xRTServer INSTANCE;
-
     public xRTServer(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -190,19 +184,19 @@ public class xRTServer
         case "setHeaders":
             return frame.f_context == hServer.f_context
                     ? invokeSetHeaders(frame, ahArg)
-                    : xRTFunction.makeAsyncNativeHandle(method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
                             call1(frame, hServer, ahArg, iReturn);
 
         case "setBodyBytes":
             return frame.f_context == hServer.f_context
                     ? invokeSetBodyBytes(frame, ahArg)
-                    : xRTFunction.makeAsyncNativeHandle(method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
                             call1(frame, hServer, ahArg, iReturn);
 
         case "readBody":
             return frame.f_context == hServer.f_context
                     ? invokeReadBody(frame, ahArg, iReturn)
-                    : xRTFunction.makeAsyncNativeHandle(method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
                             call1(frame, hServer, ahArg, iReturn);
 
         case "closeImpl":
@@ -417,7 +411,8 @@ public class xRTServer
         assert method != null;
 
         FunctionHandle hFunction =
-                xRTFunction.makeInternalHandle(frame, method).bindTarget(frame, hWrapper);
+                xRTFunction.makeInternalHandle(frame.f_context.f_container, method).
+                        bindTarget(frame, hWrapper);
         return new RequestHandler(hWrapper.f_context, hFunction, hServer);
     }
 
@@ -439,7 +434,7 @@ public class xRTServer
 
         return frame.assignValues(aiResult,
                 xByteArray.makeByteArrayHandle(ab, Mutability.Constant),
-                xUInt16.INSTANCE.makeJavaLong(nPort));
+                nativeTemplates().get(xUInt16.class).makeJavaLong(nPort));
     }
 
     /**
@@ -452,7 +447,7 @@ public class xRTServer
 
         return frame.assignValues(aiResult,
                 xByteArray.makeByteArrayHandle(ab, Mutability.Constant),
-                xUInt16.INSTANCE.makeJavaLong(nPort));
+                nativeTemplates().get(xUInt16.class).makeJavaLong(nPort));
     }
 
     /**
@@ -467,7 +462,7 @@ public class xRTServer
         return sName == null
             ? frame.assignValue(aiResult[0], xBoolean.FALSE)
             : frame.assignValues(aiResult, xBoolean.TRUE,
-                    xString.makeHandle(sName), xUInt16.INSTANCE.makeJavaLong(nPort));
+                    xString.makeHandle(frame, sName), nativeTemplates().get(xUInt16.class).makeJavaLong(nPort));
     }
 
     /**
@@ -476,7 +471,7 @@ public class xRTServer
     private int invokeGetProtocol(Frame frame, HttpContextHandle hCtx, int iResult) {
         String sProtocol = hCtx.f_exchange.getProtocol();
 
-        return frame.assignValue(iResult, xString.makeHandle(sProtocol));
+        return frame.assignValue(iResult, xString.makeHandle(frame, sProtocol));
     }
 
     /**
@@ -486,7 +481,7 @@ public class xRTServer
         Headers headers = hCtx.f_exchange.getRequestHeaders();
 
         return frame.assignValue(iResult,
-                xString.makeArrayHandle(headers.keySet().toArray(Utils.NO_NAMES)));
+                xString.makeArrayHandle(frame.f_context.f_container, headers.keySet().toArray(Utils.NO_NAMES)));
     }
 
     /**
@@ -504,7 +499,7 @@ public class xRTServer
         }
 
         return frame.assignValues(aiResult, xBoolean.TRUE,
-                xString.makeArrayHandle(listValues.toArray(Utils.NO_NAMES)));
+                xString.makeArrayHandle(frame.f_context.f_container, listValues.toArray(Utils.NO_NAMES)));
     }
 
     /**
@@ -672,10 +667,13 @@ public class xRTServer
         }
 
         private ObjectHandle[] createArguments(HttpExchange exchange) {
+            Container         container = f_hServer.getComposition().getContainer();
             ObjectHandle      hBinding  = f_hServer.getBinding();
-            HttpContextHandle hContext  = new HttpContextHandle(exchange);
-            StringHandle      hURI      = xString.makeHandle(exchange.getRequestURI().toASCIIString());
-            StringHandle      hMethod   = xString.makeHandle(exchange.getRequestMethod());
+            HttpContextHandle hContext  = new HttpContextHandle(container, exchange);
+            StringHandle      hURI      = xString.makeHandle(container,
+                                              exchange.getRequestURI().toASCIIString());
+            StringHandle      hMethod   = xString.makeHandle(container,
+                                              exchange.getRequestMethod());
             BooleanHandle     hTls      = xBoolean.makeHandle(exchange instanceof HttpsExchange);
             return new ObjectHandle[]{hBinding, hContext, hURI, hMethod, hTls};
         }
@@ -952,8 +950,8 @@ public class xRTServer
      */
     protected static class HttpContextHandle
                 extends ObjectHandle {
-        public HttpContextHandle(HttpExchange exchange) {
-            super(xObject.INSTANCE.getCanonicalClass());
+        public HttpContextHandle(Container container, HttpExchange exchange) {
+            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
 
             f_exchange = exchange;
             m_fMutable = false;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/web/xRTServer.java
@@ -184,19 +184,19 @@ public class xRTServer
         case "setHeaders":
             return frame.f_context == hServer.f_context
                     ? invokeSetHeaders(frame, ahArg)
-                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                             call1(frame, hServer, ahArg, iReturn);
 
         case "setBodyBytes":
             return frame.f_context == hServer.f_context
                     ? invokeSetBodyBytes(frame, ahArg)
-                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                             call1(frame, hServer, ahArg, iReturn);
 
         case "readBody":
             return frame.f_context == hServer.f_context
                     ? invokeReadBody(frame, ahArg, iReturn)
-                    : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                    : xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                             call1(frame, hServer, ahArg, iReturn);
 
         case "closeImpl":
@@ -411,7 +411,7 @@ public class xRTServer
         assert method != null;
 
         FunctionHandle hFunction =
-                xRTFunction.makeInternalHandle(frame.f_context.f_container, method).
+                xRTFunction.makeInternalHandle(frame.container(), method).
                         bindTarget(frame, hWrapper);
         return new RequestHandler(hWrapper.f_context, hFunction, hServer);
     }
@@ -434,7 +434,7 @@ public class xRTServer
 
         return frame.assignValues(aiResult,
                 xByteArray.makeByteArrayHandle(ab, Mutability.Constant),
-                nativeTemplates().get(xUInt16.class).makeJavaLong(nPort));
+                f_container.nativeTemplate(xUInt16.class).makeJavaLong(nPort));
     }
 
     /**
@@ -447,7 +447,7 @@ public class xRTServer
 
         return frame.assignValues(aiResult,
                 xByteArray.makeByteArrayHandle(ab, Mutability.Constant),
-                nativeTemplates().get(xUInt16.class).makeJavaLong(nPort));
+                f_container.nativeTemplate(xUInt16.class).makeJavaLong(nPort));
     }
 
     /**
@@ -462,7 +462,7 @@ public class xRTServer
         return sName == null
             ? frame.assignValue(aiResult[0], xBoolean.FALSE)
             : frame.assignValues(aiResult, xBoolean.TRUE,
-                    xString.makeHandle(frame, sName), nativeTemplates().get(xUInt16.class).makeJavaLong(nPort));
+                    xString.makeHandle(frame, sName), f_container.nativeTemplate(xUInt16.class).makeJavaLong(nPort));
     }
 
     /**
@@ -481,7 +481,7 @@ public class xRTServer
         Headers headers = hCtx.f_exchange.getRequestHeaders();
 
         return frame.assignValue(iResult,
-                xString.makeArrayHandle(frame.f_context.f_container, headers.keySet().toArray(Utils.NO_NAMES)));
+                xString.makeArrayHandle(frame.container(), headers.keySet().toArray(Utils.NO_NAMES)));
     }
 
     /**
@@ -499,7 +499,7 @@ public class xRTServer
         }
 
         return frame.assignValues(aiResult, xBoolean.TRUE,
-                xString.makeArrayHandle(frame.f_context.f_container, listValues.toArray(Utils.NO_NAMES)));
+                xString.makeArrayHandle(frame.container(), listValues.toArray(Utils.NO_NAMES)));
     }
 
     /**
@@ -951,7 +951,7 @@ public class xRTServer
     protected static class HttpContextHandle
                 extends ObjectHandle {
         public HttpContextHandle(Container container, HttpExchange exchange) {
-            super(container.nativeTemplates().get(xObject.class).getCanonicalClass());
+            super(container.nativeTemplate(xObject.class).getCanonicalClass());
 
             f_exchange = exchange;
             m_fMutable = false;

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/xRTServiceControl.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/xRTServiceControl.java
@@ -28,14 +28,8 @@ import org.xvm.runtime.template._native.reflect.xRTFunction;
  */
 public class xRTServiceControl
         extends ClassTemplate {
-    public static xRTServiceControl INSTANCE;
-
     public xRTServiceControl(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -79,7 +73,8 @@ public class xRTServiceControl
             }
             return frame.f_context == context
                 ? context.shutdown(frame)
-                : xRTFunction.makeAsyncNativeHandle(method).call1(frame, hService, ahArg, iReturn);
+                : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                        call1(frame, hService, ahArg, iReturn);
         }
 
         case "kill":
@@ -112,7 +107,8 @@ public class xRTServiceControl
     // ----- ObjectHandle --------------------------------------------------------------------------
 
     public static ObjectHandle makeHandle(ServiceContext context) {
-        return new ControlHandle(INSTANCE.m_clzControl, context);
+        return new ControlHandle(context.f_container.nativeTemplates().
+                get(xRTServiceControl.class).m_clzControl, context);
     }
 
     protected static class ControlHandle

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/xRTServiceControl.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/xRTServiceControl.java
@@ -73,7 +73,7 @@ public class xRTServiceControl
             }
             return frame.f_context == context
                 ? context.shutdown(frame)
-                : xRTFunction.makeAsyncNativeHandle(frame.f_context.f_container, method).
+                : xRTFunction.makeAsyncNativeHandle(frame.container(), method).
                         call1(frame, hService, ahArg, iReturn);
         }
 
@@ -107,8 +107,7 @@ public class xRTServiceControl
     // ----- ObjectHandle --------------------------------------------------------------------------
 
     public static ObjectHandle makeHandle(ServiceContext context) {
-        return new ControlHandle(context.f_container.nativeTemplates().
-                get(xRTServiceControl.class).m_clzControl, context);
+        return new ControlHandle(context.f_container.nativeTemplate(xRTServiceControl.class).m_clzControl, context);
     }
 
     protected static class ControlHandle

--- a/javatools/src/main/java/org/xvm/runtime/template/_native/xRTServiceControl.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/_native/xRTServiceControl.java
@@ -28,7 +28,7 @@ import org.xvm.runtime.template._native.reflect.xRTFunction;
  */
 public class xRTServiceControl
         extends ClassTemplate {
-    public xRTServiceControl(Container container, ClassStructure structure, boolean fInstance) {
+    public xRTServiceControl(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomic.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomic.java
@@ -33,7 +33,7 @@ import org.xvm.runtime.template.reflect.xVar;
  */
 public class xAtomic
         extends xVar {
-    public xAtomic(Container container, ClassStructure structure, boolean fInstance) {
+    public xAtomic(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomic.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomic.java
@@ -46,19 +46,19 @@ public class xAtomic
         Map<TypeConstant, xAtomic> mapTemplates = new HashMap<>();
 
         // Int128, UInt128
-        mapTemplates.put(pool.typeInt128(),  new xAtomicInt128(nativeTemplates().get(xInt128.class)));
-        mapTemplates.put(pool.typeUInt128(), new xAtomicInt128(nativeTemplates().get(xUInt128.class)));
+        mapTemplates.put(pool.typeInt128(),  new xAtomicInt128(f_container.nativeTemplate(xInt128.class)));
+        mapTemplates.put(pool.typeUInt128(), new xAtomicInt128(f_container.nativeTemplate(xUInt128.class)));
 
-        mapTemplates.put(pool.typeInt8(),    new xAtomicIntNumber(nativeTemplates().get(xInt8.class)));
-        mapTemplates.put(pool.typeInt16(),   new xAtomicIntNumber(nativeTemplates().get(xInt16.class)));
-        mapTemplates.put(pool.typeInt32(),   new xAtomicIntNumber(nativeTemplates().get(xInt32.class)));
-        mapTemplates.put(pool.typeInt64(),   new xAtomicIntNumber(nativeTemplates().get(xInt64.class)));
+        mapTemplates.put(pool.typeInt8(),    new xAtomicIntNumber(f_container.nativeTemplate(xInt8.class)));
+        mapTemplates.put(pool.typeInt16(),   new xAtomicIntNumber(f_container.nativeTemplate(xInt16.class)));
+        mapTemplates.put(pool.typeInt32(),   new xAtomicIntNumber(f_container.nativeTemplate(xInt32.class)));
+        mapTemplates.put(pool.typeInt64(),   new xAtomicIntNumber(f_container.nativeTemplate(xInt64.class)));
 
-        mapTemplates.put(pool.typeNibble(),  new xAtomicIntNumber(nativeTemplates().get(xNibble.class)));
-        mapTemplates.put(pool.typeUInt8(),   new xAtomicIntNumber(nativeTemplates().get(xUInt8.class)));
-        mapTemplates.put(pool.typeUInt16(),  new xAtomicIntNumber(nativeTemplates().get(xUInt16.class)));
-        mapTemplates.put(pool.typeUInt32(),  new xAtomicIntNumber(nativeTemplates().get(xUInt32.class)));
-        mapTemplates.put(pool.typeUInt64(),  new xAtomicIntNumber(nativeTemplates().get(xUInt64.class)));
+        mapTemplates.put(pool.typeNibble(),  new xAtomicIntNumber(f_container.nativeTemplate(xNibble.class)));
+        mapTemplates.put(pool.typeUInt8(),   new xAtomicIntNumber(f_container.nativeTemplate(xUInt8.class)));
+        mapTemplates.put(pool.typeUInt16(),  new xAtomicIntNumber(f_container.nativeTemplate(xUInt16.class)));
+        mapTemplates.put(pool.typeUInt32(),  new xAtomicIntNumber(f_container.nativeTemplate(xUInt32.class)));
+        mapTemplates.put(pool.typeUInt64(),  new xAtomicIntNumber(f_container.nativeTemplate(xUInt64.class)));
 
         NUMBER_TEMPLATES = mapTemplates;
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomic.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomic.java
@@ -33,14 +33,8 @@ import org.xvm.runtime.template.reflect.xVar;
  */
 public class xAtomic
         extends xVar {
-    public static xAtomic INSTANCE;
-
     public xAtomic(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -52,19 +46,19 @@ public class xAtomic
         Map<TypeConstant, xAtomic> mapTemplates = new HashMap<>();
 
         // Int128, UInt128
-        mapTemplates.put(pool.typeInt128(),  new xAtomicInt128(xInt128.INSTANCE));
-        mapTemplates.put(pool.typeUInt128(), new xAtomicInt128(xUInt128.INSTANCE));
+        mapTemplates.put(pool.typeInt128(),  new xAtomicInt128(nativeTemplates().get(xInt128.class)));
+        mapTemplates.put(pool.typeUInt128(), new xAtomicInt128(nativeTemplates().get(xUInt128.class)));
 
-        mapTemplates.put(pool.typeInt8(),    new xAtomicIntNumber(xInt8.INSTANCE));
-        mapTemplates.put(pool.typeInt16(),   new xAtomicIntNumber(xInt16.INSTANCE));
-        mapTemplates.put(pool.typeInt32(),   new xAtomicIntNumber(xInt32.INSTANCE));
-        mapTemplates.put(pool.typeInt64(),   new xAtomicIntNumber(xInt64.INSTANCE));
+        mapTemplates.put(pool.typeInt8(),    new xAtomicIntNumber(nativeTemplates().get(xInt8.class)));
+        mapTemplates.put(pool.typeInt16(),   new xAtomicIntNumber(nativeTemplates().get(xInt16.class)));
+        mapTemplates.put(pool.typeInt32(),   new xAtomicIntNumber(nativeTemplates().get(xInt32.class)));
+        mapTemplates.put(pool.typeInt64(),   new xAtomicIntNumber(nativeTemplates().get(xInt64.class)));
 
-        mapTemplates.put(pool.typeNibble(),  new xAtomicIntNumber(xNibble.INSTANCE));
-        mapTemplates.put(pool.typeUInt8(),   new xAtomicIntNumber(xUInt8.INSTANCE));
-        mapTemplates.put(pool.typeUInt16(),  new xAtomicIntNumber(xUInt16.INSTANCE));
-        mapTemplates.put(pool.typeUInt32(),  new xAtomicIntNumber(xUInt32.INSTANCE));
-        mapTemplates.put(pool.typeUInt64(),  new xAtomicIntNumber(xUInt64.INSTANCE));
+        mapTemplates.put(pool.typeNibble(),  new xAtomicIntNumber(nativeTemplates().get(xNibble.class)));
+        mapTemplates.put(pool.typeUInt8(),   new xAtomicIntNumber(nativeTemplates().get(xUInt8.class)));
+        mapTemplates.put(pool.typeUInt16(),  new xAtomicIntNumber(nativeTemplates().get(xUInt16.class)));
+        mapTemplates.put(pool.typeUInt32(),  new xAtomicIntNumber(nativeTemplates().get(xUInt32.class)));
+        mapTemplates.put(pool.typeUInt64(),  new xAtomicIntNumber(nativeTemplates().get(xUInt64.class)));
 
         NUMBER_TEMPLATES = mapTemplates;
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomicInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomicInt128.java
@@ -8,6 +8,7 @@ import org.xvm.asm.MethodStructure;
 import org.xvm.asm.Op;
 
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.TypeComposition;
 
@@ -25,7 +26,8 @@ import org.xvm.runtime.template.numbers.LongLong;
 public class xAtomicInt128
         extends xAtomic {
     public xAtomicInt128(BaseInt128 templateIntBase) {
-        super(templateIntBase.f_container, xAtomicIntNumber.INSTANCE.getStructure(), false);
+        super(templateIntBase.f_container, NativeTemplates.of(templateIntBase).
+                get(xAtomicIntNumber.class).getStructure(), false);
 
         f_templateReferent = templateIntBase;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomicIntNumber.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomicIntNumber.java
@@ -10,6 +10,7 @@ import org.xvm.asm.Op;
 
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.JavaLong;
 import org.xvm.runtime.TypeComposition;
@@ -25,19 +26,15 @@ import org.xvm.runtime.template.numbers.xConstrainedInteger;
  */
 public class xAtomicIntNumber
         extends xAtomic {
-    public static xAtomicIntNumber INSTANCE;
-
     public xAtomicIntNumber(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
 
-        if (fInstance) {
-            INSTANCE = this;
-        }
         f_templateReferent = null;
     }
 
     public xAtomicIntNumber(xConstrainedInteger templateIntNumber) {
-        super(templateIntNumber.f_container, INSTANCE.f_struct, false);
+        super(templateIntNumber.f_container, NativeTemplates.of(templateIntNumber).
+                get(xAtomicIntNumber.class).f_struct, false);
 
         f_templateReferent = templateIntNumber;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomicIntNumber.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xAtomicIntNumber.java
@@ -26,7 +26,7 @@ import org.xvm.runtime.template.numbers.xConstrainedInteger;
  */
 public class xAtomicIntNumber
         extends xAtomic {
-    public xAtomicIntNumber(Container container, ClassStructure structure, boolean fInstance) {
+    public xAtomicIntNumber(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
 
         f_templateReferent = null;

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xFuture.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xFuture.java
@@ -39,16 +39,11 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xFuture
         extends xVar {
-    public static xFuture INSTANCE;
     public static TypeConstant TYPE;
     public static xEnum COMPLETION;
 
     public xFuture(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -56,7 +51,7 @@ public class xFuture
         ConstantPool  pool     = pool();
         ClassConstant idMixin  = (ClassConstant) f_struct.getIdentityConstant();
         Annotation    anno     = pool.ensureAnnotation(idMixin);
-        TypeConstant  typeVar  = xVar.INSTANCE.getCanonicalType();
+        TypeConstant  typeVar  = nativeTemplates().get(xVar.class).getCanonicalType();
 
         TYPE       = pool.ensureAnnotatedTypeConstant(typeVar, anno);
         COMPLETION = (xEnum) f_container.getTemplate("annotations.Future.Completion");
@@ -749,8 +744,10 @@ public class xFuture
 
     // ----- ObjectHandle --------------------------------------------------------------------------
 
-    public static FutureHandle makeHandle(CompletableFuture<ObjectHandle> future) {
-        return makeHandle(INSTANCE.getCanonicalClass(), future);
+    public static FutureHandle makeHandle(Container container,
+                                          CompletableFuture<ObjectHandle> future) {
+        return makeHandle(container.nativeTemplates().get(xFuture.class).getCanonicalClass(),
+                future);
     }
 
     public static FutureHandle makeHandle(TypeComposition clz, CompletableFuture<ObjectHandle> future) {

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xFuture.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xFuture.java
@@ -42,7 +42,7 @@ public class xFuture
     public static TypeConstant TYPE;
     public static xEnum COMPLETION;
 
-    public xFuture(Container container, ClassStructure structure, boolean fInstance) {
+    public xFuture(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xFuture.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xFuture.java
@@ -51,7 +51,7 @@ public class xFuture
         ConstantPool  pool     = pool();
         ClassConstant idMixin  = (ClassConstant) f_struct.getIdentityConstant();
         Annotation    anno     = pool.ensureAnnotation(idMixin);
-        TypeConstant  typeVar  = nativeTemplates().get(xVar.class).getCanonicalType();
+        TypeConstant  typeVar  = f_container.nativeTemplate(xVar.class).getCanonicalType();
 
         TYPE       = pool.ensureAnnotatedTypeConstant(typeVar, anno);
         COMPLETION = (xEnum) f_container.getTemplate("annotations.Future.Completion");
@@ -746,7 +746,7 @@ public class xFuture
 
     public static FutureHandle makeHandle(Container container,
                                           CompletableFuture<ObjectHandle> future) {
-        return makeHandle(container.nativeTemplates().get(xFuture.class).getCanonicalClass(),
+        return makeHandle(container.nativeTemplate(xFuture.class).getCanonicalClass(),
                 future);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xInject.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xInject.java
@@ -33,7 +33,7 @@ import org.xvm.runtime.template.reflect.xRef;
  */
 public class xInject
         extends xRef {
-    public xInject(Container container, ClassStructure structure, boolean fInstance) {
+    public xInject(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xInject.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xInject.java
@@ -33,14 +33,8 @@ import org.xvm.runtime.template.reflect.xRef;
  */
 public class xInject
         extends xRef {
-    public static xInject INSTANCE;
-
     public xInject(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -82,7 +76,7 @@ public class xInject
         if (aParams.length < 2) {
             // opts are not specified; the handle could be trivially initialized on-the-spot
             InjectedHandle hInject = new InjectedHandle(clazz.ensureAccess(Access.PUBLIC), sName, sResource);
-            hInject.setField(frame, "resourceName", xString.makeHandle(sResource));
+            hInject.setField(frame, "resourceName", xString.makeHandle(frame, sResource));
             hInject.setField(frame, "opts", xNullable.NULL);
             hInject.makeImmutable();
             return hInject;

--- a/javatools/src/main/java/org/xvm/runtime/template/annotations/xLazy.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/annotations/xLazy.java
@@ -26,7 +26,7 @@ import org.xvm.runtime.template.xException;
  */
 public class xLazy
         extends xVar {
-    public xLazy(Container container, ClassStructure structure, boolean fInstance) {
+    public xLazy(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/BitBasedArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/BitBasedArray.java
@@ -11,8 +11,6 @@ import org.xvm.runtime.Container;
  */
 public abstract class BitBasedArray
         extends xArray {
-    public static BitBasedArray INSTANCE;
-
     protected BitBasedArray(Container container, ClassStructure structure) {
         super(container, structure, false);
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
@@ -84,8 +84,8 @@ public class xArray
         ConstantPool              pool         = f_container.getConstantPool();
         Map<TypeConstant, xArray> mapTemplates = new HashMap<>();
 
-        mapTemplates.put(pool.typeBit(),  nativeTemplates().get(xBitArray.class));
-        mapTemplates.put(pool.typeByte(), nativeTemplates().get(xByteArray.class));
+        mapTemplates.put(pool.typeBit(),  f_container.nativeTemplate(xBitArray.class));
+        mapTemplates.put(pool.typeByte(), f_container.nativeTemplate(xByteArray.class));
 
         ARRAY_TEMPLATES = mapTemplates;
 
@@ -119,7 +119,7 @@ public class xArray
         }
 
         // cache helper methods
-        FILL_FROM_ITERABLE = nativeTemplates().get(xRTDelegate.class).getStructure().findMethod("fillFromIterable", 4);
+        FILL_FROM_ITERABLE = f_container.nativeTemplate(xRTDelegate.class).getStructure().findMethod("fillFromIterable", 4);
         CREATE_LIST_SET    = Utils.CONST_HELPER.findMethod("createListSet", 2);
 
         // cache Mutability template
@@ -481,10 +481,10 @@ public class xArray
                     : Mutability.Fixed;
 
             DelegateHandle hView  =
-                    nativeTemplates().get(xRTViewToBit.class).createBitViewDelegate(hArray.m_hDelegate, mutability);
+                    f_container.nativeTemplate(xRTViewToBit.class).createBitViewDelegate(hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn,
-                    new ArrayHandle(nativeTemplates().get(xBitArray.class).getCanonicalClass(), hView, mutability));
+                    new ArrayHandle(f_container.nativeTemplate(xBitArray.class).getCanonicalClass(), hView, mutability));
         }
 
         case "clear": {
@@ -561,8 +561,8 @@ public class xArray
             TypeConstant   typeRef   = pool.ensureParameterizedTypeConstant(
                                            pool.typeVar(), hDelegate.getType());
 
-            ClassComposition clzRef  = frame.f_context.f_container.ensureClassComposition(typeRef,
-                    nativeTemplates().get(xRef.class));
+            ClassComposition clzRef  = frame.container().ensureClassComposition(typeRef,
+                    f_container.nativeTemplate(xRef.class));
             RefHandle        hRef    = new RefHandle(clzRef, "delegate", hDelegate);
 
             return frame.assignValue(iReturn, hRef);

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
@@ -65,7 +65,7 @@ public class xArray
         implements IndexSupport {
     public static xEnum  MUTABILITY;
 
-    public xArray(Container container, ClassStructure structure, boolean fInstance) {
+    public xArray(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xArray.java
@@ -22,6 +22,7 @@ import org.xvm.asm.constants.TypeConstant;
 import org.xvm.runtime.ClassComposition;
 import org.xvm.runtime.Container;
 import org.xvm.runtime.Frame;
+import org.xvm.runtime.NativeTemplates;
 import org.xvm.runtime.ObjectHandle;
 import org.xvm.runtime.ObjectHandle.ExceptionHandle;
 import org.xvm.runtime.ObjectHandle.GenericHandle;
@@ -62,20 +63,15 @@ import org.xvm.util.Handy;
 public class xArray
         extends ClassTemplate
         implements IndexSupport {
-    public static xArray INSTANCE;
     public static xEnum  MUTABILITY;
 
     public xArray(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xArray.class)) {
             registerNativeTemplate(new xBitArray   (f_container, f_struct, true));
             registerNativeTemplate(new xByteArray  (f_container, f_struct, true));
             registerNativeTemplate(new xNibbleArray(f_container, f_struct, true));
@@ -88,8 +84,8 @@ public class xArray
         ConstantPool              pool         = f_container.getConstantPool();
         Map<TypeConstant, xArray> mapTemplates = new HashMap<>();
 
-        mapTemplates.put(pool.typeBit(),  xBitArray.INSTANCE);
-        mapTemplates.put(pool.typeByte(), xByteArray.INSTANCE);
+        mapTemplates.put(pool.typeBit(),  nativeTemplates().get(xBitArray.class));
+        mapTemplates.put(pool.typeByte(), nativeTemplates().get(xByteArray.class));
 
         ARRAY_TEMPLATES = mapTemplates;
 
@@ -123,7 +119,7 @@ public class xArray
         }
 
         // cache helper methods
-        FILL_FROM_ITERABLE = xRTDelegate.INSTANCE.getStructure().findMethod("fillFromIterable", 4);
+        FILL_FROM_ITERABLE = nativeTemplates().get(xRTDelegate.class).getStructure().findMethod("fillFromIterable", 4);
         CREATE_LIST_SET    = Utils.CONST_HELPER.findMethod("createListSet", 2);
 
         // cache Mutability template
@@ -322,7 +318,7 @@ public class xArray
                     int                 cArgs       = hfnSupplier.getVarCount();
                     ObjectHandle[]      ahArg       = new ObjectHandle[cArgs];
                     Utils.ValueSupplier supplier    = (frameCaller, index) -> {
-                        ahArg[0] = xInt64.makeHandle(index);
+                        ahArg[0] = xInt64.makeHandle(frame, index);
                         return hfnSupplier.call1(frameCaller, null, ahArg, Op.A_STACK);
                     };
                     return new Utils.FillArray(hArray, cSize, supplier, iReturn).doNext(frame);
@@ -485,10 +481,10 @@ public class xArray
                     : Mutability.Fixed;
 
             DelegateHandle hView  =
-                    xRTViewToBit.INSTANCE.createBitViewDelegate(hArray.m_hDelegate, mutability);
+                    nativeTemplates().get(xRTViewToBit.class).createBitViewDelegate(hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn,
-                    new ArrayHandle(xBitArray.INSTANCE.getCanonicalClass(), hView, mutability));
+                    new ArrayHandle(nativeTemplates().get(xBitArray.class).getCanonicalClass(), hView, mutability));
         }
 
         case "clear": {
@@ -565,7 +561,8 @@ public class xArray
             TypeConstant   typeRef   = pool.ensureParameterizedTypeConstant(
                                            pool.typeVar(), hDelegate.getType());
 
-            ClassComposition clzRef  = frame.f_context.f_container.ensureClassComposition(typeRef, xRef.INSTANCE);
+            ClassComposition clzRef  = frame.f_context.f_container.ensureClassComposition(typeRef,
+                    nativeTemplates().get(xRef.class));
             RefHandle        hRef    = new RefHandle(clzRef, "delegate", hDelegate);
 
             return frame.assignValue(iReturn, hRef);
@@ -909,7 +906,8 @@ public class xArray
      * @return a Bit array handle
      */
     public static ArrayHandle makeBitArrayHandle(byte[] abValue, int cBits, Mutability mutability) {
-        DelegateHandle hDelegate = xRTBitDelegate.INSTANCE.makeHandle(abValue, cBits, mutability);
+        DelegateHandle hDelegate = NativeTemplates.of(BIT_ARRAY_CLZ).
+                get(xRTBitDelegate.class).makeHandle(abValue, cBits, mutability);
         return new ArrayHandle(BIT_ARRAY_CLZ, hDelegate, mutability);
     }
 
@@ -917,7 +915,8 @@ public class xArray
      * @return a Boolean array handle
      */
     public static ArrayHandle makeBooleanArrayHandle(byte[] abValue, int cBits, Mutability mutability) {
-        DelegateHandle hDelegate = xRTBooleanDelegate.INSTANCE.makeHandle(abValue, cBits, mutability);
+        DelegateHandle hDelegate = NativeTemplates.of(BOOLEAN_ARRAY_CLZ).
+                get(xRTBooleanDelegate.class).makeHandle(abValue, cBits, mutability);
         return new ArrayHandle(BOOLEAN_ARRAY_CLZ, hDelegate, mutability);
     }
 
@@ -935,7 +934,8 @@ public class xArray
         if (abValue.length == 0 && mutability == Mutability.Constant) {
             return ensureEmptyByteArray();
         }
-        DelegateHandle hDelegate = xRTUInt8Delegate.INSTANCE.makeHandle(abValue, cBytes, mutability);
+        DelegateHandle hDelegate = NativeTemplates.of(BYTE_ARRAY_CLZ).
+                get(xRTUInt8Delegate.class).makeHandle(abValue, cBytes, mutability);
         return new ArrayHandle(BYTE_ARRAY_CLZ, hDelegate, mutability);
     }
 
@@ -944,8 +944,9 @@ public class xArray
      */
     public static ArrayHandle ensureEmptyByteArray() {
         if (EMPTY_BYTE_ARRAY == null) {
-            DelegateHandle hDelegate = xRTUInt8Delegate.INSTANCE.makeHandle(
-                    Handy.EMPTY_BYTE_ARRAY, 0, Mutability.Constant);
+            DelegateHandle hDelegate = NativeTemplates.of(BYTE_ARRAY_CLZ).
+                    get(xRTUInt8Delegate.class).makeHandle(
+                            Handy.EMPTY_BYTE_ARRAY, 0, Mutability.Constant);
             EMPTY_BYTE_ARRAY = new ArrayHandle(BYTE_ARRAY_CLZ, hDelegate, Mutability.Constant);
         }
         return EMPTY_BYTE_ARRAY;
@@ -955,7 +956,8 @@ public class xArray
      * @return a Char array handle
      */
     public static ArrayHandle makeCharArrayHandle(char[] achValue, Mutability mutability) {
-        DelegateHandle hDelegate = xRTCharDelegate.INSTANCE.makeHandle(achValue, mutability);
+        DelegateHandle hDelegate = NativeTemplates.of(CHAR_ARRAY_CLZ).
+                get(xRTCharDelegate.class).makeHandle(achValue, mutability);
         return new ArrayHandle(CHAR_ARRAY_CLZ, hDelegate, mutability);
     }
 
@@ -983,7 +985,8 @@ public class xArray
     protected static DelegateHandle makeDelegate(TypeComposition clzArray, int cCapacity,
                                                  ObjectHandle[] ahValue, Mutability mutability) {
         TypeConstant typeElement      = clzArray.getType().getParamType(0);
-        xRTDelegate  templateDelegate = xRTDelegate.getArrayTemplate(typeElement);
+        xRTDelegate  templateDelegate = xRTDelegate.getArrayTemplate(
+                                            clzArray.getContainer(), typeElement);
 
         return templateDelegate.createDelegate(
                 clzArray.getContainer(), typeElement, cCapacity, ahValue, mutability);

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xBitArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xBitArray.java
@@ -30,14 +30,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTViewFromBitToNibbl
  */
 public class xBitArray
         extends BitBasedArray {
-    public static xBitArray INSTANCE;
-
     public xBitArray(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -112,7 +106,7 @@ public class xBitArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = xRTViewFromBitToBoolean.INSTANCE.createBitViewDelegate(
+            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToBoolean.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
@@ -128,11 +122,11 @@ public class xBitArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = xRTViewFromBitToByte.INSTANCE.createBitViewDelegate(
+            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToByte.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    xByteArray.INSTANCE.getCanonicalClass(), hDelegate, mutability));
+                    nativeTemplates().get(xByteArray.class).getCanonicalClass(), hDelegate, mutability));
         }
 
         case "asNibbleArray": {
@@ -144,11 +138,11 @@ public class xBitArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = xRTViewFromBitToNibble.INSTANCE.createBitViewDelegate(
+            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToNibble.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    xNibbleArray.INSTANCE.getCanonicalClass(), hDelegate, mutability));
+                    nativeTemplates().get(xNibbleArray.class).getCanonicalClass(), hDelegate, mutability));
         }
 
         case "toByteArray":

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xBitArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xBitArray.java
@@ -106,7 +106,7 @@ public class xBitArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToBoolean.class).createBitViewDelegate(
+            DelegateHandle hDelegate  = f_container.nativeTemplate(xRTViewFromBitToBoolean.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
@@ -122,11 +122,11 @@ public class xBitArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToByte.class).createBitViewDelegate(
+            DelegateHandle hDelegate  = f_container.nativeTemplate(xRTViewFromBitToByte.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    nativeTemplates().get(xByteArray.class).getCanonicalClass(), hDelegate, mutability));
+                    f_container.nativeTemplate(xByteArray.class).getCanonicalClass(), hDelegate, mutability));
         }
 
         case "asNibbleArray": {
@@ -138,11 +138,11 @@ public class xBitArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToNibble.class).createBitViewDelegate(
+            DelegateHandle hDelegate  = f_container.nativeTemplate(xRTViewFromBitToNibble.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    nativeTemplates().get(xNibbleArray.class).getCanonicalClass(), hDelegate, mutability));
+                    f_container.nativeTemplate(xNibbleArray.class).getCanonicalClass(), hDelegate, mutability));
         }
 
         case "toByteArray":

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xBitArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xBitArray.java
@@ -30,7 +30,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTViewFromBitToNibbl
  */
 public class xBitArray
         extends BitBasedArray {
-    public xBitArray(Container container, ClassStructure structure, boolean fInstance) {
+    public xBitArray(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xByteArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xByteArray.java
@@ -79,7 +79,7 @@ public class xByteArray
         case "asInt8Array": {
             ArrayHandle    hArray     = (ArrayHandle) hTarget;
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToInt8.class).createByteView(
+            DelegateHandle hView      = f_container.nativeTemplate(xRTViewFromByteToInt8.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 1);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getInt8ArrayComposition(), hView, mutability));
@@ -93,7 +93,7 @@ public class xByteArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToInt16.class).createByteView(
+            DelegateHandle hView      = f_container.nativeTemplate(xRTViewFromByteToInt16.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 2);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getInt16ArrayComposition(), hView, mutability));
@@ -107,7 +107,7 @@ public class xByteArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToInt64.class).createByteView(
+            DelegateHandle hView      = f_container.nativeTemplate(xRTViewFromByteToInt64.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 8);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getInt64ArrayComposition(), hView, mutability));
@@ -121,7 +121,7 @@ public class xByteArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToFloat64.class).createByteView(
+            DelegateHandle hView      = f_container.nativeTemplate(xRTViewFromByteToFloat64.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 8);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getFloat64ArrayComposition(), hView, mutability));

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xByteArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xByteArray.java
@@ -31,14 +31,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTViewFromByteToFloa
  */
 public class xByteArray
         extends xArray {
-    public static xByteArray INSTANCE;
-
     public xByteArray(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -85,7 +79,7 @@ public class xByteArray
         case "asInt8Array": {
             ArrayHandle    hArray     = (ArrayHandle) hTarget;
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = xRTViewFromByteToInt8.INSTANCE.createByteView(
+            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToInt8.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 1);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getInt8ArrayComposition(), hView, mutability));
@@ -99,7 +93,7 @@ public class xByteArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = xRTViewFromByteToInt16.INSTANCE.createByteView(
+            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToInt16.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 2);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getInt16ArrayComposition(), hView, mutability));
@@ -113,7 +107,7 @@ public class xByteArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = xRTViewFromByteToInt64.INSTANCE.createByteView(
+            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToInt64.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 8);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getInt64ArrayComposition(), hView, mutability));
@@ -127,7 +121,7 @@ public class xByteArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hView      = xRTViewFromByteToFloat64.INSTANCE.createByteView(
+            DelegateHandle hView      = nativeTemplates().get(xRTViewFromByteToFloat64.class).createByteView(
                                                 hArray.m_hDelegate, mutability, 8);
             return frame.assignValue(iReturn,
                     new ArrayHandle(getFloat64ArrayComposition(), hView, mutability));

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xByteArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xByteArray.java
@@ -31,7 +31,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTViewFromByteToFloa
  */
 public class xByteArray
         extends xArray {
-    public xByteArray(Container container, ClassStructure structure, boolean fInstance) {
+    public xByteArray(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xNibbleArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xNibbleArray.java
@@ -50,11 +50,11 @@ public class xNibbleArray
             ArrayHandle hArray = (ArrayHandle) hTarget;
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewToBitFromNibble.class).createBitViewDelegate(
+            DelegateHandle hDelegate  = f_container.nativeTemplate(xRTViewToBitFromNibble.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    nativeTemplates().get(xBitArray.class).getCanonicalClass(), hDelegate, mutability));
+                    f_container.nativeTemplate(xBitArray.class).getCanonicalClass(), hDelegate, mutability));
         }
 
         case "asByteArray": {
@@ -66,11 +66,11 @@ public class xNibbleArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToByte.class).createBitViewDelegate(
+            DelegateHandle hDelegate  = f_container.nativeTemplate(xRTViewFromBitToByte.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    nativeTemplates().get(xByteArray.class).getCanonicalClass(), hDelegate, mutability));
+                    f_container.nativeTemplate(xByteArray.class).getCanonicalClass(), hDelegate, mutability));
         }
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xNibbleArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xNibbleArray.java
@@ -23,7 +23,7 @@ import org.xvm.runtime.template._native.collections.arrays.xRTViewToBitFromNibbl
  */
 public class xNibbleArray
         extends BitBasedArray {
-    public xNibbleArray(Container container, ClassStructure structure, boolean fInstance) {
+    public xNibbleArray(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xNibbleArray.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xNibbleArray.java
@@ -23,14 +23,8 @@ import org.xvm.runtime.template._native.collections.arrays.xRTViewToBitFromNibbl
  */
 public class xNibbleArray
         extends BitBasedArray {
-    public static xNibbleArray INSTANCE;
-
     public xNibbleArray(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -56,11 +50,11 @@ public class xNibbleArray
             ArrayHandle hArray = (ArrayHandle) hTarget;
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = xRTViewToBitFromNibble.INSTANCE.createBitViewDelegate(
+            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewToBitFromNibble.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    xBitArray.INSTANCE.getCanonicalClass(), hDelegate, mutability));
+                    nativeTemplates().get(xBitArray.class).getCanonicalClass(), hDelegate, mutability));
         }
 
         case "asByteArray": {
@@ -72,11 +66,11 @@ public class xNibbleArray
             }
 
             Mutability     mutability = hArray.m_mutability;
-            DelegateHandle hDelegate  = xRTViewFromBitToByte.INSTANCE.createBitViewDelegate(
+            DelegateHandle hDelegate  = nativeTemplates().get(xRTViewFromBitToByte.class).createBitViewDelegate(
                     hArray.m_hDelegate, mutability);
 
             return frame.assignValue(iReturn, new ArrayHandle(
-                    xByteArray.INSTANCE.getCanonicalClass(), hDelegate, mutability));
+                    nativeTemplates().get(xByteArray.class).getCanonicalClass(), hDelegate, mutability));
         }
         }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
@@ -614,7 +614,7 @@ public class xTuple
 
                 int iResult = index < cTypes
                     ? atype[index].callEquals(frameCaller, h1, h2, Op.A_STACK)
-                    : frameCaller.f_context.f_container.nativeTemplates().get(xObject.class).
+                    : frameCaller.nativeTemplate(xObject.class).
                             callEquals(frameCaller, xObject.CLASS, h1, h2, Op.A_STACK);
                 switch (iResult) {
                 case Op.R_NEXT:

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
@@ -48,10 +48,10 @@ public class xTuple
     private final ClassConstant f_idInception;
     public static TupleHandle H_VOID;
 
-    public xTuple(Container container, ClassStructure structure, boolean fInstance) {
+    public xTuple(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
 
-        f_idInception = fInstance
+        f_idInception = fBaseTemplate
                 ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
                 : null;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/collections/xTuple.java
@@ -42,18 +42,18 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
 public class xTuple
         extends ClassTemplate
         implements IndexSupport {
-    public static xTuple INSTANCE;
-    public static ClassConstant INCEPTION_CLASS;
+    /**
+     * The rebased inception class for this container's Tuple template.
+     */
+    private final ClassConstant f_idInception;
     public static TupleHandle H_VOID;
 
     public xTuple(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
 
-        if (fInstance) {
-            INSTANCE = this;
-            INCEPTION_CLASS = new NativeRebaseConstant(
-                (ClassConstant) structure.getIdentityConstant());
-        }
+        f_idInception = fInstance
+                ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
+                : null;
     }
 
     @Override
@@ -77,7 +77,7 @@ public class xTuple
 
     @Override
     protected ClassConstant getInceptionClassConstant() {
-        return INCEPTION_CLASS;
+        return f_idInception;
     }
 
     @Override
@@ -165,7 +165,7 @@ public class xTuple
 
         switch (sPropName) {
         case "size":
-            return frame.assignValue(iReturn, xInt64.makeHandle(hTuple.m_ahValue.length));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, hTuple.m_ahValue.length));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -614,7 +614,8 @@ public class xTuple
 
                 int iResult = index < cTypes
                     ? atype[index].callEquals(frameCaller, h1, h2, Op.A_STACK)
-                    : xObject.INSTANCE.callEquals(frameCaller, xObject.CLASS, h1, h2, Op.A_STACK);
+                    : frameCaller.f_context.f_container.nativeTemplates().get(xObject.class).
+                            callEquals(frameCaller, xObject.CLASS, h1, h2, Op.A_STACK);
                 switch (iResult) {
                 case Op.R_NEXT:
                     ObjectHandle hResult = frameCaller.popStack();

--- a/javatools/src/main/java/org/xvm/runtime/template/maps/xListMap.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/maps/xListMap.java
@@ -29,14 +29,8 @@ import org.xvm.runtime.template.collections.xArray;
  */
 public class xListMap
         extends ClassTemplate {
-    public static xListMap INSTANCE;
-
     public xListMap(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/maps/xListMap.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/maps/xListMap.java
@@ -29,7 +29,7 @@ import org.xvm.runtime.template.collections.xArray;
  */
 public class xListMap
         extends ClassTemplate {
-    public xListMap(Container container, ClassStructure structure, boolean fInstance) {
+    public xListMap(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseBinaryFP.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseBinaryFP.java
@@ -149,19 +149,19 @@ public abstract class BaseBinaryFP
             return convertToInt64(frame, d, ahArg, iReturn);
 
         case "toDec32":
-            return frame.assignValue(iReturn, nativeTemplates().get(xDec32.class).makeHandle(toDec32(d)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xDec32.class).makeHandle(toDec32(d)));
 
         case "toDec64":
-            return frame.assignValue(iReturn, nativeTemplates().get(xDec64.class).makeHandle(toDec64(d)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xDec64.class).makeHandle(toDec64(d)));
 
         case "toDec128":
-            return frame.assignValue(iReturn, nativeTemplates().get(xDec128.class).makeHandle(toDec128(d)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xDec128.class).makeHandle(toDec128(d)));
 
         case "toFloat32":
-            return frame.assignValue(iReturn, nativeTemplates().get(xFloat32.class).makeHandle(d));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xFloat32.class).makeHandle(d));
 
         case "toFloat64":
-            return frame.assignValue(iReturn, nativeTemplates().get(xFloat64.class).makeHandle(toFloat64(d)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xFloat64.class).makeHandle(toFloat64(d)));
 
         case "toIntN":
         case "toUIntN":
@@ -418,13 +418,13 @@ public abstract class BaseBinaryFP
                 case TowardZero     -> (long) (d < 0 ? Math.ceil(d) : Math.floor(d));
                 case TowardNegative -> (long) Math.floor(d);
             };
-            return frame.assignValue(iReturn, nativeTemplates().get(xInt64.class).makeJavaLong(l));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xInt64.class).makeJavaLong(l));
         }
 
         BigInteger n = roundedInteger(d, ahArg[1]);
         return fCheckBound && n.bitLength() >= Long.SIZE
                 ? overflow(frame)
-                : frame.assignValue(iReturn, nativeTemplates().get(xInt64.class).makeJavaLong(n.longValue()));
+                : frame.assignValue(iReturn, f_container.nativeTemplate(xInt64.class).makeJavaLong(n.longValue()));
     }
 
     protected int convertToIntN(Frame frame, double d, ObjectHandle hRound, int iReturn) {
@@ -433,7 +433,7 @@ public abstract class BaseBinaryFP
         }
 
         return frame.assignValue(iReturn,
-                nativeTemplates().get(xIntN.class).makeInt(new PackedInteger(roundedInteger(d, hRound))));
+                f_container.nativeTemplate(xIntN.class).makeInt(new PackedInteger(roundedInteger(d, hRound))));
     }
 
     protected int convertToUIntN(Frame frame, double d, ObjectHandle hRound, int iReturn) {
@@ -446,7 +446,7 @@ public abstract class BaseBinaryFP
             return overflow(frame);
         }
 
-        return frame.assignValue(iReturn, nativeTemplates().get(xUIntN.class).makeInt(new PackedInteger(n)));
+        return frame.assignValue(iReturn, f_container.nativeTemplate(xUIntN.class).makeInt(new PackedInteger(n)));
     }
 
     protected BigInteger roundedInteger(double d, ObjectHandle hRound) {

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseBinaryFP.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseBinaryFP.java
@@ -149,19 +149,19 @@ public abstract class BaseBinaryFP
             return convertToInt64(frame, d, ahArg, iReturn);
 
         case "toDec32":
-            return frame.assignValue(iReturn, xDec32.INSTANCE.makeHandle(toDec32(d)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xDec32.class).makeHandle(toDec32(d)));
 
         case "toDec64":
-            return frame.assignValue(iReturn, xDec64.INSTANCE.makeHandle(toDec64(d)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xDec64.class).makeHandle(toDec64(d)));
 
         case "toDec128":
-            return frame.assignValue(iReturn, xDec128.INSTANCE.makeHandle(toDec128(d)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xDec128.class).makeHandle(toDec128(d)));
 
         case "toFloat32":
-            return frame.assignValue(iReturn, xFloat32.INSTANCE.makeHandle(d));
+            return frame.assignValue(iReturn, nativeTemplates().get(xFloat32.class).makeHandle(d));
 
         case "toFloat64":
-            return frame.assignValue(iReturn, xFloat64.INSTANCE.makeHandle(toFloat64(d)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xFloat64.class).makeHandle(toFloat64(d)));
 
         case "toIntN":
         case "toUIntN":
@@ -281,7 +281,7 @@ public abstract class BaseBinaryFP
                     lMantissa = l & MANTISSA_MASK;
             }
             return frame.assignValues(aiReturn, xBoolean.makeHandle(fSign),
-                                      xInt64.makeHandle(lMantissa), xInt64.makeHandle(iExp));
+                                      xInt64.makeHandle(frame, lMantissa), xInt64.makeHandle(frame, iExp));
         }
         }
 
@@ -365,28 +365,28 @@ public abstract class BaseBinaryFP
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         double d = ((FloatHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(Double.hashCode(d)));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, Double.hashCode(d)));
     }
 
     @Override
     protected int callEstimateLength(Frame frame, ObjectHandle hTarget, int iReturn) {
         double d = ((FloatHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(toString(d).length()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, toString(d).length()));
     }
 
     @Override
     protected int callAppendTo(Frame frame, ObjectHandle hTarget, ObjectHandle hAppender, int iReturn) {
         double d = ((FloatHandle) hTarget).getValue();
 
-        return xString.callAppendTo(frame, xString.makeHandle(toString(d)), hAppender, iReturn);
+        return xString.callAppendTo(frame, xString.makeHandle(frame, toString(d)), hAppender, iReturn);
     }
 
     @Override
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
         double d = ((FloatHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xString.makeHandle(toString(d)));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, toString(d)));
     }
 
 
@@ -418,13 +418,13 @@ public abstract class BaseBinaryFP
                 case TowardZero     -> (long) (d < 0 ? Math.ceil(d) : Math.floor(d));
                 case TowardNegative -> (long) Math.floor(d);
             };
-            return frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(l));
+            return frame.assignValue(iReturn, nativeTemplates().get(xInt64.class).makeJavaLong(l));
         }
 
         BigInteger n = roundedInteger(d, ahArg[1]);
         return fCheckBound && n.bitLength() >= Long.SIZE
                 ? overflow(frame)
-                : frame.assignValue(iReturn, xInt64.INSTANCE.makeJavaLong(n.longValue()));
+                : frame.assignValue(iReturn, nativeTemplates().get(xInt64.class).makeJavaLong(n.longValue()));
     }
 
     protected int convertToIntN(Frame frame, double d, ObjectHandle hRound, int iReturn) {
@@ -433,7 +433,7 @@ public abstract class BaseBinaryFP
         }
 
         return frame.assignValue(iReturn,
-                xIntN.INSTANCE.makeInt(new PackedInteger(roundedInteger(d, hRound))));
+                nativeTemplates().get(xIntN.class).makeInt(new PackedInteger(roundedInteger(d, hRound))));
     }
 
     protected int convertToUIntN(Frame frame, double d, ObjectHandle hRound, int iReturn) {
@@ -446,7 +446,7 @@ public abstract class BaseBinaryFP
             return overflow(frame);
         }
 
-        return frame.assignValue(iReturn, xUIntN.INSTANCE.makeInt(new PackedInteger(n)));
+        return frame.assignValue(iReturn, nativeTemplates().get(xUIntN.class).makeInt(new PackedInteger(n)));
     }
 
     protected BigInteger roundedInteger(double d, ObjectHandle hRound) {

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseDecFP.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseDecFP.java
@@ -165,17 +165,18 @@ public abstract class BaseDecFP
 
         case "toFloat64":
             return dec.isFinite()
-                ? frame.assignValue(iReturn, xFloat64.INSTANCE.makeHandle(dec.toBigDecimal().doubleValue()))
+                ? frame.assignValue(iReturn, nativeTemplates().get(xFloat64.class).
+                        makeHandle(dec.toBigDecimal().doubleValue()))
                 : overflow(frame);
 
         case "toDec32":
-            return frame.assignValue(iReturn, xDec32.INSTANCE.makeHandle(toDec32(dec)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xDec32.class).makeHandle(toDec32(dec)));
 
         case "toDec64":
-            return frame.assignValue(iReturn, xDec64.INSTANCE.makeHandle(toDec64(dec)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xDec64.class).makeHandle(toDec64(dec)));
 
         case "toDec128":
-            return frame.assignValue(iReturn, xDec128.INSTANCE.makeHandle(toDec128(dec)));
+            return frame.assignValue(iReturn, nativeTemplates().get(xDec128.class).makeHandle(toDec128(dec)));
 
         case "toInt64": {
             boolean      fCheckBounds = ahArg[0] == xBoolean.TRUE;
@@ -186,7 +187,7 @@ public abstract class BaseDecFP
                 if (!fCheckBounds ||
                         n.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) >= 0 &&
                         n.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) <= 0) {
-                    return frame.assignValue(iReturn, xInt64.makeHandle(n.longValue()));
+                    return frame.assignValue(iReturn, xInt64.makeHandle(frame, n.longValue()));
                 }
             }
 
@@ -309,7 +310,7 @@ public abstract class BaseDecFP
                     lMantissa = 0;
             }
             return frame.assignValues(aiReturn, xBoolean.makeHandle(fSign),
-                                      xInt64.makeHandle(lMantissa), xInt64.makeHandle(iExp));
+                                      xInt64.makeHandle(frame, lMantissa), xInt64.makeHandle(frame, iExp));
         }
         }
 
@@ -398,28 +399,28 @@ public abstract class BaseDecFP
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         Decimal dec = ((DecimalHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(dec.hashCode()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, dec.hashCode()));
     }
 
     @Override
     protected int callEstimateLength(Frame frame, ObjectHandle hTarget, int iReturn) {
         Decimal dec = ((DecimalHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(dec.toString().length()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, dec.toString().length()));
     }
 
     @Override
     protected int callAppendTo(Frame frame, ObjectHandle hTarget, ObjectHandle hAppender, int iReturn) {
         Decimal dec = ((DecimalHandle) hTarget).getValue();
 
-        return xString.callAppendTo(frame, xString.makeHandle(dec.toString()), hAppender, iReturn);
+        return xString.callAppendTo(frame, xString.makeHandle(frame, dec.toString()), hAppender, iReturn);
     }
 
     @Override
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
         Decimal dec = ((DecimalHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xString.makeHandle(dec.toString()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, dec.toString()));
     }
 
 
@@ -440,7 +441,7 @@ public abstract class BaseDecFP
         }
 
         return frame.assignValue(iReturn,
-                xIntN.INSTANCE.makeInt(new PackedInteger(roundedInteger(dec, hRound))));
+                nativeTemplates().get(xIntN.class).makeInt(new PackedInteger(roundedInteger(dec, hRound))));
     }
 
     protected int convertToUIntN(Frame frame, Decimal dec, ObjectHandle hRound, int iReturn) {
@@ -453,7 +454,7 @@ public abstract class BaseDecFP
             return overflow(frame);
         }
 
-        return frame.assignValue(iReturn, xUIntN.INSTANCE.makeInt(new PackedInteger(n)));
+        return frame.assignValue(iReturn, nativeTemplates().get(xUIntN.class).makeInt(new PackedInteger(n)));
     }
 
     protected BigInteger roundedInteger(Decimal dec, ObjectHandle hRound) {

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseDecFP.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseDecFP.java
@@ -165,18 +165,18 @@ public abstract class BaseDecFP
 
         case "toFloat64":
             return dec.isFinite()
-                ? frame.assignValue(iReturn, nativeTemplates().get(xFloat64.class).
+                ? frame.assignValue(iReturn, f_container.nativeTemplate(xFloat64.class).
                         makeHandle(dec.toBigDecimal().doubleValue()))
                 : overflow(frame);
 
         case "toDec32":
-            return frame.assignValue(iReturn, nativeTemplates().get(xDec32.class).makeHandle(toDec32(dec)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xDec32.class).makeHandle(toDec32(dec)));
 
         case "toDec64":
-            return frame.assignValue(iReturn, nativeTemplates().get(xDec64.class).makeHandle(toDec64(dec)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xDec64.class).makeHandle(toDec64(dec)));
 
         case "toDec128":
-            return frame.assignValue(iReturn, nativeTemplates().get(xDec128.class).makeHandle(toDec128(dec)));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xDec128.class).makeHandle(toDec128(dec)));
 
         case "toInt64": {
             boolean      fCheckBounds = ahArg[0] == xBoolean.TRUE;
@@ -441,7 +441,7 @@ public abstract class BaseDecFP
         }
 
         return frame.assignValue(iReturn,
-                nativeTemplates().get(xIntN.class).makeInt(new PackedInteger(roundedInteger(dec, hRound))));
+                f_container.nativeTemplate(xIntN.class).makeInt(new PackedInteger(roundedInteger(dec, hRound))));
     }
 
     protected int convertToUIntN(Frame frame, Decimal dec, ObjectHandle hRound, int iReturn) {
@@ -454,7 +454,7 @@ public abstract class BaseDecFP
             return overflow(frame);
         }
 
-        return frame.assignValue(iReturn, nativeTemplates().get(xUIntN.class).makeInt(new PackedInteger(n)));
+        return frame.assignValue(iReturn, f_container.nativeTemplate(xUIntN.class).makeInt(new PackedInteger(n)));
     }
 
     protected BigInteger roundedInteger(Decimal dec, ObjectHandle hRound) {

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/BaseInt128.java
@@ -144,12 +144,12 @@ public abstract class BaseInt128
 
         case "bitCount": {
             LongLong ll = ((LongLongHandle) hTarget).getValue();
-            return frame.assignValue(iReturn, xInt64.makeHandle(
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame,
                 Long.bitCount(ll.getLowValue()) + Long.bitCount(ll.getHighValue())));
         }
 
         case "bitLength":
-            return frame.assignValue(iReturn, xInt64.makeHandle(128));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 128));
 
         case "leftmostBit": {
             LongLong ll  = ((LongLongHandle) hTarget).getValue();
@@ -171,7 +171,7 @@ public abstract class BaseInt128
             LongLong ll = ((LongLongHandle) hTarget).getValue();
             long     lH = ll.getHighValue();
 
-            return frame.assignValue(iReturn, xInt64.makeHandle(lH == 0
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, lH == 0
                 ? 64 + Long.numberOfLeadingZeros(ll.getLowValue())
                 : Long.numberOfLeadingZeros(lH)));
         }
@@ -180,7 +180,7 @@ public abstract class BaseInt128
             LongLong ll   = ((LongLongHandle) hTarget).getValue();
             long     lLow = ll.getLowValue();
 
-            return frame.assignValue(iReturn, xInt64.makeHandle(lLow == 0
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, lLow == 0
                 ? 64 + Long.numberOfTrailingZeros(ll.getHighValue())
                 : Long.numberOfTrailingZeros(lLow)));
         }
@@ -498,14 +498,14 @@ public abstract class BaseInt128
     public int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         LongLong ll = ((LongLongHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(ll.hashCode()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, ll.hashCode()));
     }
 
     @Override
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
         LongLong ll = ((LongLongHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xString.makeHandle(
+        return frame.assignValue(iReturn, xString.makeHandle(frame,
             f_fSigned
                 ? ll.toBigInteger().toString()
                 : ll.toUnsignedBigInteger().toString()));

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xBit.java
@@ -30,7 +30,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xBit
         extends xConst {
-    public xBit(Container container, ClassStructure structure, boolean fInstance) {
+    public xBit(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xBit.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xBit.java
@@ -180,7 +180,7 @@ public class xBit
     public int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         long l = ((JavaLong) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(l != 0 ? 1L : 0L));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, l != 0 ? 1L : 0L));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt16.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt16
         extends xCheckedConstrainedInt {
-    public xCheckedInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Short.MIN_VALUE, Short.MAX_VALUE, 16, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt16.java
@@ -17,6 +17,6 @@ public class xCheckedInt16
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedUInt16.class);
+        return f_container.nativeTemplate(xCheckedUInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt16.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt16
         extends xCheckedConstrainedInt {
-    public static xCheckedInt16 INSTANCE;
-
     public xCheckedInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Short.MIN_VALUE, Short.MAX_VALUE, 16, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedUInt16.INSTANCE;
+        return nativeTemplates().get(xCheckedUInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt32.java
@@ -17,6 +17,6 @@ public class xCheckedInt32
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedUInt32.class);
+        return f_container.nativeTemplate(xCheckedUInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt32.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt32
         extends xCheckedConstrainedInt {
-    public static xCheckedInt32 INSTANCE;
-
     public xCheckedInt32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Integer.MIN_VALUE, Integer.MAX_VALUE, 32, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedUInt32.INSTANCE;
+        return nativeTemplates().get(xCheckedUInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt32.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt32
         extends xCheckedConstrainedInt {
-    public xCheckedInt32(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedInt32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Integer.MIN_VALUE, Integer.MAX_VALUE, 32, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt64.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt64
         extends xCheckedConstrainedInt {
-    public xCheckedInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Long.MIN_VALUE, Long.MAX_VALUE, 64, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt64.java
@@ -17,6 +17,6 @@ public class xCheckedInt64
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedUInt64.class);
+        return f_container.nativeTemplate(xCheckedUInt64.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt64.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt64
         extends xCheckedConstrainedInt {
-    public static xCheckedInt64 INSTANCE;
-
     public xCheckedInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Long.MIN_VALUE, Long.MAX_VALUE, 64, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedUInt64.INSTANCE;
+        return nativeTemplates().get(xCheckedUInt64.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt8.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt8
         extends xCheckedConstrainedInt {
-    public xCheckedInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Byte.MIN_VALUE, Byte.MAX_VALUE, 8, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt8.java
@@ -17,6 +17,6 @@ public class xCheckedInt8
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedUInt8.class);
+        return f_container.nativeTemplate(xCheckedUInt8.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedInt8.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedInt8
         extends xCheckedConstrainedInt {
-    public static xCheckedInt8 INSTANCE;
-
     public xCheckedInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Byte.MIN_VALUE, Byte.MAX_VALUE, 8, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedUInt8.INSTANCE;
+        return nativeTemplates().get(xCheckedUInt8.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt16.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedUInt16
         extends xCheckedUnsignedInt {
-    public static xCheckedUInt16 INSTANCE;
-
     public xCheckedUInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0L, 0xFFFFL, 16);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedInt16.INSTANCE;
+        return nativeTemplates().get(xCheckedInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt16.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedUInt16
         extends xCheckedUnsignedInt {
-    public xCheckedUInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedUInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0L, 0xFFFFL, 16);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt16.java
@@ -17,6 +17,6 @@ public class xCheckedUInt16
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedInt16.class);
+        return f_container.nativeTemplate(xCheckedInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt32.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedUInt32
         extends xCheckedUnsignedInt {
-    public xCheckedUInt32(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedUInt32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0L, 0xFFFF_FFFFL, 32);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt32.java
@@ -17,6 +17,6 @@ public class xCheckedUInt32
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedInt32.class);
+        return f_container.nativeTemplate(xCheckedInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt32.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedUInt32
         extends xCheckedUnsignedInt {
-    public static xCheckedUInt32 INSTANCE;
-
     public xCheckedUInt32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0L, 0xFFFF_FFFFL, 32);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedInt32.INSTANCE;
+        return nativeTemplates().get(xCheckedInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt64.java
@@ -14,19 +14,13 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public class xCheckedUInt64
         extends xCheckedUnsignedInt {
-    public static xCheckedUInt64 INSTANCE;
-
     public xCheckedUInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0L, 0xFFFF_FFFF_FFFF_FFFFL, 64);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedInt64.INSTANCE;
+        return nativeTemplates().get(xCheckedInt64.class);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt64.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public class xCheckedUInt64
         extends xCheckedUnsignedInt {
-    public xCheckedUInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedUInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0L, 0xFFFF_FFFF_FFFF_FFFFL, 64);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt64.java
@@ -20,7 +20,7 @@ public class xCheckedUInt64
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedInt64.class);
+        return f_container.nativeTemplate(xCheckedInt64.class);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt8.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedUInt8
         extends xCheckedUnsignedInt {
-    public xCheckedUInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xCheckedUInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0L, 0xFFL, 8);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt8.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xCheckedUInt8
         extends xCheckedUnsignedInt {
-    public static xCheckedUInt8 INSTANCE;
-
     public xCheckedUInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0L, 0xFFL, 8);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xCheckedInt8.INSTANCE;
+        return nativeTemplates().get(xCheckedInt8.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xCheckedUInt8.java
@@ -17,6 +17,6 @@ public class xCheckedUInt8
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xCheckedInt8.class);
+        return f_container.nativeTemplate(xCheckedInt8.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xConstrainedInteger.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xConstrainedInteger.java
@@ -279,7 +279,7 @@ public abstract class xConstrainedInteger
 
         case "stepsTo":
             // the return value must be an Int!
-            return nativeTemplates().get(xInt64.class).invokeSub(frame, hArg, hTarget, iReturn);
+            return f_container.nativeTemplate(xInt64.class).invokeSub(frame, hArg, hTarget, iReturn);
 
         case "toInt8":
         case "toInt16":

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xConstrainedInteger.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xConstrainedInteger.java
@@ -169,7 +169,7 @@ public abstract class xConstrainedInteger
                 }
             }
 
-            return frame.assignValue(iReturn, xInt64.makeHandle(cDigits));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, cDigits));
         }
 
         case "bits": {
@@ -181,11 +181,11 @@ public abstract class xConstrainedInteger
 
         case "bitCount": {
             long l = ((JavaLong) hTarget).getValue();
-            return frame.assignValue(iReturn, xInt64.makeHandle(Long.bitCount(l)));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, Long.bitCount(l)));
         }
 
         case "bitLength":
-            return frame.assignValue(iReturn, xInt64.makeHandle(f_cNumBits));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, f_cNumBits));
 
         case "leftmostBit": {
             long l = ((JavaLong) hTarget).getValue();
@@ -213,7 +213,7 @@ public abstract class xConstrainedInteger
             } else {
                 c = Long.numberOfLeadingZeros(l) - 64 + f_cNumBits;
             }
-            return frame.assignValue(iReturn, xInt64.makeHandle(c));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, c));
         }
 
         case "trailingZeroCount": {
@@ -224,7 +224,7 @@ public abstract class xConstrainedInteger
             } else {
                 c = Long.numberOfTrailingZeros(l);
             }
-            return frame.assignValue(iReturn, xInt64.makeHandle(c));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, c));
         }
         }
 
@@ -279,7 +279,7 @@ public abstract class xConstrainedInteger
 
         case "stepsTo":
             // the return value must be an Int!
-            return xInt64.INSTANCE.invokeSub(frame, hArg, hTarget, iReturn);
+            return nativeTemplates().get(xInt64.class).invokeSub(frame, hArg, hTarget, iReturn);
 
         case "toInt8":
         case "toInt16":
@@ -356,7 +356,7 @@ public abstract class xConstrainedInteger
                     }
                     lValue &= 0x0F_FFFF;
                 }
-                return frame.assignValue(iReturn, xChar.makeHandle(lValue));
+                return frame.assignValue(iReturn, xChar.makeHandle(frame, lValue));
             }
 
             break;
@@ -593,7 +593,7 @@ public abstract class xConstrainedInteger
     public int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         long l = ((JavaLong) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(l));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, l));
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec128.java
@@ -20,14 +20,8 @@ import org.xvm.type.Decimal128;
  */
 public class xDec128
         extends BaseDecFP {
-    public static xDec128 INSTANCE;
-
     public xDec128(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 128);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     // ----- helpers -------------------------------------------------------------------------------

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec128.java
@@ -20,7 +20,7 @@ import org.xvm.type.Decimal128;
  */
 public class xDec128
         extends BaseDecFP {
-    public xDec128(Container container, ClassStructure structure, boolean fInstance) {
+    public xDec128(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 128);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec32.java
@@ -20,14 +20,8 @@ import org.xvm.type.Decimal32;
  */
 public class xDec32
         extends BaseDecFP {
-    public static xDec32 INSTANCE;
-
     public xDec32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 32);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     // ----- helpers -------------------------------------------------------------------------------

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec32.java
@@ -20,7 +20,7 @@ import org.xvm.type.Decimal32;
  */
 public class xDec32
         extends BaseDecFP {
-    public xDec32(Container container, ClassStructure structure, boolean fInstance) {
+    public xDec32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 32);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec64.java
@@ -20,14 +20,8 @@ import org.xvm.type.Decimal64;
  */
 public class xDec64
         extends BaseDecFP {
-    public static xDec64 INSTANCE;
-
     public xDec64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 64);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     // ----- helpers -------------------------------------------------------------------------------

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xDec64.java
@@ -20,7 +20,7 @@ import org.xvm.type.Decimal64;
  */
 public class xDec64
         extends BaseDecFP {
-    public xDec64(Container container, ClassStructure structure, boolean fInstance) {
+    public xDec64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 64);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFPLiteral.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFPLiteral.java
@@ -139,15 +139,15 @@ public class xFPLiteral
 
         case "toDec32":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xDec32.class).makeHandle(new Decimal32(hLiteral.getValue())));
+                    f_container.nativeTemplate(xDec32.class).makeHandle(new Decimal32(hLiteral.getValue())));
 
         case "toDec64":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xDec64.class).makeHandle(new Decimal64(hLiteral.getValue())));
+                    f_container.nativeTemplate(xDec64.class).makeHandle(new Decimal64(hLiteral.getValue())));
 
         case "toDec128":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xDec128.class).makeHandle(new Decimal128(hLiteral.getValue())));
+                    f_container.nativeTemplate(xDec128.class).makeHandle(new Decimal128(hLiteral.getValue())));
 
         case "toFloat128":
         case "toFloatN":

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFPLiteral.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFPLiteral.java
@@ -32,14 +32,8 @@ import org.xvm.type.Decimal128;
  */
 public class xFPLiteral
         extends xConst {
-    public static xFPLiteral INSTANCE;
-
     public xFPLiteral(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -145,15 +139,15 @@ public class xFPLiteral
 
         case "toDec32":
             return frame.assignValue(iReturn,
-                    xDec32.INSTANCE.makeHandle(new Decimal32(hLiteral.getValue())));
+                    nativeTemplates().get(xDec32.class).makeHandle(new Decimal32(hLiteral.getValue())));
 
         case "toDec64":
             return frame.assignValue(iReturn,
-                    xDec64.INSTANCE.makeHandle(new Decimal64(hLiteral.getValue())));
+                    nativeTemplates().get(xDec64.class).makeHandle(new Decimal64(hLiteral.getValue())));
 
         case "toDec128":
             return frame.assignValue(iReturn,
-                    xDec128.INSTANCE.makeHandle(new Decimal128(hLiteral.getValue())));
+                    nativeTemplates().get(xDec128.class).makeHandle(new Decimal128(hLiteral.getValue())));
 
         case "toFloat128":
         case "toFloatN":
@@ -175,7 +169,7 @@ public class xFPLiteral
     @Override
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         FPNHandle hLiteral = (FPNHandle) hTarget;
-        return frame.assignValue(iReturn, xInt64.makeHandle(hLiteral.getValue().hashCode()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hLiteral.getValue().hashCode()));
     }
 
     @Override
@@ -201,7 +195,8 @@ public class xFPLiteral
         public StringHandle getText() {
             StringHandle hText = m_hText;
             if (hText == null) {
-                m_hText = hText = xString.makeHandle(m_decValue.toString());
+                m_hText = hText = xString.makeHandle(getComposition().getContainer(),
+                        m_decValue.toString());
             }
             return hText;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFPLiteral.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFPLiteral.java
@@ -32,7 +32,7 @@ import org.xvm.type.Decimal128;
  */
 public class xFPLiteral
         extends xConst {
-    public xFPLiteral(Container container, ClassStructure structure, boolean fInstance) {
+    public xFPLiteral(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat16.java
@@ -15,7 +15,7 @@ import org.xvm.runtime.Frame;
  */
 public class xFloat16
         extends BaseBinaryFP {
-    public xFloat16(Container container, ClassStructure structure, boolean fInstance) {
+    public xFloat16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 16);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat16.java
@@ -15,14 +15,8 @@ import org.xvm.runtime.Frame;
  */
 public class xFloat16
         extends BaseBinaryFP {
-    public static xFloat16 INSTANCE;
-
     public xFloat16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 16);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat32.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.Frame;
  */
 public class xFloat32
         extends BaseBinaryFP {
-    public xFloat32(Container container, ClassStructure structure, boolean fInstance) {
+    public xFloat32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 32);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat32.java
@@ -18,14 +18,8 @@ import org.xvm.runtime.Frame;
  */
 public class xFloat32
         extends BaseBinaryFP {
-    public static xFloat32 INSTANCE;
-
     public xFloat32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 32);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat64.java
@@ -15,14 +15,8 @@ import org.xvm.runtime.Frame;
  */
 public class xFloat64
         extends BaseBinaryFP {
-    public static xFloat64 INSTANCE;
-
     public xFloat64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 64);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xFloat64.java
@@ -15,7 +15,7 @@ import org.xvm.runtime.Frame;
  */
 public class xFloat64
         extends BaseBinaryFP {
-    public xFloat64(Container container, ClassStructure structure, boolean fInstance) {
+    public xFloat64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 64);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt128.java
@@ -10,14 +10,8 @@ import org.xvm.runtime.ObjectHandle;
 
 public class xInt128
         extends BaseInt128 {
-    public static xInt128 INSTANCE;
-
     public xInt128(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, true);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -37,7 +31,7 @@ public class xInt128
             if (ll.signum() < 0) {
                 ll = ll.complement().addUnchecked(LongLong.ONE);
             }
-            return frame.assignValue(iReturn, xUInt128.INSTANCE.makeHandle(ll));
+            return frame.assignValue(iReturn, nativeTemplates().get(xUInt128.class).makeHandle(ll));
         }
         }
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt128.java
@@ -31,7 +31,7 @@ public class xInt128
             if (ll.signum() < 0) {
                 ll = ll.complement().addUnchecked(LongLong.ONE);
             }
-            return frame.assignValue(iReturn, nativeTemplates().get(xUInt128.class).makeHandle(ll));
+            return frame.assignValue(iReturn, f_container.nativeTemplate(xUInt128.class).makeHandle(ll));
         }
         }
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt128.java
@@ -10,7 +10,7 @@ import org.xvm.runtime.ObjectHandle;
 
 public class xInt128
         extends BaseInt128 {
-    public xInt128(Container container, ClassStructure structure, boolean fInstance) {
+    public xInt128(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, true);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt16.java
@@ -17,6 +17,6 @@ public class xInt16
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xUInt16.class);
+        return f_container.nativeTemplate(xUInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt16.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xInt16
         extends xConstrainedInteger {
-    public xInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Short.MIN_VALUE, Short.MAX_VALUE, 16, false, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt16.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xInt16
         extends xConstrainedInteger {
-    public static xInt16 INSTANCE;
-
     public xInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Short.MIN_VALUE, Short.MAX_VALUE, 16, false, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xUInt16.INSTANCE;
+        return nativeTemplates().get(xUInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt32.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xInt32
         extends xConstrainedInteger {
-    public static xInt32 INSTANCE;
-
     public xInt32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Integer.MIN_VALUE, Integer.MAX_VALUE, 32, false, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xUInt32.INSTANCE;
+        return nativeTemplates().get(xUInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt32.java
@@ -17,6 +17,6 @@ public class xInt32
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xUInt32.class);
+        return f_container.nativeTemplate(xUInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt32.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xInt32
         extends xConstrainedInteger {
-    public xInt32(Container container, ClassStructure structure, boolean fInstance) {
+    public xInt32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Integer.MIN_VALUE, Integer.MAX_VALUE, 32, false, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt64.java
@@ -15,7 +15,7 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public class xInt64
         extends xConstrainedInteger {
-    public xInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Long.MIN_VALUE, Long.MAX_VALUE, 64, false, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt64.java
@@ -15,19 +15,13 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public class xInt64
         extends xConstrainedInteger {
-    public static xInt64 INSTANCE;
-
     public xInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Long.MIN_VALUE, Long.MAX_VALUE, 64, false, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xUInt64.INSTANCE;
+        return nativeTemplates().get(xUInt64.class);
     }
 
     @Override
@@ -62,7 +56,17 @@ public class xInt64
         return super.invokeNativeN(frame, method, hTarget, ahArg, iReturn);
     }
 
-    public static JavaLong makeHandle(long lValue) {
-        return INSTANCE.makeJavaLong(lValue);
+    /**
+     * @return an Int64 handle owned by the specified container
+     */
+    public static JavaLong makeHandle(Container container, long lValue) {
+        return container.nativeTemplates().get(xInt64.class).makeJavaLong(lValue);
+    }
+
+    /**
+     * @return an Int64 handle owned by the container the specified frame runs in
+     */
+    public static JavaLong makeHandle(Frame frame, long lValue) {
+        return makeHandle(frame.f_context.f_container, lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt64.java
@@ -21,7 +21,7 @@ public class xInt64
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xUInt64.class);
+        return f_container.nativeTemplate(xUInt64.class);
     }
 
     @Override
@@ -60,13 +60,13 @@ public class xInt64
      * @return an Int64 handle owned by the specified container
      */
     public static JavaLong makeHandle(Container container, long lValue) {
-        return container.nativeTemplates().get(xInt64.class).makeJavaLong(lValue);
+        return container.nativeTemplate(xInt64.class).makeJavaLong(lValue);
     }
 
     /**
      * @return an Int64 handle owned by the container the specified frame runs in
      */
     public static JavaLong makeHandle(Frame frame, long lValue) {
-        return makeHandle(frame.f_context.f_container, lValue);
+        return makeHandle(frame.container(), lValue);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt8.java
@@ -20,7 +20,7 @@ public class xInt8
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xUInt8.class);
+        return f_container.nativeTemplate(xUInt8.class);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt8.java
@@ -14,19 +14,13 @@ import org.xvm.runtime.Frame;
  */
 public class xInt8
         extends xConstrainedInteger {
-    public static xInt8 INSTANCE;
-
     public xInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, Byte.MIN_VALUE, Byte.MAX_VALUE, 8, false, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xUInt8.INSTANCE;
+        return nativeTemplates().get(xUInt8.class);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xInt8.java
@@ -14,7 +14,7 @@ import org.xvm.runtime.Frame;
  */
 public class xInt8
         extends xConstrainedInteger {
-    public xInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, Byte.MIN_VALUE, Byte.MAX_VALUE, 8, false, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntLiteral.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntLiteral.java
@@ -40,14 +40,8 @@ import org.xvm.util.PackedInteger;
  */
 public class xIntLiteral
         extends xConst {
-    public static xIntLiteral INSTANCE;
-
     public xIntLiteral(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -343,7 +337,7 @@ public class xIntLiteral
     @Override
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         IntNHandle hLiteral = (IntNHandle) hTarget;
-        return frame.assignValue(iReturn, xInt64.makeHandle(hLiteral.getValue().hashCode()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hLiteral.getValue().hashCode()));
     }
 
     @Override
@@ -448,7 +442,8 @@ public class xIntLiteral
         public StringHandle getText() {
             StringHandle hText = m_hText;
             if (hText == null) {
-                m_hText = hText = xString.makeHandle(m_piValue.toString());
+                m_hText = hText = xString.makeHandle(getComposition().getContainer(),
+                        m_piValue.toString());
             }
             return hText;
         }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntLiteral.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntLiteral.java
@@ -40,7 +40,7 @@ import org.xvm.util.PackedInteger;
  */
 public class xIntLiteral
         extends xConst {
-    public xIntLiteral(Container container, ClassStructure structure, boolean fInstance) {
+    public xIntLiteral(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntN.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntN.java
@@ -18,14 +18,8 @@ import org.xvm.util.PackedInteger;
  */
 public class xIntN
         extends xUnconstrainedInteger {
-    public static xIntN INSTANCE;
-
     public xIntN(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, true);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntN.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntN.java
@@ -18,7 +18,7 @@ import org.xvm.util.PackedInteger;
  */
 public class xIntN
         extends xUnconstrainedInteger {
-    public xIntN(Container container, ClassStructure structure, boolean fInstance) {
+    public xIntN(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, true);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntNumber.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xIntNumber.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public abstract class xIntNumber
         extends xNumber {
-    public xIntNumber(Container container, ClassStructure structure, boolean fInstance) {
+    public xIntNumber(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xNibble.java
@@ -22,21 +22,15 @@ import org.xvm.runtime.template.text.xChar;
  */
 public class xNibble
         extends xUnsignedConstrainedInt {
-    public static xNibble INSTANCE;
-
     public xNibble(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0, 15, 4, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
         super.initNative();
 
-        if (this == INSTANCE) {
+        if (isNativeInstance(xNibble.class)) {
             ClassComposition clz = getCanonicalClass();
             for (int i = 0; i < cache.length; ++i) {
                 cache[i] = new JavaLong(clz, i);
@@ -46,7 +40,7 @@ public class xNibble
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xNibble.INSTANCE;
+        return nativeTemplates().get(xNibble.class);
     }
 
     @Override
@@ -63,9 +57,26 @@ public class xNibble
         return makeHandle(lValue & 0x0FL);
     }
 
-    public static JavaLong makeHandle(long lValue) {
+    /**
+     * @return a Nibble handle owned by this template's container
+     */
+    public JavaLong makeHandle(long lValue) {
         assert lValue >= 0 & lValue <= 15;
-        return INSTANCE.cache[(int) lValue];
+        return cache[(int) lValue];
+    }
+
+    /**
+     * @return a Nibble handle owned by the specified container
+     */
+    public static JavaLong makeHandle(Container container, long lValue) {
+        return container.nativeTemplates().get(xNibble.class).makeHandle(lValue);
+    }
+
+    /**
+     * @return a Nibble handle owned by the container the specified frame runs in
+     */
+    public static JavaLong makeHandle(Frame frame, long lValue) {
+        return makeHandle(frame.f_context.f_container, lValue);
     }
 
     @Override
@@ -74,7 +85,7 @@ public class xNibble
         if (method.getName().equals("toChar")) {
             long lValue = ((JavaLong) hTarget).getValue();
             long cValue = lValue <= 9 ? '0' + lValue : 'A' + lValue - 0xA;
-            return frame.assignValue(iReturn, xChar.makeHandle(cValue));
+            return frame.assignValue(iReturn, xChar.makeHandle(frame, cValue));
         }
         return super.invokeNative1(frame, method, hTarget, hArg, iReturn);
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xNibble.java
@@ -22,7 +22,7 @@ import org.xvm.runtime.template.text.xChar;
  */
 public class xNibble
         extends xUnsignedConstrainedInt {
-    public xNibble(Container container, ClassStructure structure, boolean fInstance) {
+    public xNibble(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0, 15, 4, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xNibble.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xNibble.java
@@ -40,7 +40,7 @@ public class xNibble
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xNibble.class);
+        return f_container.nativeTemplate(xNibble.class);
     }
 
     @Override
@@ -69,14 +69,14 @@ public class xNibble
      * @return a Nibble handle owned by the specified container
      */
     public static JavaLong makeHandle(Container container, long lValue) {
-        return container.nativeTemplates().get(xNibble.class).makeHandle(lValue);
+        return container.nativeTemplate(xNibble.class).makeHandle(lValue);
     }
 
     /**
      * @return a Nibble handle owned by the container the specified frame runs in
      */
     public static JavaLong makeHandle(Frame frame, long lValue) {
-        return makeHandle(frame.f_context.f_container, lValue);
+        return makeHandle(frame.container(), lValue);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xNumber.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xNumber.java
@@ -28,7 +28,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public abstract class xNumber
         extends xConst {
-    public xNumber(Container container, ClassStructure structure, boolean fInstance) {
+    public xNumber(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt128.java
@@ -9,14 +9,8 @@ import org.xvm.runtime.Frame;
 
 public class xUInt128
         extends BaseInt128 {
-    public static xUInt128 INSTANCE;
-
     public xUInt128(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt128.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt128.java
@@ -9,7 +9,7 @@ import org.xvm.runtime.Frame;
 
 public class xUInt128
         extends BaseInt128 {
-    public xUInt128(Container container, ClassStructure structure, boolean fInstance) {
+    public xUInt128(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt16.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xUInt16
         extends xUnsignedConstrainedInt {
-    public xUInt16(Container container, ClassStructure structure, boolean fInstance) {
+    public xUInt16(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0, 2L * (long) Short.MAX_VALUE + 1, 16, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt16.java
@@ -17,6 +17,6 @@ public class xUInt16
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xInt16.class);
+        return f_container.nativeTemplate(xInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt16.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt16.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xUInt16
         extends xUnsignedConstrainedInt {
-    public static xUInt16 INSTANCE;
-
     public xUInt16(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0, 2L * (long) Short.MAX_VALUE + 1, 16, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xInt16.INSTANCE;
+        return nativeTemplates().get(xInt16.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt32.java
@@ -11,18 +11,12 @@ import org.xvm.runtime.Container;
  */
 public class xUInt32
         extends xUnsignedConstrainedInt {
-    public static xUInt32 INSTANCE;
-
     public xUInt32(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0, 2L * (long) Integer.MAX_VALUE + 1, 32, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xInt32.INSTANCE;
+        return nativeTemplates().get(xInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt32.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xUInt32
         extends xUnsignedConstrainedInt {
-    public xUInt32(Container container, ClassStructure structure, boolean fInstance) {
+    public xUInt32(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0, 2L * (long) Integer.MAX_VALUE + 1, 32, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt32.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt32.java
@@ -17,6 +17,6 @@ public class xUInt32
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xInt32.class);
+        return f_container.nativeTemplate(xInt32.class);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt64.java
@@ -20,19 +20,13 @@ import org.xvm.util.PackedInteger;
  */
 public class xUInt64
         extends xUnsignedConstrainedInt {
-    public static xUInt64 INSTANCE;
-
     public xUInt64(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0, -1, 64, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xInt64.INSTANCE;
+        return nativeTemplates().get(xInt64.class);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt64.java
@@ -20,7 +20,7 @@ import org.xvm.util.PackedInteger;
  */
 public class xUInt64
         extends xUnsignedConstrainedInt {
-    public xUInt64(Container container, ClassStructure structure, boolean fInstance) {
+    public xUInt64(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0, -1, 64, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt64.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt64.java
@@ -26,7 +26,7 @@ public class xUInt64
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xInt64.class);
+        return f_container.nativeTemplate(xInt64.class);
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt8.java
@@ -36,7 +36,7 @@ public class xUInt8
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return nativeTemplates().get(xInt8.class);
+        return f_container.nativeTemplate(xInt8.class);
     }
 
     @Override
@@ -65,14 +65,14 @@ public class xUInt8
      * @return a Byte handle owned by the specified container
      */
     public static JavaLong makeHandle(Container container, long lValue) {
-        return container.nativeTemplates().get(xUInt8.class).makeHandle(lValue);
+        return container.nativeTemplate(xUInt8.class).makeHandle(lValue);
     }
 
     /**
      * @return a Byte handle owned by the container the specified frame runs in
      */
     public static JavaLong makeHandle(Frame frame, long lValue) {
-        return makeHandle(frame.f_context.f_container, lValue);
+        return makeHandle(frame.container(), lValue);
     }
 
     private final JavaLong[] cache = new JavaLong[256];

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt8.java
@@ -18,7 +18,7 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public class xUInt8
         extends xUnsignedConstrainedInt {
-    public xUInt8(Container container, ClassStructure structure, boolean fInstance) {
+    public xUInt8(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, 0, 255, 8, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt8.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUInt8.java
@@ -18,21 +18,15 @@ import org.xvm.runtime.ObjectHandle.JavaLong;
  */
 public class xUInt8
         extends xUnsignedConstrainedInt {
-    public static xUInt8 INSTANCE;
-
     public xUInt8(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, 0, 255, 8, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
         super.initNative();
 
-        if (this == INSTANCE) {
+        if (isNativeInstance(xUInt8.class)) {
             ClassComposition clz = getCanonicalClass();
             for (int i = 0; i < cache.length; ++i) {
                 cache[i] = new JavaLong(clz, i);
@@ -42,7 +36,7 @@ public class xUInt8
 
     @Override
     protected xConstrainedInteger getComplimentaryTemplate() {
-        return xInt8.INSTANCE;
+        return nativeTemplates().get(xInt8.class);
     }
 
     @Override
@@ -59,9 +53,26 @@ public class xUInt8
         return makeHandle(lValue & 0xFFL);
     }
 
-    public static JavaLong makeHandle(long lValue) {
+    /**
+     * @return a Byte handle owned by this template's container
+     */
+    public JavaLong makeHandle(long lValue) {
         assert lValue >= 0 & lValue <= 255;
-        return INSTANCE.cache[(int) lValue];
+        return cache[(int) lValue];
+    }
+
+    /**
+     * @return a Byte handle owned by the specified container
+     */
+    public static JavaLong makeHandle(Container container, long lValue) {
+        return container.nativeTemplates().get(xUInt8.class).makeHandle(lValue);
+    }
+
+    /**
+     * @return a Byte handle owned by the container the specified frame runs in
+     */
+    public static JavaLong makeHandle(Frame frame, long lValue) {
+        return makeHandle(frame.f_context.f_container, lValue);
     }
 
     private final JavaLong[] cache = new JavaLong[256];

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUIntN.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUIntN.java
@@ -11,7 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xUIntN
         extends xUnconstrainedInteger {
-    public xUIntN(Container container, ClassStructure structure, boolean fInstance) {
+    public xUIntN(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUIntN.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUIntN.java
@@ -11,13 +11,7 @@ import org.xvm.runtime.Container;
  */
 public class xUIntN
         extends xUnconstrainedInteger {
-    public static xUIntN INSTANCE;
-
     public xUIntN(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/numbers/xUnconstrainedInteger.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/numbers/xUnconstrainedInteger.java
@@ -133,13 +133,13 @@ public abstract class xUnconstrainedInteger
         case "bitCount": {
             PackedInteger pi = ((IntNHandle) hTarget).m_piValue;
             int cBits = pi.isBig() ? pi.getBigInteger().bitCount() : Long.bitCount(pi.getLong());
-            return frame.assignValue(iReturn, xInt64.makeHandle(cBits));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, cBits));
         }
 
         case "bitLength": {
             PackedInteger pi    = ((IntNHandle) hTarget).m_piValue;
             int           cBits = pi.getBigInteger().bitLength();
-            return frame.assignValue(iReturn, xInt64.makeHandle(cBits));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, cBits));
         }
 
         case "leftmostBit": {
@@ -165,7 +165,7 @@ public abstract class xUnconstrainedInteger
         }
 
         case "leadingZeroCount":
-            return frame.assignValue(iReturn, xInt64.makeHandle(0));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 0));
 
         case "trailingZeroCount": {
             PackedInteger pi = ((IntNHandle) hTarget).m_piValue;
@@ -175,7 +175,7 @@ public abstract class xUnconstrainedInteger
             } else {
                 c = Long.numberOfTrailingZeros(pi.getLong());
             }
-            return frame.assignValue(iReturn, xInt64.makeHandle(c));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, c));
         }
         }
 
@@ -464,7 +464,7 @@ public abstract class xUnconstrainedInteger
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
         PackedInteger pi = ((IntNHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xString.makeHandle(pi.toString()));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, pi.toString()));
     }
 
 
@@ -488,7 +488,7 @@ public abstract class xUnconstrainedInteger
     public int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         PackedInteger pi = ((IntNHandle) hTarget).getValue();
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(pi.hashCode()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, pi.hashCode()));
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
@@ -93,8 +93,8 @@ public class xClass
                         frame.getGenericsResolver(typeClz.containsDynamicType()));
 
             ClassTemplate template = switch (idClz.getComponent().getFormat()) {
-                case ENUMVALUE -> nativeTemplates().get(xEnumValue.class);
-                case ENUM      -> nativeTemplates().get(xEnumeration.class);
+                case ENUMVALUE -> f_container.nativeTemplate(xEnumValue.class);
+                case ENUM      -> f_container.nativeTemplate(xEnumeration.class);
                 default        -> this;
             };
 
@@ -490,7 +490,7 @@ public class xClass
      */
     public static TypeComposition ensureArrayComposition(Container container) {
         return container.ensureClassComposition(CLASS_ARRAY_TYPE,
-                container.nativeTemplates().get(xArray.class));
+                container.nativeTemplate(xArray.class));
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
@@ -52,14 +52,8 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xClass
         extends xConst {
-    public static xClass INSTANCE;
-
     public xClass(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -99,8 +93,8 @@ public class xClass
                         frame.getGenericsResolver(typeClz.containsDynamicType()));
 
             ClassTemplate template = switch (idClz.getComponent().getFormat()) {
-                case ENUMVALUE -> xEnumValue  .INSTANCE;
-                case ENUM      -> xEnumeration.INSTANCE;
+                case ENUMVALUE -> nativeTemplates().get(xEnumValue.class);
+                case ENUM      -> nativeTemplates().get(xEnumeration.class);
                 default        -> this;
             };
 
@@ -170,7 +164,7 @@ public class xClass
 
     @Override
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
-        return frame.assignValue(iReturn, xInt64.makeHandle(getClassType(hTarget).hashCode()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, getClassType(hTarget).hashCode()));
     }
 
 
@@ -344,14 +338,14 @@ public class xClass
                 if (fTuple) {
                     TypeConstant[] atypeParam = typeClz.getParamTypesArray();
                     for (int i = 0; i < cParams; ++i) {
-                        ahNames[i] = xString.makeHandle("ElementTypes[" + i + "]");
+                        ahNames[i] = xString.makeHandle(frame, "ElementTypes[" + i + "]");
                         ahTypes[i] = atypeParam[i].ensureTypeHandle(container);
                     }
                 } else {
                     Iterator<StringConstant> iterNames  = clz.getTypeParams().keySet().iterator();
                     TypeConstant[]           atypeParam = clz.normalizeParameters(pool, typeClz.getParamTypesArray());
                     for (int i = 0; i < cParams; ++i) {
-                        ahNames[i] = xString.makeHandle(iterNames.next().getValue());
+                        ahNames[i] = xString.makeHandle(frame, iterNames.next().getValue());
                         ahTypes[i] = atypeParam[i].ensureTypeHandle(container);
                     }
                 }
@@ -495,7 +489,8 @@ public class xClass
      * @return the TypeComposition for an Array of Class
      */
     public static TypeComposition ensureArrayComposition(Container container) {
-        return container.ensureClassComposition(CLASS_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(CLASS_ARRAY_TYPE,
+                container.nativeTemplates().get(xArray.class));
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClass.java
@@ -52,7 +52,7 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xClass
         extends xConst {
-    public xClass(Container container, ClassStructure structure, boolean fInstance) {
+    public xClass(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClassTemplate.java
@@ -20,7 +20,7 @@ import org.xvm.runtime.template._native.reflect.xRTComponentTemplate.ComponentTe
  */
 public class xClassTemplate
         extends ClassTemplate {
-    public xClassTemplate(Container container, ClassStructure structure, boolean fInstance) {
+    public xClassTemplate(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClassTemplate.java
@@ -20,14 +20,8 @@ import org.xvm.runtime.template._native.reflect.xRTComponentTemplate.ComponentTe
  */
 public class xClassTemplate
         extends ClassTemplate {
-    public static xClassTemplate INSTANCE;
-
     public xClassTemplate(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -35,7 +29,7 @@ public class xClassTemplate
                           ObjectHandle hValue1, ObjectHandle hValue2, int iReturn) {
         return hValue1 instanceof ComponentTemplateHandle &&
                 hValue2 instanceof ComponentTemplateHandle
-            ? xRTComponentTemplate.INSTANCE.callEquals(frame, clazz, hValue1, hValue2, iReturn)
+            ? nativeTemplates().get(xRTComponentTemplate.class).callEquals(frame, clazz, hValue1, hValue2, iReturn)
             : frame.assignValue(iReturn, xBoolean.FALSE);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xClassTemplate.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xClassTemplate.java
@@ -29,7 +29,7 @@ public class xClassTemplate
                           ObjectHandle hValue1, ObjectHandle hValue2, int iReturn) {
         return hValue1 instanceof ComponentTemplateHandle &&
                 hValue2 instanceof ComponentTemplateHandle
-            ? nativeTemplates().get(xRTComponentTemplate.class).callEquals(frame, clazz, hValue1, hValue2, iReturn)
+            ? f_container.nativeTemplate(xRTComponentTemplate.class).callEquals(frame, clazz, hValue1, hValue2, iReturn)
             : frame.assignValue(iReturn, xBoolean.FALSE);
     }
 }

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumValue.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumValue.java
@@ -19,14 +19,8 @@ import org.xvm.runtime.template.xEnum;
  */
 public class xEnumValue
         extends xClass {
-    public static xEnumValue INSTANCE;
-
     public xEnumValue(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumValue.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumValue.java
@@ -19,7 +19,7 @@ import org.xvm.runtime.template.xEnum;
  */
 public class xEnumValue
         extends xClass {
-    public xEnumValue(Container container, ClassStructure structure, boolean fInstance) {
+    public xEnumValue(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumeration.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumeration.java
@@ -118,7 +118,7 @@ public class xEnumeration
             ConstantPool pool    = frame.poolContext();
             TypeConstant typeMap = pool.ensureMapType(pool.typeString(), idEnumeration.getType());
 
-            switch (nativeTemplates().get(xListMap.class).constructMap(
+            switch (f_container.nativeTemplate(xListMap.class).constructMap(
                         frame, typeMap, ahName, ahVal, false, fDefer, Op.A_STACK)) {
             case Op.R_NEXT: {
                 hMap = frame.popStack();

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumeration.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumeration.java
@@ -30,7 +30,7 @@ import org.xvm.runtime.template.xEnum.EnumHandle;
  */
 public class xEnumeration
         extends xClass {
-    public xEnumeration(Container container, ClassStructure structure, boolean fInstance) {
+    public xEnumeration(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumeration.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xEnumeration.java
@@ -30,14 +30,8 @@ import org.xvm.runtime.template.xEnum.EnumHandle;
  */
 public class xEnumeration
         extends xClass {
-    public static xEnumeration INSTANCE;
-
     public xEnumeration(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -95,7 +89,7 @@ public class xEnumeration
             boolean        fDefer = false;
 
             for (int i = 0; i < cNames; i++) {
-                ahName[i] = xString.makeHandle(listNames.get(i));
+                ahName[i] = xString.makeHandle(frame, listNames.get(i));
 
                 EnumHandle hValue = listValues.get(i);
                 if (hValue.isStruct()) {
@@ -124,7 +118,7 @@ public class xEnumeration
             ConstantPool pool    = frame.poolContext();
             TypeConstant typeMap = pool.ensureMapType(pool.typeString(), idEnumeration.getType());
 
-            switch (xListMap.INSTANCE.constructMap(
+            switch (nativeTemplates().get(xListMap.class).constructMap(
                         frame, typeMap, ahName, ahVal, false, fDefer, Op.A_STACK)) {
             case Op.R_NEXT: {
                 hMap = frame.popStack();

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xInjector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xInjector.java
@@ -22,14 +22,8 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xInjector
         extends xService {
-    public static xInjector INSTANCE;
-
     public xInjector(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xInjector.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xInjector.java
@@ -22,7 +22,7 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xInjector
         extends xService {
-    public xInjector(Container container, ClassStructure structure, boolean fInstance) {
+    public xInjector(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xModule.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xModule.java
@@ -47,19 +47,13 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xModule
         extends xPackage {
-    public static xModule INSTANCE;
-
     public xModule(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xModule.class)) {
             ConstantPool pool = f_container.getConstantPool();
 
             MODULE_ARRAY_TYPE  = pool.ensureArrayType(pool.typeModule());
@@ -131,7 +125,7 @@ public class xModule
      */
     public int getPropertySimpleName(Frame frame, PackageHandle hModule, int iReturn) {
         String sName = ((ModuleConstant) hModule.getId()).getUnqualifiedName();
-        return frame.assignValue(iReturn, xString.makeHandle(sName));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, sName));
     }
 
     /**
@@ -139,7 +133,7 @@ public class xModule
      */
     public int getPropertyQualifiedName(Frame frame, PackageHandle hModule, int iReturn) {
         String sName = hModule.getId().getName();
-        return frame.assignValue(iReturn, xString.makeHandle(sName));
+        return frame.assignValue(iReturn, xString.makeHandle(frame, sName));
     }
 
     /**
@@ -161,7 +155,7 @@ public class xModule
         Container       container = frame.f_context.f_container;
         ModuleConstant  idModule  = (ModuleConstant) hTarget.getId();
         ModuleStructure module    = (ModuleStructure) idModule.getComponent();
-        TypeComposition clzMap    = container.resolveClass(ensureListMapType());
+        TypeComposition clzMap    = container.resolveClass(ensureListMapType(container));
 
         // starting with this module, find all module dependencies, and the shortest path to each
         Map<ModuleConstant, String> mapModulePaths = module.collectDependencies();
@@ -179,7 +173,7 @@ public class xModule
             ModuleConstant idDep = entry.getKey();
             if (idDep != idModule) {
                 ObjectHandle hM = frame.getConstHandle(idDep);
-                ahPaths  [index] = xString.makeHandle(entry.getValue());
+                ahPaths  [index] = xString.makeHandle(container, entry.getValue());
                 ahModules[index] = hM;
                 fDeferred |= Op.isDeferred(hM);
                 ++index;
@@ -210,7 +204,8 @@ public class xModule
     public int invokeClassForName(Frame frame, PackageHandle hTarget, ObjectHandle hArg, int[] aiReturn) {
         ModuleStructure module  = (ModuleStructure) hTarget.getStructure();
         String          sClass  = ((StringHandle) hArg).getStringValue();
-        Object          oResult = resolveClass(module.getFileStructure(), module, sClass);
+        Object          oResult = resolveClass(frame.f_context.f_container,
+                                    module.getFileStructure(), module, sClass);
         if (oResult == null) {
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
         }
@@ -229,7 +224,8 @@ public class xModule
     public int invokeTypeForName(Frame frame, PackageHandle hTarget, ObjectHandle hArg, int[] aiReturn) {
         ModuleStructure module  = (ModuleStructure) hTarget.getStructure();
         String          sType   = ((StringHandle) hArg).getStringValue();
-        Object          oResult = resolveType(module.getFileStructure(), module, sType);
+        Object          oResult = resolveType(frame.f_context.f_container,
+                                    module.getFileStructure(), module, sType);
         if (oResult == null) {
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
         }
@@ -251,8 +247,9 @@ public class xModule
      *
      * @return either a TypeConstant or null if the class couldn't be resolved for any reason
      */
-    public static Object resolveClass(FileStructure structTS, ModuleStructure module, String sClass) {
-        return resolveClassOrType(structTS, module, sClass, true);
+    public static Object resolveClass(Container container, FileStructure structTS,
+                                      ModuleStructure module, String sClass) {
+        return resolveClassOrType(container, structTS, module, sClass, true);
     }
 
     /**
@@ -264,14 +261,18 @@ public class xModule
      *
      * @return either a TypeConstant or null if the type couldn't be resolved for any reason
      */
-    public static Object resolveType(FileStructure structTS, ModuleStructure module, String sType) {
-        return resolveClassOrType(structTS, module, sType, false);
+    public static Object resolveType(Container container, FileStructure structTS,
+                                     ModuleStructure module, String sType) {
+        return resolveClassOrType(container, structTS, module, sType, false);
     }
 
-    private static Object resolveClassOrType(FileStructure structTS, ModuleStructure module, String sClassOrType, boolean fClass) {
+    private static Object resolveClassOrType(Container container, FileStructure structTS,
+                                             ModuleStructure module, String sClassOrType,
+                                             boolean fClass) {
         if (module == null) {
             module = structTS == null
-                ? INSTANCE.f_struct.getFileStructure().getModule()  // only Ecstasy classes
+                ? container.nativeTemplates().get(xModule.class).
+                        f_struct.getFileStructure().getModule()  // only Ecstasy classes
                 : structTS.getModule();
         }
 
@@ -314,7 +315,8 @@ public class xModule
      * @return the TypeComposition for an Array of Module
      */
     public static TypeComposition ensureArrayComposition(Container container) {
-        return container.ensureClassComposition(MODULE_ARRAY_TYPE, xArray.INSTANCE);
+        return container.ensureClassComposition(MODULE_ARRAY_TYPE,
+                container.nativeTemplates().get(xArray.class));
     }
 
     /**
@@ -332,10 +334,10 @@ public class xModule
     /**
      * @return the TypeConstant for {@code ListMap<String, Module>}
      */
-    private static TypeConstant ensureListMapType() {
+    private static TypeConstant ensureListMapType(Container container) {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null) {
-            ConstantPool pool = INSTANCE.pool();
+            ConstantPool pool = container.nativeTemplates().get(xModule.class).pool();
             LISTMAP_TYPE = type = pool.ensureParameterizedTypeConstant(
                     pool.typeListMap(),
                     pool.typeString(), pool.typeModule());

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xModule.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xModule.java
@@ -204,7 +204,7 @@ public class xModule
     public int invokeClassForName(Frame frame, PackageHandle hTarget, ObjectHandle hArg, int[] aiReturn) {
         ModuleStructure module  = (ModuleStructure) hTarget.getStructure();
         String          sClass  = ((StringHandle) hArg).getStringValue();
-        Object          oResult = resolveClass(frame.f_context.f_container,
+        Object          oResult = resolveClass(frame.container(),
                                     module.getFileStructure(), module, sClass);
         if (oResult == null) {
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
@@ -224,7 +224,7 @@ public class xModule
     public int invokeTypeForName(Frame frame, PackageHandle hTarget, ObjectHandle hArg, int[] aiReturn) {
         ModuleStructure module  = (ModuleStructure) hTarget.getStructure();
         String          sType   = ((StringHandle) hArg).getStringValue();
-        Object          oResult = resolveType(frame.f_context.f_container,
+        Object          oResult = resolveType(frame.container(),
                                     module.getFileStructure(), module, sType);
         if (oResult == null) {
             return frame.assignValue(aiReturn[0], xBoolean.FALSE);
@@ -271,7 +271,7 @@ public class xModule
                                              boolean fClass) {
         if (module == null) {
             module = structTS == null
-                ? container.nativeTemplates().get(xModule.class).
+                ? container.nativeTemplate(xModule.class).
                         f_struct.getFileStructure().getModule()  // only Ecstasy classes
                 : structTS.getModule();
         }
@@ -316,7 +316,7 @@ public class xModule
      */
     public static TypeComposition ensureArrayComposition(Container container) {
         return container.ensureClassComposition(MODULE_ARRAY_TYPE,
-                container.nativeTemplates().get(xArray.class));
+                container.nativeTemplate(xArray.class));
     }
 
     /**
@@ -337,7 +337,7 @@ public class xModule
     private static TypeConstant ensureListMapType(Container container) {
         TypeConstant type = LISTMAP_TYPE;
         if (type == null) {
-            ConstantPool pool = container.nativeTemplates().get(xModule.class).pool();
+            ConstantPool pool = container.nativeTemplate(xModule.class).pool();
             LISTMAP_TYPE = type = pool.ensureParameterizedTypeConstant(
                     pool.typeListMap(),
                     pool.typeString(), pool.typeModule());

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xModule.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xModule.java
@@ -47,7 +47,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xModule
         extends xPackage {
-    public xModule(Container container, ClassStructure structure, boolean fInstance) {
+    public xModule(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xPackage.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xPackage.java
@@ -46,19 +46,13 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xPackage
         extends xConst {
-    public static xPackage INSTANCE;
-
     public xPackage(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xPackage.class)) {
             ConstantPool pool = f_container.getConstantPool();
             LIST_MAP_TYPE = pool.ensureParameterizedTypeConstant(
                     pool.typeListMap(), pool.typeString(), pool.typeClass());
@@ -119,7 +113,7 @@ public class xPackage
     @Override
     protected int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         return frame.assignValue(iReturn,
-            xInt64.makeHandle(((PackageHandle) hTarget).getId().hashCode()));
+            xInt64.makeHandle(frame, ((PackageHandle) hTarget).getId().hashCode()));
     }
 
 
@@ -149,7 +143,7 @@ public class xPackage
                 IdentityConstant id     = component.getIdentityConstant();
                 ObjectHandle     hClass = frame.getConstHandle(pool.ensureClassConstant(id.getType()));
 
-                listNames  .add(xString.makeHandle(entry.getKey()));
+                listNames  .add(xString.makeHandle(frame, entry.getKey()));
                 listClasses.add(hClass);
                 fDeferred |= Op.isDeferred(hClass);
             }

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xPackage.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xPackage.java
@@ -46,7 +46,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xPackage
         extends xConst {
-    public xPackage(Container container, ClassStructure structure, boolean fInstance) {
+    public xPackage(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xRef.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xRef.java
@@ -111,7 +111,7 @@ public class xRef
         // subclasses (xInject) inherit this and are not themselves rebased, so the
         // answer is the container's own xRef template's constant - not this instance's, which
         // is only populated for that one template
-        return nativeTemplates().get(xRef.class).f_idInception;
+        return f_container.nativeTemplate(xRef.class).f_idInception;
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xRef.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xRef.java
@@ -66,10 +66,10 @@ public class xRef
      */
     private final ClassConstant f_idInception;
 
-    public xRef(Container container, ClassStructure structure, boolean fInstance) {
+    public xRef(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
 
-        f_idInception = fInstance
+        f_idInception = fBaseTemplate
                 ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
                 : null;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xRef.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xRef.java
@@ -61,17 +61,17 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
 public class xRef
         extends ClassTemplate
         implements VarSupport {
-    public static xRef INSTANCE;
-    public static ClassConstant INCEPTION_CLASS;
+    /**
+     * The rebased inception class for this container's Ref template.
+     */
+    private final ClassConstant f_idInception;
 
     public xRef(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
 
-        if (fInstance) {
-            INSTANCE = this;
-            INCEPTION_CLASS = new NativeRebaseConstant(
-                    (ClassConstant) structure.getIdentityConstant());
-        }
+        f_idInception = fInstance
+                ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
+                : null;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class xRef
 
     @Override
     public void registerNativeTemplates() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xRef.class)) {
             // register the native "Identity" template
             ClassStructure structId = (ClassStructure) f_struct.getChild("Identity");
 
@@ -108,7 +108,10 @@ public class xRef
 
     @Override
     protected ClassConstant getInceptionClassConstant() {
-        return INCEPTION_CLASS;
+        // subclasses (xInject) inherit this and are not themselves rebased, so the
+        // answer is the container's own xRef template's constant - not this instance's, which
+        // is only populated for that one template
+        return nativeTemplates().get(xRef.class).f_idInception;
     }
 
     @Override
@@ -145,7 +148,7 @@ public class xRef
                 h -> frame.assignValue(iReturn, Identity.ensureIdentity(h)));
 
         case "bitLength":
-            return frame.assignValue(iReturn, xInt64.makeHandle(64)); // TODO
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 64)); // TODO
 
         case "selfContained":
             return frame.assignValue(iReturn, xBoolean.makeHandle(hRef.isSelfContained()));
@@ -291,7 +294,7 @@ public class xRef
             String sName = hRef.getName();
             return sName == null
                     ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
-                    : frame.assignValues(aiReturn, xBoolean.TRUE, xString.makeHandle(sName));
+                    : frame.assignValues(aiReturn, xBoolean.TRUE, xString.makeHandle(frame, sName));
         }
 
         case "isProperty": {

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xVar.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xVar.java
@@ -34,10 +34,10 @@ public class xVar
      */
     private final ClassConstant f_idInception;
 
-    public xVar(Container container, ClassStructure structure, boolean fInstance) {
+    public xVar(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
 
-        f_idInception = fInstance
+        f_idInception = fBaseTemplate
                 ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
                 : null;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xVar.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xVar.java
@@ -52,7 +52,7 @@ public class xVar
         // subclasses (xFuture, xLazy, xAtomic) inherit this and are not themselves rebased, so the
         // answer is the container's own xVar template's constant - not this instance's, which
         // is only populated for that one template
-        return nativeTemplates().get(xVar.class).f_idInception;
+        return f_container.nativeTemplate(xVar.class).f_idInception;
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/reflect/xVar.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/reflect/xVar.java
@@ -29,17 +29,17 @@ import org.xvm.runtime.template.xException;
 public class xVar
         extends xRef
         implements VarSupport {
-    public static xVar INSTANCE;
-    public static ClassConstant INCEPTION_CLASS;
+    /**
+     * The rebased inception class for this container's Var template.
+     */
+    private final ClassConstant f_idInception;
 
     public xVar(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
 
-        if (fInstance) {
-            INSTANCE = this;
-            INCEPTION_CLASS = new NativeRebaseConstant(
-                (ClassConstant) structure.getIdentityConstant());
-        }
+        f_idInception = fInstance
+                ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
+                : null;
     }
 
     @Override
@@ -49,7 +49,10 @@ public class xVar
 
     @Override
     protected ClassConstant getInceptionClassConstant() {
-        return INCEPTION_CLASS;
+        // subclasses (xFuture, xLazy, xAtomic) inherit this and are not themselves rebased, so the
+        // answer is the container's own xVar template's constant - not this instance's, which
+        // is only populated for that one template
+        return nativeTemplates().get(xVar.class).f_idInception;
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xChar.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xChar.java
@@ -40,7 +40,7 @@ import org.xvm.util.Handy;
  */
 public class xChar
         extends xConst {
-    public xChar(Container container, ClassStructure structure, boolean fInstance) {
+    public xChar(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xChar.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xChar.java
@@ -40,14 +40,8 @@ import org.xvm.util.Handy;
  */
 public class xChar
         extends xConst {
-    public static xChar INSTANCE;
-
     public xChar(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -58,7 +52,7 @@ public class xChar
 
         invalidateTypeInfo();
 
-        if (this == INSTANCE) {
+        if (isNativeInstance(xChar.class)) {
             ClassComposition clz = getCanonicalClass();
             for (int i = 0; i < cache.length; ++i) {
                 cache[i] = new JavaLong(clz, i);
@@ -122,7 +116,8 @@ public class xChar
     public int invokeNativeGet(Frame frame, String sPropName, ObjectHandle hTarget, int iReturn) {
         switch (sPropName) {
         case "codepoint":
-            return frame.assignValue(iReturn, xUInt32.INSTANCE.makeJavaLong(((JavaLong) hTarget).getValue()));
+            return frame.assignValue(iReturn,
+                    nativeTemplates().get(xUInt32.class).makeJavaLong(((JavaLong) hTarget).getValue()));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -178,18 +173,34 @@ public class xChar
     public int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         JavaLong hThis = (JavaLong) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hThis.getValue()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hThis.getValue()));
     }
 
 
     // ----- helpers -------------------------------------------------------------------------------
 
-    public static JavaLong makeHandle(long chValue) {
+    /**
+     * @return a Char handle owned by this template's container
+     */
+    public JavaLong makeHandle(long chValue) {
         assert chValue >= 0 & chValue <= 0x10FFFF;
-        if (chValue < 128) {
-            return INSTANCE.cache[(int)chValue];
-        }
-        return new JavaLong(INSTANCE.getCanonicalClass(), chValue);
+        return chValue < 128
+                ? cache[(int) chValue]
+                : new JavaLong(getCanonicalClass(), chValue);
+    }
+
+    /**
+     * @return a Char handle owned by the specified container
+     */
+    public static JavaLong makeHandle(Container container, long chValue) {
+        return container.nativeTemplates().get(xChar.class).makeHandle(chValue);
+    }
+
+    /**
+     * @return a Char handle owned by the container the specified frame runs in
+     */
+    public static JavaLong makeHandle(Frame frame, long chValue) {
+        return makeHandle(frame.f_context.f_container, chValue);
     }
 
     private final JavaLong[] cache = new JavaLong[128];

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xChar.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xChar.java
@@ -117,7 +117,7 @@ public class xChar
         switch (sPropName) {
         case "codepoint":
             return frame.assignValue(iReturn,
-                    nativeTemplates().get(xUInt32.class).makeJavaLong(((JavaLong) hTarget).getValue()));
+                    f_container.nativeTemplate(xUInt32.class).makeJavaLong(((JavaLong) hTarget).getValue()));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -193,14 +193,14 @@ public class xChar
      * @return a Char handle owned by the specified container
      */
     public static JavaLong makeHandle(Container container, long chValue) {
-        return container.nativeTemplates().get(xChar.class).makeHandle(chValue);
+        return container.nativeTemplate(xChar.class).makeHandle(chValue);
     }
 
     /**
      * @return a Char handle owned by the container the specified frame runs in
      */
     public static JavaLong makeHandle(Frame frame, long chValue) {
-        return makeHandle(frame.f_context.f_container, chValue);
+        return makeHandle(frame.container(), chValue);
     }
 
     private final JavaLong[] cache = new JavaLong[128];

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xRegEx.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xRegEx.java
@@ -42,7 +42,7 @@ import org.xvm.runtime.template.xNullable;
  */
 public class xRegEx
         extends xConst {
-    public xRegEx(Container container, ClassStructure structure, boolean fInstance) {
+    public xRegEx(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xRegEx.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xRegEx.java
@@ -42,14 +42,8 @@ import org.xvm.runtime.template.xNullable;
  */
 public class xRegEx
         extends xConst {
-    public static xRegEx INSTANCE;
-
     public xRegEx(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -93,7 +87,7 @@ public class xRegEx
     public int invokeNativeGet(Frame frame, String sPropName, ObjectHandle hTarget, int iReturn) {
         RegExHandle hPattern = (RegExHandle) hTarget;
         if ("pattern".equals(sPropName)) {
-            return frame.assignValue(iReturn, xString.makeHandle(hPattern.f_regex));
+            return frame.assignValue(iReturn, xString.makeHandle(frame, hPattern.f_regex));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -110,7 +104,7 @@ public class xRegEx
             return frame.assignValue(iReturn, makeHandle(regex, nFlags));
         }
         case "appendTo": {
-            StringHandle hRegex = xString.makeHandle(((RegExHandle) hTarget).getRegex());
+            StringHandle hRegex = xString.makeHandle(frame, ((RegExHandle) hTarget).getRegex());
             return xString.callAppendTo(frame, hRegex, hArg, iReturn);
         }
         }
@@ -127,7 +121,7 @@ public class xRegEx
             String       text        = hText.getStringValue();
             String       replacement = ((StringHandle) ahArg[1]).getStringValue();
             Matcher      matcher     = ((RegExHandle) hTarget).getPattern().matcher(text);
-            StringHandle hResult     = xString.makeHandle(matcher.replaceAll(replacement));
+            StringHandle hResult     = xString.makeHandle(frame, matcher.replaceAll(replacement));
             return frame.assignValue(iReturn, hResult);
         }
         }
@@ -218,9 +212,9 @@ public class xRegEx
             int nStart = match.start(i);
             if (nStart >= 0) {
                 GenericHandle hRange = new GenericHandle(clzRange);
-                hRange.setField(frame, "lowerBound",     xInt64.makeHandle(nStart));
+                hRange.setField(frame, "lowerBound",     xInt64.makeHandle(frame, nStart));
                 hRange.setField(frame, "lowerExclusive", xBoolean.FALSE);
-                hRange.setField(frame, "upperBound",     xInt64.makeHandle(match.end(i)));
+                hRange.setField(frame, "upperBound",     xInt64.makeHandle(frame, match.end(i)));
                 hRange.setField(frame, "upperExclusive", xBoolean.TRUE);
                 hRange.setField(frame, "descending",     xBoolean.FALSE);
                 hRange.makeImmutable();

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xString.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xString.java
@@ -45,14 +45,8 @@ import org.xvm.util.Handy;
 public class xString
         extends xConst
         implements IndexSupport {
-    public static xString INSTANCE;
-
     public xString(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -136,7 +130,7 @@ public class xString
 
         switch (sPropName) {
         case "size":
-            return frame.assignValue(iReturn, xInt64.makeHandle(hThis.m_achValue.length));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, hThis.m_achValue.length));
 
         case "chars":
             return frame.assignValue(iReturn,
@@ -175,7 +169,7 @@ public class xString
                 }
                 return ofResult < 0
                         ? frame.assignValue(aiReturn[0], xBoolean.FALSE)
-                        : frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(ofResult));
+                        : frame.assignValues(aiReturn, xBoolean.TRUE, xInt64.makeHandle(frame, ofResult));
             }
             }
         }
@@ -192,7 +186,7 @@ public class xString
 
         return nIx < 0
                 ? frame.raiseException(xException.outOfBounds(frame, lIndex, ach.length))
-                : frame.assignValue(iReturn, xChar.makeHandle(ach[nIx]));
+                : frame.assignValue(iReturn, xChar.makeHandle(frame, ach[nIx]));
     }
 
     @Override
@@ -279,7 +273,9 @@ public class xString
         char[] ach = new char[c1 + c2];
         System.arraycopy(ach1, 0, ach, 0, c1);
         System.arraycopy(ach2, 0, ach, c1, c2);
-        return makeHandle(ach);
+
+        // the result belongs where the string being appended to belongs
+        return makeHandle(h1.getComposition().getContainer(), ach);
     }
 
     private static int indexOf(char[] achSource, char chTarget, int ofStart) {
@@ -367,7 +363,8 @@ public class xString
         public JavaLong getHashCode() {
             JavaLong hHash = m_hash;
             return hHash == null
-                    ? (m_hash = xInt64.makeHandle(calcHashCode()))
+                    ? (m_hash = xInt64.makeHandle(getComposition().getContainer(),
+                            calcHashCode()))
                     : hHash;
         }
 
@@ -400,14 +397,48 @@ public class xString
         }
     }
 
-    public static StringHandle makeHandle(String sValue) {
+    /**
+     * @return a String handle owned by this template's container
+     */
+    public StringHandle makeHandle(String sValue) {
         return makeHandle(sValue.toCharArray());
     }
 
-    public static StringHandle makeHandle(char[] achValue) {
+    /**
+     * @return a String handle owned by this template's container
+     */
+    public StringHandle makeHandle(char[] achValue) {
         return achValue.length == 0
             ? EMPTY_STRING
-            : new StringHandle(INSTANCE.getCanonicalClass(), achValue);
+            : new StringHandle(getCanonicalClass(), achValue);
+    }
+
+    /**
+     * @return a String handle owned by the specified container
+     */
+    public static StringHandle makeHandle(Container container, String sValue) {
+        return container.nativeTemplates().get(xString.class).makeHandle(sValue);
+    }
+
+    /**
+     * @return a String handle owned by the specified container
+     */
+    public static StringHandle makeHandle(Container container, char[] achValue) {
+        return container.nativeTemplates().get(xString.class).makeHandle(achValue);
+    }
+
+    /**
+     * @return a String handle owned by the container the specified frame runs in
+     */
+    public static StringHandle makeHandle(Frame frame, String sValue) {
+        return makeHandle(frame.f_context.f_container, sValue);
+    }
+
+    /**
+     * @return a String handle owned by the container the specified frame runs in
+     */
+    public static StringHandle makeHandle(Frame frame, char[] achValue) {
+        return makeHandle(frame.f_context.f_container, achValue);
     }
 
 
@@ -416,11 +447,11 @@ public class xString
     /**
      * @return an immutable array of Strings
      */
-    public static ArrayHandle makeArrayHandle(String[] asValue) {
+    public static ArrayHandle makeArrayHandle(Container container, String[] asValue) {
         int            cValues = asValue.length;
         StringHandle[] ahValue = new StringHandle[cValues];
         for (int i = 0; i < cValues; i++) {
-            ahValue[i] = makeHandle(asValue[i]);
+            ahValue[i] = makeHandle(container, asValue[i]);
         }
         return xArray.makeStringArrayHandle(ahValue);
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xString.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xString.java
@@ -417,28 +417,28 @@ public class xString
      * @return a String handle owned by the specified container
      */
     public static StringHandle makeHandle(Container container, String sValue) {
-        return container.nativeTemplates().get(xString.class).makeHandle(sValue);
+        return container.nativeTemplate(xString.class).makeHandle(sValue);
     }
 
     /**
      * @return a String handle owned by the specified container
      */
     public static StringHandle makeHandle(Container container, char[] achValue) {
-        return container.nativeTemplates().get(xString.class).makeHandle(achValue);
+        return container.nativeTemplate(xString.class).makeHandle(achValue);
     }
 
     /**
      * @return a String handle owned by the container the specified frame runs in
      */
     public static StringHandle makeHandle(Frame frame, String sValue) {
-        return makeHandle(frame.f_context.f_container, sValue);
+        return makeHandle(frame.container(), sValue);
     }
 
     /**
      * @return a String handle owned by the container the specified frame runs in
      */
     public static StringHandle makeHandle(Frame frame, char[] achValue) {
-        return makeHandle(frame.f_context.f_container, achValue);
+        return makeHandle(frame.container(), achValue);
     }
 
 

--- a/javatools/src/main/java/org/xvm/runtime/template/text/xString.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/text/xString.java
@@ -45,7 +45,7 @@ import org.xvm.util.Handy;
 public class xString
         extends xConst
         implements IndexSupport {
-    public xString(Container container, ClassStructure structure, boolean fInstance) {
+    public xString(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xBoolean.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xBoolean.java
@@ -19,7 +19,7 @@ public class xBoolean
     public static BooleanHandle TRUE;
     public static BooleanHandle FALSE;
 
-    public xBoolean(Container container, ClassStructure structure, boolean fInstance) {
+    public xBoolean(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xBoolean.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xBoolean.java
@@ -66,7 +66,7 @@ public class xBoolean
     @Override
     protected int buildStringValue(Frame frame, ObjectHandle hTarget, int iReturn) {
         return frame.assignValue(iReturn,
-                xString.makeHandle(hTarget == FALSE ? "False" : "True"));
+                xString.makeHandle(frame, hTarget == FALSE ? "False" : "True"));
     }
 
     public static BooleanHandle makeHandle(boolean f) {

--- a/javatools/src/main/java/org/xvm/runtime/template/xConst.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xConst.java
@@ -57,14 +57,8 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xConst
         extends ClassTemplate {
-    public static xConst INSTANCE;
-
     public xConst(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
@@ -80,7 +74,7 @@ public class xConst
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xConst.class)) {
             // equals and Comparable support
             getStructure().findMethod("equals",   3).markNative();
             getStructure().findMethod("compare",  3).markNative();
@@ -192,7 +186,7 @@ public class xConst
             }
 
             ObjectHandle[] ahArg = new ObjectHandle[constructor.getMaxVars()];
-            ahArg[0] = xString.makeHandle(constLiteral.getValue());
+            ahArg[0] = xString.makeHandle(frame, constLiteral.getValue());
 
             return construct(frame, constructor, clz, null, ahArg, Op.A_STACK);
         }
@@ -357,7 +351,7 @@ public class xConst
     protected int callEqualsImpl(Frame frame, TypeComposition clazz,
                                  ObjectHandle hValue1, ObjectHandle hValue2, int iReturn) {
         // Note: the actual types could be subclasses of the specified class
-        return this == INSTANCE
+        return isNativeInstance(xConst.class)
                 ? frame.raiseException(xException.abstractMethod(frame, "Const.compare()"))
                 : new Equals((GenericHandle) hValue1, (GenericHandle) hValue2,
                     (ClassComposition) clazz, iReturn).doNext(frame);
@@ -367,7 +361,7 @@ public class xConst
     protected int callCompareImpl(Frame frame, TypeComposition clazz,
                                   ObjectHandle hValue1, ObjectHandle hValue2, int iReturn) {
         // Note: the actual types could be subclasses of the specified class
-        return this == INSTANCE
+        return isNativeInstance(xConst.class)
                 ? frame.raiseException(xException.abstractMethod(frame, "Const.compare()"))
                 : new Compare((GenericHandle) hValue1, (GenericHandle) hValue2,
                         (ClassComposition) clazz, iReturn).doNext(frame);
@@ -384,7 +378,7 @@ public class xConst
      * @return one of the {@link Op#R_NEXT}, {@link Op#R_CALL} or {@link Op#R_EXCEPTION} values
      */
     public int callHashCode(Frame frame, TypeConstant type, ObjectHandle hValue, int iReturn) {
-        return this == INSTANCE
+        return isNativeInstance(xConst.class)
                 ? frame.raiseException(xException.abstractMethod(frame, "Const.hashCode()"))
                 : buildHashCode(frame, getCanonicalClass(frame.f_context.f_container), hValue, iReturn);
     }
@@ -435,7 +429,7 @@ public class xConst
 
             return frame.call1(FN_ESTIMATE_LENGTH, null, ahVars, iReturn);
         } else {
-            return frame.assignValue(iReturn, xInt64.makeHandle(2));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, 2));
         }
     }
 
@@ -762,7 +756,7 @@ public class xConst
                 lResult = clzBase.hashCode();
             }
 
-            JavaLong hHash = xInt64.makeHandle(lResult);
+            JavaLong hHash = xInt64.makeHandle(frameCaller, lResult);
             if (fCache) {
                 hConst.setField(frameCaller, PROP_HASH, hHash);
             }

--- a/javatools/src/main/java/org/xvm/runtime/template/xConst.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xConst.java
@@ -57,7 +57,7 @@ import org.xvm.runtime.template._native.reflect.xRTType.TypeHandle;
  */
 public class xConst
         extends ClassTemplate {
-    public xConst(Container container, ClassStructure structure, boolean fInstance) {
+    public xConst(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
@@ -36,7 +36,7 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xEnum
         extends xConst {
-    public xEnum(Container container, ClassStructure structure, boolean fInstance) {
+    public xEnum(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xEnum.java
@@ -36,19 +36,13 @@ import org.xvm.runtime.template.text.xString;
  */
 public class xEnum
         extends xConst {
-    public static xEnum INSTANCE;
-
     public xEnum(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xEnum.class)) {
             // all the methods are marked as native due to a "rebase"
 
             RANGE_TEMPLATE = f_container.getTemplate("Range");
@@ -158,10 +152,10 @@ public class xEnum
         }
 
         case "name":
-            return frame.assignValue(iReturn, xString.makeHandle(m_listNames.get(hThis.getOrdinal())));
+            return frame.assignValue(iReturn, xString.makeHandle(frame, m_listNames.get(hThis.getOrdinal())));
 
         case "ordinal":
-            return frame.assignValue(iReturn, xInt64.makeHandle(hThis.getOrdinal()));
+            return frame.assignValue(iReturn, xInt64.makeHandle(frame, hThis.getOrdinal()));
         }
 
         return super.invokeNativeGet(frame, sPropName, hTarget, iReturn);
@@ -175,7 +169,7 @@ public class xEnum
         if (method.getName().equals("stepsTo")) {
             EnumHandle hThat = (EnumHandle) hTarget;
             return frame.assignValue(iReturn,
-                    xInt64.makeHandle(hThis.getOrdinal() - hThat.getOrdinal()));
+                    xInt64.makeHandle(frame, hThis.getOrdinal() - hThat.getOrdinal()));
         }
         return super.invokeNative1(frame, method, hTarget, hArg, iReturn);
     }
@@ -203,7 +197,7 @@ public class xEnum
     public int buildHashCode(Frame frame, TypeComposition clazz, ObjectHandle hTarget, int iReturn) {
         EnumHandle hThis = (EnumHandle) hTarget;
 
-        return frame.assignValue(iReturn, xInt64.makeHandle(hThis.getOrdinal()));
+        return frame.assignValue(iReturn, xInt64.makeHandle(frame, hThis.getOrdinal()));
     }
 
     @Override
@@ -211,7 +205,7 @@ public class xEnum
         EnumHandle hThis = (EnumHandle) hTarget;
 
         return frame.assignValue(iReturn,
-                xString.makeHandle(m_listNames.get(hThis.getOrdinal())));
+                xString.makeHandle(frame, m_listNames.get(hThis.getOrdinal())));
     }
 
     @Override

--- a/javatools/src/main/java/org/xvm/runtime/template/xException.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xException.java
@@ -27,7 +27,7 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xException
         extends xConst {
-    public xException(Container container, ClassStructure structure, boolean fInstance) {
+    public xException(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xException.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xException.java
@@ -27,21 +27,15 @@ import org.xvm.runtime.template.text.xString.StringHandle;
  */
 public class xException
         extends xConst {
-    public static xException INSTANCE;
-
     public xException(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure, false);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xException.class)) {
             // cache all the well-known exception classes
-            s_clzException                  = INSTANCE.getCanonicalClass();
+            s_clzException                  = nativeTemplates().get(xException.class).getCanonicalClass();
             s_clzDeadlock                   = f_container.getTemplate("Deadlock"                     ).getCanonicalClass();
             s_clzIllegalArgument            = f_container.getTemplate("IllegalArgument"              ).getCanonicalClass();
             s_clzIllegalState               = f_container.getTemplate("IllegalState"                 ).getCanonicalClass();
@@ -282,7 +276,9 @@ public class xException
                                              String sMessage, ExceptionHandle hCause) {
         ExceptionHandle hException = makeMutableStruct(frame, clzEx, null);
 
-        hException.setField(frame, "text",  sMessage == null ? xNullable.NULL : xString.makeHandle(sMessage));
+        hException.setField(frame, "text",  sMessage == null
+                ? xNullable.NULL
+                : xString.makeHandle(clzEx.getContainer(), sMessage));
         hException.setField(frame, "cause", hCause == null   ? xNullable.NULL : hCause);
         hException.makeImmutable();
 
@@ -309,7 +305,9 @@ public class xException
                                              String sMessage, String sRtError) {
         ExceptionHandle hException = makeMutableStruct(frame, clzEx, sRtError);
 
-        hException.setField(frame, "text",  sMessage == null ? xNullable.NULL : xString.makeHandle(sMessage));
+        hException.setField(frame, "text",  sMessage == null
+                ? xNullable.NULL
+                : xString.makeHandle(clzEx.getContainer(), sMessage));
         hException.setField(frame, "cause", xNullable.NULL);
         hException.makeImmutable();
 
@@ -321,7 +319,9 @@ public class xException
 
         ExceptionHandle hException = new ExceptionHandle(clxEx, sRTError);
 
-        hException.setField(frame, "stackTrace", xString.makeHandle(
+        // the frame is null when translating a native exception (see Utils.translate), so the
+        // owner has to come from the composition the exception is being built with
+        hException.setField(frame, "stackTrace", xString.makeHandle(clxEx.getContainer(),
                 frame == null ? "" : frame.getStackTrace()));
 
         return hException;

--- a/javatools/src/main/java/org/xvm/runtime/template/xException.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xException.java
@@ -35,7 +35,7 @@ public class xException
     public void initNative() {
         if (isNativeInstance(xException.class)) {
             // cache all the well-known exception classes
-            s_clzException                  = nativeTemplates().get(xException.class).getCanonicalClass();
+            s_clzException                  = f_container.nativeTemplate(xException.class).getCanonicalClass();
             s_clzDeadlock                   = f_container.getTemplate("Deadlock"                     ).getCanonicalClass();
             s_clzIllegalArgument            = f_container.getTemplate("IllegalArgument"              ).getCanonicalClass();
             s_clzIllegalState               = f_container.getTemplate("IllegalState"                 ).getCanonicalClass();

--- a/javatools/src/main/java/org/xvm/runtime/template/xNullable.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xNullable.java
@@ -15,7 +15,7 @@ public class xNullable
         extends xEnum {
     public static EnumHandle NULL;
 
-    public xNullable(Container container, ClassStructure structure, boolean fInstance) {
+    public xNullable(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xObject.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xObject.java
@@ -13,20 +13,15 @@ import org.xvm.runtime.Container;
  */
 public class xObject
         extends ClassTemplate {
-    public static xObject INSTANCE;
     public static ClassComposition CLASS;
 
     public xObject(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
-
-        if (fInstance) {
-            INSTANCE = this;
-        }
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xObject.class)) {
             CLASS = getCanonicalClass();
 
             markNativeMethod("equals", null, BOOLEAN);

--- a/javatools/src/main/java/org/xvm/runtime/template/xObject.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xObject.java
@@ -15,7 +15,7 @@ public class xObject
         extends ClassTemplate {
     public static ClassComposition CLASS;
 
-    public xObject(Container container, ClassStructure structure, boolean fInstance) {
+    public xObject(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xOrdered.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xOrdered.java
@@ -19,7 +19,7 @@ public class xOrdered
     public static EnumHandle EQUAL;
     public static EnumHandle GREATER;
 
-    public xOrdered(Container container, ClassStructure structure, boolean fInstance) {
+    public xOrdered(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure, false);
     }
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xOrdered.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xOrdered.java
@@ -32,9 +32,9 @@ public class xOrdered
             EQUAL   = getEnumByOrdinal(1);
             GREATER = getEnumByOrdinal(2);
 
-            LESSER .setField(null, "symbol", xString.makeHandle("<"));
-            EQUAL  .setField(null, "symbol", xString.makeHandle("="));
-            GREATER.setField(null, "symbol", xString.makeHandle(">"));
+            LESSER .setField(null, "symbol", xString.makeHandle(f_container, "<"));
+            EQUAL  .setField(null, "symbol", xString.makeHandle(f_container, "="));
+            GREATER.setField(null, "symbol", xString.makeHandle(f_container, ">"));
 
             LESSER .setField(null, "reversed", GREATER);
             EQUAL  .setField(null, "reversed", EQUAL);

--- a/javatools/src/main/java/org/xvm/runtime/template/xService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xService.java
@@ -52,6 +52,16 @@ public class xService
      */
     private final ClassConstant f_idInception;
 
+    /**
+     * @param fInstance  true iff this is the rebased base template over the {@code Service}
+     *                   interface, rather than a template for a concrete service class
+     *
+     * Note: the flag cannot be replaced by a {@code NativeTemplates} lookup. The
+     * table only answers once construction has finished - that is what keeps a half-built template
+     * from escaping - and the answer is needed here, because {@link NativeRebaseConstant} may only
+     * be built over an interface. Every concrete service template (xRTKeyStore, xRTServer, ...)
+     * runs this constructor over a SERVICE structure, and would trip that assertion.
+     */
     public xService(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
 

--- a/javatools/src/main/java/org/xvm/runtime/template/xService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xService.java
@@ -53,8 +53,9 @@ public class xService
     private final ClassConstant f_idInception;
 
     /**
-     * @param fInstance  true iff this is the rebased base template over the {@code Service}
-     *                   interface, rather than a template for a concrete service class
+     * @param fBaseTemplate  true iff this is the container's base template for this class - here,
+     *                       the rebased template over the {@code Service} interface, rather than
+     *                       a template for a concrete service class
      *
      * Note: the flag cannot be replaced by a {@code NativeTemplates} lookup. The
      * table only answers once construction has finished - that is what keeps a half-built template
@@ -62,10 +63,10 @@ public class xService
      * be built over an interface. Every concrete service template (xRTKeyStore, xRTServer, ...)
      * runs this constructor over a SERVICE structure, and would trip that assertion.
      */
-    public xService(Container container, ClassStructure structure, boolean fInstance) {
+    public xService(Container container, ClassStructure structure, boolean fBaseTemplate) {
         super(container, structure);
 
-        f_idInception = fInstance
+        f_idInception = fBaseTemplate
                 ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
                 : null;
     }

--- a/javatools/src/main/java/org/xvm/runtime/template/xService.java
+++ b/javatools/src/main/java/org/xvm/runtime/template/xService.java
@@ -46,27 +46,23 @@ import org.xvm.runtime.template._native.temporal.xNanosTimer;
  */
 public class xService
         extends ClassTemplate {
-    public static xService INSTANCE;
-    public static ClassConstant INCEPTION_CLASS;
+    /**
+     * The rebased inception class for this container's Service template; null unless this is
+     * the container's native Service template.
+     */
+    private final ClassConstant f_idInception;
 
     public xService(Container container, ClassStructure structure, boolean fInstance) {
         super(container, structure);
 
-        if (fInstance) {
-            INSTANCE = this;
-            INCEPTION_CLASS = new NativeRebaseConstant(
-                (ClassConstant) structure.getIdentityConstant());
-        }
-    }
-
-    @Override
-    public void registerNativeTemplates() {
-        new Proxy(f_container); // this initializes the Proxy.INSTANCE reference
+        f_idInception = fInstance
+                ? new NativeRebaseConstant((ClassConstant) structure.getIdentityConstant())
+                : null;
     }
 
     @Override
     public void initNative() {
-        if (this == INSTANCE) {
+        if (isNativeInstance(xService.class)) {
             SYNCHRONICITY = (xEnum) f_container.getTemplate("Service.Synchronicity");
 
             // since Service is an interface, we cannot annotate the properties naturally and need to do
@@ -85,7 +81,7 @@ public class xService
 
     @Override
     protected ClassConstant getInceptionClassConstant() {
-        return this == INSTANCE ? INCEPTION_CLASS : (ClassConstant) super.getInceptionClassConstant();
+        return isNativeInstance(xService.class) ? f_idInception : (ClassConstant) super.getInceptionClassConstant();
     }
 
     /**
@@ -320,7 +316,7 @@ public class xService
             return frame.f_context.f_container.ensureTypeSystemHandle(frame, iReturn);
 
         case "serviceName":
-            return frame.assignValue(iReturn, xString.makeHandle(hService.f_context.f_sName));
+            return frame.assignValue(iReturn, xString.makeHandle(frame, hService.f_context.f_sName));
 
         case "serviceControl":
             return frame.assignValue(iReturn, xRTServiceControl.makeHandle(hService.f_context));

--- a/javatools/src/test/java/org/xvm/runtime/NativeTemplatePerContainerTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/NativeTemplatePerContainerTest.java
@@ -17,7 +17,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import java.io.File;
+
+import java.util.Objects;
+
+import java.util.concurrent.CancellationException;
+
 import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.Constants;
+import org.xvm.asm.DirRepository;
+import org.xvm.asm.LinkedRepository;
+import org.xvm.asm.ModuleRepository;
+
+import org.xvm.asm.constants.TypeConstant;
+
+import org.xvm.runtime.template._native.reflect.xRTType;
 
 import org.xvm.runtime.template.collections.xArray;
 import org.xvm.runtime.template.numbers.xInt64;
@@ -30,12 +45,15 @@ import org.xvm.runtime.template._native.collections.arrays.xRTDelegate;
 import org.xvm.runtime.template._native.reflect.xRTFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Coverage for replacing the per-template {@code INSTANCE} statics with the container-owned table.
  *
- * <p>Both tests read javatools' own compiled classes - not XTC modules, and nothing from the XDK.
+ * <p>The first two tests read javatools' own compiled classes - not XTC modules, and nothing from the XDK.
  * {@code compileJava} is upstream of {@code test}, so those class files exist by construction; that
  * is what lets these run everywhere without an assumption, unlike anything that needs a built
  * distribution.</p>
@@ -108,6 +126,35 @@ public class NativeTemplatePerContainerTest {
                 NativeTemplates.componentNameOf(xRTDelegate.class));
     }
 
+    /**
+     * Threading a container through the static factories must not break the paths that have no
+     * frame and no container to give.
+     *
+     * <p>{@code Utils.translate} turns a native throwable into an exception handle with a null
+     * frame, and a "foreign" type handle is built for a type outside the asking type system.
+     * Both used to read a process-global template and so never needed an owner; both now take one
+     * from the composition they are building against.</p>
+     */
+    @Test
+    public void ownerlessFactoryPathsStillWork() {
+        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+
+        var runtime = new Runtime();
+        try {
+            var container = new NativeContainer(runtime, systemRepository());
+
+            ObjectHandle.ExceptionHandle hEx =
+                    Utils.translate(new CancellationException());
+            assertNotNull(hEx, "a native throwable must translate without a frame");
+
+            TypeConstant type = container.getTemplate("Object").getCanonicalType();
+            assertNotNull(xRTType.makeForeignHandle(container, type),
+                    "a foreign type handle must be creatable");
+        } finally {
+            runtime.shutdownXVM();
+        }
+    }
+
     // ----- helpers -----------------------------------------------------------------------------
 
     @FunctionalInterface
@@ -144,5 +191,47 @@ public class NativeTemplatePerContainerTest {
             }
         }
         return cScanned;
+    }
+    private static boolean systemModulesAvailable() {
+        var repository = systemRepository();
+        return repository != null
+            && repository.loadModule(Constants.ECSTASY_MODULE) != null
+            && repository.loadModule(Constants.TURTLE_MODULE)  != null
+            && repository.loadModule(Constants.NATIVE_MODULE)  != null;
+    }
+
+    private static ModuleRepository systemRepository() {
+        var repositories = Stream.of(
+                "lib_ecstasy/build/xtc/main/lib",
+                "javatools_bridge/build/xtc/main/lib",
+                "xdk/build/install/xdk/lib")
+                .map(NativeTemplatePerContainerTest::repositoryFor)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return switch (repositories.size()) {
+        case 0  -> null;
+        case 1  -> repositories.getFirst();
+        default -> new LinkedRepository(repositories.toArray(ModuleRepository.NO_REPOS));
+        };
+    }
+
+    private static ModuleRepository repositoryFor(String sPath) {
+        File dir = checkoutRoot().resolve(sPath).toFile();
+        return dir.isDirectory()
+                ? new DirRepository(dir, true)
+                : null;
+    }
+
+    private static Path checkoutRoot() {
+        var path = Path.of("").toAbsolutePath();
+        while (path != null) {
+            if (Files.isDirectory(path.resolve("javatools"))
+                    && Files.isDirectory(path.resolve("lib_ecstasy"))) {
+                return path;
+            }
+            path = path.getParent();
+        }
+        throw new IllegalStateException("Cannot locate checkout root");
     }
 }

--- a/javatools/src/test/java/org/xvm/runtime/NativeTemplatePerContainerTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/NativeTemplatePerContainerTest.java
@@ -1,0 +1,229 @@
+package org.xvm.runtime;
+
+
+import java.io.File;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.Objects;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import org.xvm.asm.Constants;
+import org.xvm.asm.DirRepository;
+import org.xvm.asm.LinkedRepository;
+import org.xvm.asm.ModuleRepository;
+
+import org.xvm.asm.constants.TypeConstant;
+
+import org.xvm.runtime.template._native.reflect.xRTType;
+
+import org.xvm.runtime.template.xConst;
+import org.xvm.runtime.template.xEnum;
+import org.xvm.runtime.template.xObject;
+import org.xvm.runtime.template.xService;
+
+import org.xvm.runtime.template.collections.xArray;
+
+import org.xvm.runtime.template.numbers.xInt64;
+
+import org.xvm.runtime.template.text.xString;
+
+import org.xvm.runtime.template._native.collections.arrays.xRTDelegate;
+
+import org.xvm.runtime.template._native.reflect.xRTFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+
+/**
+ * A native template must belong to the container that asks for it.
+ *
+ * <p>Native templates are built per container: {@link NativeContainer} constructs a fresh set for
+ * every instance, and a single JVM can build several (the interpreter connector does exactly that).
+ * The templates therefore carry an owner - {@link ClassTemplate#f_container} - and every lookup
+ * has to resolve to the asking container's copy.</p>
+ *
+ * <p>These tests build two containers <em>in series</em>, with no concurrency at all, and check
+ * that the earlier container still resolves its own templates after the later one exists.</p>
+ */
+public class NativeTemplatePerContainerTest {
+    /**
+     * Baseline: two containers built in series own two disjoint sets of templates, and the first
+     * container stays live and keeps resolving its own templates by name.
+     */
+    @Test
+    public void containersBuiltInSeriesOwnDistinctTemplates() {
+        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+
+        var runtime = new Runtime();
+        try {
+            var containerA = new NativeContainer(runtime, systemRepository());
+            var containerB = new NativeContainer(runtime, systemRepository());
+
+            for (String sName : new String[] {"Object", "Const", "Enum", "Service"}) {
+                ClassTemplate templateA = containerA.getTemplate(sName);
+                ClassTemplate templateB = containerB.getTemplate(sName);
+
+                assertNotSame(templateA, templateB,
+                        () -> "each container builds its own \"" + sName + "\" template");
+                assertSame(containerA, templateA.f_container,
+                        () -> "container A's \"" + sName + "\" template must be owned by A");
+                assertSame(containerB, templateB.f_container,
+                        () -> "container B's \"" + sName + "\" template must be owned by B");
+            }
+        } finally {
+            runtime.shutdownXVM();
+        }
+    }
+
+    /**
+     * The defect, in series and fully deterministic.
+     *
+     * <p>A {@link TypeComposition} reports both the container it belongs to and the template that
+     * implements it, and those two must agree - the template a composition hands out is used to
+     * build handles, resolve types and pick a constant pool. {@link ProxyComposition} resolves its
+     * template through the native template cache, so this asserts the invariant for the container
+     * built first while a second container exists.</p>
+     *
+     * <p>When the cache is a process-global mutable static, the last container to be constructed
+     * wins it and the first container is handed a foreign template - and with it a foreign
+     * container, pool and type system.</p>
+     */
+    @Test
+    public void aCompositionResolvesTheTemplateOfItsOwnContainer() {
+        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+
+        var runtime = new Runtime();
+        try {
+            var containerA = new NativeContainer(runtime, systemRepository());
+            var containerB = new NativeContainer(runtime, systemRepository());
+
+            assertCompositionOwnsItsTemplate(containerB, "B (built last)");
+            assertCompositionOwnsItsTemplate(containerA, "A (built first)");
+        } finally {
+            runtime.shutdownXVM();
+        }
+    }
+
+    private static void assertCompositionOwnsItsTemplate(NativeContainer container, String sLabel) {
+        ClassTemplate   templateObject = container.getTemplate("Object");
+        TypeComposition clzOrigin      = templateObject.getCanonicalClass();
+
+        assertSame(container, clzOrigin.getContainer(),
+                () -> "the origin composition must belong to container " + sLabel);
+
+        var clzProxy = new ProxyComposition(clzOrigin, templateObject.getCanonicalType());
+
+        assertSame(container, clzProxy.getContainer(),
+                () -> "the proxy composition must belong to container " + sLabel);
+        assertSame(container, clzProxy.getTemplate().f_container,
+                () -> "container " + sLabel + " must resolve its own Proxy template, but got one"
+                        + " owned by a different container");
+        assertSame(clzProxy.getTemplate(), clzProxy.getSupport(),
+                () -> "template and op-support must be the same object for container " + sLabel);
+    }
+
+    /**
+     * The table finds most templates by deriving a component name from the template class, so that
+     * derivation has to agree with the rule NativeContainer's scanner used to register them:
+     * strip the package prefix, then drop the leading 'x' from the simple name.
+     *
+     * <p>This is the one stringly-typed step in the lookup, and it needs no container to check.</p>
+     */
+    @Test
+    public void componentNamesFollowTheLoadersRule() {
+        assertEquals("Object",            NativeTemplates.componentNameOf(xObject.class));
+        assertEquals("Enum",              NativeTemplates.componentNameOf(xEnum.class));
+        assertEquals("Const",             NativeTemplates.componentNameOf(xConst.class));
+        assertEquals("Service",           NativeTemplates.componentNameOf(xService.class));
+        assertEquals("numbers.Int64",     NativeTemplates.componentNameOf(xInt64.class));
+        assertEquals("text.String",       NativeTemplates.componentNameOf(xString.class));
+        assertEquals("collections.Array", NativeTemplates.componentNameOf(xArray.class));
+        assertEquals("_native.reflect.RTFunction",
+                NativeTemplates.componentNameOf(xRTFunction.class));
+        assertEquals("_native.collections.arrays.RTDelegate",
+                NativeTemplates.componentNameOf(xRTDelegate.class));
+    }
+
+    /**
+     * Threading a container through the static factories must not break the paths that have no
+     * frame and no container to give.
+     *
+     * <p>{@code Utils.translate} turns a native throwable into an exception handle with a null
+     * frame, and a "foreign" type handle is built for a type outside the asking type system.
+     * Both used to read a process-global template and so never needed an owner; both now take one
+     * from the composition they are building against.</p>
+     */
+    @Test
+    public void ownerlessFactoryPathsStillWork() {
+        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+
+        var runtime = new Runtime();
+        try {
+            var container = new NativeContainer(runtime, systemRepository());
+
+            ObjectHandle.ExceptionHandle hEx =
+                    Utils.translate(new java.util.concurrent.CancellationException());
+            assertNotNull(hEx, "a native throwable must translate without a frame");
+
+            TypeConstant type = container.getTemplate("Object").getCanonicalType();
+            assertNotNull(xRTType.makeForeignHandle(container, type),
+                    "a foreign type handle must be creatable");
+        } finally {
+            runtime.shutdownXVM();
+        }
+    }
+
+    // ----- helpers -----------------------------------------------------------------------------
+
+    private static boolean systemModulesAvailable() {
+        var repository = systemRepository();
+        return repository != null
+            && repository.loadModule(Constants.ECSTASY_MODULE) != null
+            && repository.loadModule(Constants.TURTLE_MODULE)  != null
+            && repository.loadModule(Constants.NATIVE_MODULE)  != null;
+    }
+
+    private static ModuleRepository systemRepository() {
+        var repositories = Stream.of(
+                "lib_ecstasy/build/xtc/main/lib",
+                "javatools_bridge/build/xtc/main/lib",
+                "xdk/build/install/xdk/lib")
+                .map(NativeTemplatePerContainerTest::repositoryFor)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return switch (repositories.size()) {
+        case 0  -> null;
+        case 1  -> repositories.getFirst();
+        default -> new LinkedRepository(repositories.toArray(ModuleRepository.NO_REPOS));
+        };
+    }
+
+    private static ModuleRepository repositoryFor(String sPath) {
+        File dir = checkoutRoot().resolve(sPath).toFile();
+        return dir.isDirectory()
+                ? new DirRepository(dir, true)
+                : null;
+    }
+
+    private static Path checkoutRoot() {
+        var path = Path.of("").toAbsolutePath();
+        while (path != null) {
+            if (Files.isDirectory(path.resolve("javatools"))
+                    && Files.isDirectory(path.resolve("lib_ecstasy"))) {
+                return path;
+            }
+            path = path.getParent();
+        }
+        throw new IllegalStateException("Cannot locate checkout root");
+    }
+}

--- a/javatools/src/test/java/org/xvm/runtime/NativeTemplatePerContainerTest.java
+++ b/javatools/src/test/java/org/xvm/runtime/NativeTemplatePerContainerTest.java
@@ -1,142 +1,97 @@
 package org.xvm.runtime;
 
 
-import java.io.File;
+import java.io.IOException;
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.instruction.FieldInstruction;
+
+import java.lang.reflect.AccessFlag;
+
+import java.net.URISyntaxException;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import java.util.Objects;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import org.xvm.asm.Constants;
-import org.xvm.asm.DirRepository;
-import org.xvm.asm.LinkedRepository;
-import org.xvm.asm.ModuleRepository;
-
-import org.xvm.asm.constants.TypeConstant;
-
-import org.xvm.runtime.template._native.reflect.xRTType;
-
+import org.xvm.runtime.template.collections.xArray;
+import org.xvm.runtime.template.numbers.xInt64;
+import org.xvm.runtime.template.text.xString;
 import org.xvm.runtime.template.xConst;
 import org.xvm.runtime.template.xEnum;
 import org.xvm.runtime.template.xObject;
 import org.xvm.runtime.template.xService;
-
-import org.xvm.runtime.template.collections.xArray;
-
-import org.xvm.runtime.template.numbers.xInt64;
-
-import org.xvm.runtime.template.text.xString;
-
 import org.xvm.runtime.template._native.collections.arrays.xRTDelegate;
-
 import org.xvm.runtime.template._native.reflect.xRTFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A native template must belong to the container that asks for it.
+ * Coverage for replacing the per-template {@code INSTANCE} statics with the container-owned table.
  *
- * <p>Native templates are built per container: {@link NativeContainer} constructs a fresh set for
- * every instance, and a single JVM can build several (the interpreter connector does exactly that).
- * The templates therefore carry an owner - {@link ClassTemplate#f_container} - and every lookup
- * has to resolve to the asking container's copy.</p>
+ * <p>Both tests read javatools' own compiled classes - not XTC modules, and nothing from the XDK.
+ * {@code compileJava} is upstream of {@code test}, so those class files exist by construction; that
+ * is what lets these run everywhere without an assumption, unlike anything that needs a built
+ * distribution.</p>
  *
- * <p>These tests build two containers <em>in series</em>, with no concurrency at all, and check
- * that the earlier container still resolves its own templates after the later one exists.</p>
+ * <p>Reading the class files rather than the source is the point of the exercise. A reviewer of a
+ * change spread over 139 sites can read a handful, recognise the pattern, and have the scan
+ * guarantee the rest did not deviate - including a site that kept the old shape under a different
+ * spelling, which reading text would miss.</p>
  */
 public class NativeTemplatePerContainerTest {
     /**
-     * Baseline: two containers built in series own two disjoint sets of templates, and the first
-     * container stays live and keeps resolving its own templates by name.
+     * No native template declares an {@code INSTANCE} static, and no code in the template tree
+     * reads one. Together those are the invariant the change establishes: a template is reached
+     * through its container's table, never through a JVM-global field.
+     *
+     * <p>Deliberately narrow. The template tree still holds other mutable statics, some of them
+     * templates under different names ({@code xPackage.LIST_MAP_TEMPLATE},
+     * {@code xEnum.RANGE_TEMPLATE}, {@code xArray.MUTABILITY} among them). They are the same shape
+     * and worth converting, but they are not what this change touched, and a test should pin what
+     * was done rather than fail on work nobody claimed to have finished.</p>
      */
     @Test
-    public void containersBuiltInSeriesOwnDistinctTemplates() {
-        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
+    public void theTemplateTreeIsFreeOfInstanceStatics() throws IOException, URISyntaxException {
+        var listDeclared = new ArrayList<String>();
+        var listRead     = new ArrayList<String>();
 
-        var runtime = new Runtime();
-        try {
-            var containerA = new NativeContainer(runtime, systemRepository());
-            var containerB = new NativeContainer(runtime, systemRepository());
+        int cScanned = forEachTemplateClassFile((sClass, abBytes) -> {
+            var model = ClassFile.of().parse(abBytes);
 
-            for (String sName : new String[] {"Object", "Const", "Enum", "Service"}) {
-                ClassTemplate templateA = containerA.getTemplate(sName);
-                ClassTemplate templateB = containerB.getTemplate(sName);
+            model.fields().forEach(field -> {
+                if (field.flags().has(AccessFlag.STATIC)
+                        && "INSTANCE".equals(field.fieldName().stringValue())) {
+                    listDeclared.add(sClass);
+                }
+            });
 
-                assertNotSame(templateA, templateB,
-                        () -> "each container builds its own \"" + sName + "\" template");
-                assertSame(containerA, templateA.f_container,
-                        () -> "container A's \"" + sName + "\" template must be owned by A");
-                assertSame(containerB, templateB.f_container,
-                        () -> "container B's \"" + sName + "\" template must be owned by B");
-            }
-        } finally {
-            runtime.shutdownXVM();
-        }
+            model.methods().forEach(method ->
+                method.code().ifPresent(code -> code.elementList().stream()
+                        .filter(FieldInstruction.class::isInstance)
+                        .map(FieldInstruction.class::cast)
+                        .filter(field -> "INSTANCE".equals(field.name().stringValue()))
+                        .forEach(field -> listRead.add(
+                                sClass + '.' + method.methodName().stringValue()))));
+        });
+
+        assertTrue(cScanned > 100,
+                "expected the whole template tree; only " + cScanned + " classes were scanned");
+        assertEquals(List.of(), listDeclared,
+                "native templates must not publish themselves through an INSTANCE static");
+        assertEquals(List.of(), listRead,
+                "these sites still reach a template through a static INSTANCE field");
     }
 
     /**
-     * The defect, in series and fully deterministic.
-     *
-     * <p>A {@link TypeComposition} reports both the container it belongs to and the template that
-     * implements it, and those two must agree - the template a composition hands out is used to
-     * build handles, resolve types and pick a constant pool. {@link ProxyComposition} resolves its
-     * template through the native template cache, so this asserts the invariant for the container
-     * built first while a second container exists.</p>
-     *
-     * <p>When the cache is a process-global mutable static, the last container to be constructed
-     * wins it and the first container is handed a foreign template - and with it a foreign
-     * container, pool and type system.</p>
-     */
-    @Test
-    public void aCompositionResolvesTheTemplateOfItsOwnContainer() {
-        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
-
-        var runtime = new Runtime();
-        try {
-            var containerA = new NativeContainer(runtime, systemRepository());
-            var containerB = new NativeContainer(runtime, systemRepository());
-
-            assertCompositionOwnsItsTemplate(containerB, "B (built last)");
-            assertCompositionOwnsItsTemplate(containerA, "A (built first)");
-        } finally {
-            runtime.shutdownXVM();
-        }
-    }
-
-    private static void assertCompositionOwnsItsTemplate(NativeContainer container, String sLabel) {
-        ClassTemplate   templateObject = container.getTemplate("Object");
-        TypeComposition clzOrigin      = templateObject.getCanonicalClass();
-
-        assertSame(container, clzOrigin.getContainer(),
-                () -> "the origin composition must belong to container " + sLabel);
-
-        var clzProxy = new ProxyComposition(clzOrigin, templateObject.getCanonicalType());
-
-        assertSame(container, clzProxy.getContainer(),
-                () -> "the proxy composition must belong to container " + sLabel);
-        assertSame(container, clzProxy.getTemplate().f_container,
-                () -> "container " + sLabel + " must resolve its own Proxy template, but got one"
-                        + " owned by a different container");
-        assertSame(clzProxy.getTemplate(), clzProxy.getSupport(),
-                () -> "template and op-support must be the same object for container " + sLabel);
-    }
-
-    /**
-     * The table finds most templates by deriving a component name from the template class, so that
-     * derivation has to agree with the rule NativeContainer's scanner used to register them:
-     * strip the package prefix, then drop the leading 'x' from the simple name.
-     *
-     * <p>This is the one stringly-typed step in the lookup, and it needs no container to check.</p>
+     * The class-to-component-name rule the container's table resolves through - the mechanism that
+     * replaced the statics, so the thing all 139 sites now depend on.
      */
     @Test
     public void componentNamesFollowTheLoadersRule() {
@@ -153,77 +108,41 @@ public class NativeTemplatePerContainerTest {
                 NativeTemplates.componentNameOf(xRTDelegate.class));
     }
 
-    /**
-     * Threading a container through the static factories must not break the paths that have no
-     * frame and no container to give.
-     *
-     * <p>{@code Utils.translate} turns a native throwable into an exception handle with a null
-     * frame, and a "foreign" type handle is built for a type outside the asking type system.
-     * Both used to read a process-global template and so never needed an owner; both now take one
-     * from the composition they are building against.</p>
-     */
-    @Test
-    public void ownerlessFactoryPathsStillWork() {
-        assumeTrue(systemModulesAvailable(), "compiled XDK system modules are required");
-
-        var runtime = new Runtime();
-        try {
-            var container = new NativeContainer(runtime, systemRepository());
-
-            ObjectHandle.ExceptionHandle hEx =
-                    Utils.translate(new java.util.concurrent.CancellationException());
-            assertNotNull(hEx, "a native throwable must translate without a frame");
-
-            TypeConstant type = container.getTemplate("Object").getCanonicalType();
-            assertNotNull(xRTType.makeForeignHandle(container, type),
-                    "a foreign type handle must be creatable");
-        } finally {
-            runtime.shutdownXVM();
-        }
-    }
-
     // ----- helpers -----------------------------------------------------------------------------
 
-    private static boolean systemModulesAvailable() {
-        var repository = systemRepository();
-        return repository != null
-            && repository.loadModule(Constants.ECSTASY_MODULE) != null
-            && repository.loadModule(Constants.TURTLE_MODULE)  != null
-            && repository.loadModule(Constants.NATIVE_MODULE)  != null;
+    @FunctionalInterface
+    private interface ClassFileVisitor {
+        void accept(String className, byte[] bytes);
     }
 
-    private static ModuleRepository systemRepository() {
-        var repositories = Stream.of(
-                "lib_ecstasy/build/xtc/main/lib",
-                "javatools_bridge/build/xtc/main/lib",
-                "xdk/build/install/xdk/lib")
-                .map(NativeTemplatePerContainerTest::repositoryFor)
-                .filter(Objects::nonNull)
-                .toList();
+    /**
+     * Visit every compiled native template class.
+     *
+     * <p>Failures here are assertions rather than assumptions on purpose: if the classes cannot be
+     * scanned the test has proved nothing, and saying so quietly is how a suite comes to report a
+     * coverage it does not have.</p>
+     *
+     * @return the number of classes scanned
+     */
+    private static int forEachTemplateClassFile(ClassFileVisitor visitor)
+            throws IOException, URISyntaxException {
+        Path pathAnchor = Path.of(xObject.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI());
+        assertTrue(Files.isDirectory(pathAnchor),
+                "the templates must be scannable as exploded classes, but the code source is "
+                        + pathAnchor);
 
-        return switch (repositories.size()) {
-        case 0  -> null;
-        case 1  -> repositories.getFirst();
-        default -> new LinkedRepository(repositories.toArray(ModuleRepository.NO_REPOS));
-        };
-    }
+        Path pathTemplates = pathAnchor.resolve("org/xvm/runtime/template");
+        assertTrue(Files.isDirectory(pathTemplates),
+                "the compiled template tree is missing at " + pathTemplates);
 
-    private static ModuleRepository repositoryFor(String sPath) {
-        File dir = checkoutRoot().resolve(sPath).toFile();
-        return dir.isDirectory()
-                ? new DirRepository(dir, true)
-                : null;
-    }
-
-    private static Path checkoutRoot() {
-        var path = Path.of("").toAbsolutePath();
-        while (path != null) {
-            if (Files.isDirectory(path.resolve("javatools"))
-                    && Files.isDirectory(path.resolve("lib_ecstasy"))) {
-                return path;
+        int cScanned = 0;
+        try (Stream<Path> files = Files.walk(pathTemplates)) {
+            for (Path path : files.filter(p -> p.toString().endsWith(".class")).toList()) {
+                visitor.accept(pathAnchor.relativize(path).toString(), Files.readAllBytes(path));
+                cScanned++;
             }
-            path = path.getParent();
         }
-        throw new IllegalStateException("Cannot locate checkout root");
+        return cScanned;
     }
 }


### PR DESCRIPTION
## The defect

Native templates published themselves into mutable `public static` fields from their constructors:

```java
public class xEnum extends xConst {
    public static xEnum INSTANCE;                      // plain mutable static

    public xEnum(Container container, ClassStructure structure, boolean fInstance) {
        super(container, structure, false);
        if (fInstance) {
            INSTANCE = this;                           // this-escape, during construction
        }
    }
}
```

**139 sites did this. 196 sites read the result.** None of the fields were `volatile` or `final`.

Templates are constructed **per container** (`NativeContainer:172-175`), and a JVM can build several — `InterpreterConnector:36` does `new NativeContainer(runtime, repository)`, and so does every embedding host and several tests.

### It is wrong in series, with no concurrency involved

Every `Connector` builds its own root: `InterpreterConnector`'s constructor is `new Runtime()` plus `new NativeContainer(...)`, and `Runner` builds a Connector per run. A host that runs several modules in one JVM therefore has several native containers alive at once — the Gradle plugin's direct mode does exactly this, in one cached classloader.

All ~139 native templates are constructed by a native container (`newInstance(this, structClass, Boolean.TRUE)`), so each new root overwrites the statics. Two native containers are **unrelated** — neither is an ancestor or descendant of the other — so code acting on root A's behalf then reads a template owned by root B: wrong container, wrong pool, wrong type system.

To be precise about what is *not* the problem: nested containers under a single root never construct native templates, and `getTemplate(String)` resolves through `getNativeContainer()`, so under one root `INSTANCE` holds an ancestor-owned template and reading it is legitimate. This bug needs a second root.

The clearest case is `Proxy.makeAsyncNativeHandle`, which does `new AsyncHandle(INSTANCE.f_container, method)`: **it takes a `Container` out of a JVM-global mutable static** — and with more than one root, that container can belong to an entirely different runtime.

Note that the reachability sweep cannot catch this: it deliberately does not enumerate `static` roots. That is a reason to delete the static, not to trust a clean sweep.

`xEnum.initNative()` also branches on `if (this == INSTANCE)`, so which object won the assignment decides whether native rebase initialisation runs at all. That is behaviour, not caching.

Add threads and it is additionally a `this`-escape publishing a partially-constructed object to a shared static with no safe publication.

## The change

Template lookup moves into one container-owned table (`NativeTemplates`), reached from the container that is asking rather than from a static. The dangerous pattern is expressed once, in one reviewable place, instead of being pasted 139 times.

**Zero `INSTANCE = this` and zero mutable `public static … INSTANCE` declarations remain.** Net **−75 lines** (187 files, +1639/−1714) despite adding the module.

Seven commits, each building independently: the table; the migration; a note recording why the `fInstance` constructor flag has to stay (it does not become redundant, contrary to my first assumption); two readability passes (container accessors, and renaming that flag to `fBaseTemplate`); a dead cast; and the test rework described below.

## Verification

- `./gradlew build` green; `:javatools:test` 351 tests, 0 failures, 40 skips (the standing set).
- End-to-end `xcc` + `xec` on a real module: output **byte-identical to master**.
- Commits 1 and 2 each verified to build on their own.

A review pass over my own change caught **two regressions I had introduced**, both from a scripted rewrite threading a container or frame that master deliberately leaves null: an NPE on `xRTType.makeHandle`'s foreign-handle path (three callers pass `null` intentionally), and an NPE on every native-throwable translation in `xException`, because `Utils.translate` passes a null frame. Both are fixed, folded into the commits that introduced them, and pinned by `ownerlessFactoryPathsStillWork`.

That pass also found composition caches I had bound to the *first caller's* container — which could be a short-lived nested container pinned forever in a static — where master bound them to the long-lived native container. Restored.

## Readability: say which container is being asked

Two accessors, in their own commit, because the migration otherwise made the diff harder to read than the code it replaced. Call sites had become:

```java
frame.f_context.f_container.nativeTemplates().get(xListMap.class)
```

Four hops to name one template — and when the lookup is four hops through another object's fields, a reader cannot see *whose* table is being asked, which is the question this PR exists to make answerable.

- `Frame.container()` — three lines; master had no such accessor.
- `Container.nativeTemplate(Class<T>)` and `Frame.nativeTemplate(Class<T>)` — a shorthand for the case that is 91% of all uses.

On the lines this PR introduces: `f_context.f_container` went **89 → 1**, and `nativeTemplates().get(...)` went **256 → 1**. Both survivors are deliberate — one chain starts from a `ServiceHandle`, which has no `container()`, and the other is `Container.nativeTemplate`'s own body.

`NativeTemplates.of(...)` keeps all four overloads; they are layered rather than redundant, and each now says so in its javadoc. `of(TypeComposition)` alone has 21 call sites, and neither it nor `of(ClassTemplate)` can be replaced by the shorthand, because those types have no owner accessor of their own. `ClassTemplate` deliberately did **not** gain a `nativeTemplate(...)` — `isNativeInstance` now reads `this == f_container.nativeTemplate(clz)`, which names the owner at the identity comparison instead of hiding it.

The ~198 pre-existing `f_context.f_container` sites elsewhere in the tree are untouched. That sweep is mechanical and obvious, but it does not belong inside a 181-file diff.

## `fInstance` renamed to `fBaseTemplate`

The flag used to mean "assign yourself to `INSTANCE`". That mechanism is gone, so the name was a fossil pointing at a removed mechanism — and with 151 declarations against 6 real consumers, a reader's first conclusion is that it is dead.

It is not. Removing it was attempted, and fails during bootstrap: `xService` is constructed both as the rebased base template over the `Service` interface and as the template for every concrete service class, and only the first may build a `NativeRebaseConstant`, whose constructor asserts its argument is an interface. The table cannot answer the question either, and that is by design — it is populated *after* a template finishes constructing, which is precisely the property that stops templates escaping mid-construction.

`fBaseTemplate` rather than `fRebase`, because five consumers turn it into a rebase but the sixth does not: `xRTConnector` passes `false` to its super and uses its own flag to build a process-wide user-agent string. "This is the container's base template for this class" is true at all 151 sites; "rebase" is not.

## What this does NOT fix — see #572

This removes the `INSTANCE` template cache. It does **not** end last-writer-wins across containers, because a large population of owner-bearing values is still held in mutable `public static` fields assigned from per-container `initNative()`: `xObject.CLASS`, `xString.EMPTY_STRING`/`EMPTY_ARRAY`, `xBoolean.TRUE`/`FALSE`, `xNullable.NULL`, `xArray`'s `*_ARRAY_CLZ` compositions, `xRTDelegate.DELEGATES`, and others.

Two places that leaks through a public API even after this change:

- `xString.makeHandle(Container, char[])` returns the global `EMPTY_STRING` for a zero-length array, ignoring the container it was handed;
- `xArray.makeBitArrayHandle` and friends derive their owner *from* a static `TypeComposition`.

Those are pre-existing and out of scope here, but they mean the guarantee this change provides is narrower than its name suggests, and I would rather say so than let the name carry more weight than the code. Filed as #572.



