### PR TITLE
Fix potential deadlock in XUnit when obtaining injectables during test execution

### DIFF
--- a/lib_xunit/src/main/x/xunit/annotations/AfterAll.x
+++ b/lib_xunit/src/main/x/xunit/annotations/AfterAll.x
@@ -43,6 +43,6 @@ annotation AfterAll
             implements AfterAllCallback {
 
         @Override
-        void afterAll(ExecutionContext context) = context.methodExecutor.invoke(after, context);
+        void afterAll(ExecutionContext context) = executor.invoke(after, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/AfterAll.x
+++ b/lib_xunit/src/main/x/xunit/annotations/AfterAll.x
@@ -43,6 +43,6 @@ annotation AfterAll
             implements AfterAllCallback {
 
         @Override
-        void afterAll(ExecutionContext context) = context.invoke(after);
+        void afterAll(ExecutionContext context) = context.methodExecutor.invoke(after, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/AfterEach.x
+++ b/lib_xunit/src/main/x/xunit/annotations/AfterEach.x
@@ -42,6 +42,6 @@ annotation AfterEach
         Boolean requiresTarget.get() = after.is(Method);
 
         @Override
-        void afterEach(ExecutionContext context) = context.methodExecutor.invoke(after, context);
+        void afterEach(ExecutionContext context) = executor.invoke(after, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/AfterEach.x
+++ b/lib_xunit/src/main/x/xunit/annotations/AfterEach.x
@@ -42,6 +42,6 @@ annotation AfterEach
         Boolean requiresTarget.get() = after.is(Method);
 
         @Override
-        void afterEach(ExecutionContext context) = context.invoke(after);
+        void afterEach(ExecutionContext context) = context.methodExecutor.invoke(after, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/BeforeAll.x
+++ b/lib_xunit/src/main/x/xunit/annotations/BeforeAll.x
@@ -40,6 +40,6 @@ annotation BeforeAll
             implements BeforeAllCallback {
 
         @Override
-        void beforeAll(ExecutionContext context) = context.invoke(before);
+        void beforeAll(ExecutionContext context) = context.methodExecutor.invoke(before, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/BeforeAll.x
+++ b/lib_xunit/src/main/x/xunit/annotations/BeforeAll.x
@@ -40,6 +40,6 @@ annotation BeforeAll
             implements BeforeAllCallback {
 
         @Override
-        void beforeAll(ExecutionContext context) = context.methodExecutor.invoke(before, context);
+        void beforeAll(ExecutionContext context) = executor.invoke(before, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/BeforeEach.x
+++ b/lib_xunit/src/main/x/xunit/annotations/BeforeEach.x
@@ -42,6 +42,6 @@ annotation BeforeEach
         Boolean requiresTarget.get() = before.is(Method);
 
         @Override
-        void beforeEach(ExecutionContext context) = context.invoke(before);
+        void beforeEach(ExecutionContext context) = context.methodExecutor.invoke(before, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/BeforeEach.x
+++ b/lib_xunit/src/main/x/xunit/annotations/BeforeEach.x
@@ -42,6 +42,6 @@ annotation BeforeEach
         Boolean requiresTarget.get() = before.is(Method);
 
         @Override
-        void beforeEach(ExecutionContext context) = context.methodExecutor.invoke(before, context);
+        void beforeEach(ExecutionContext context) = executor.invoke(before, context);
     }
 }

--- a/lib_xunit/src/main/x/xunit/annotations/ParameterizedTest.x
+++ b/lib_xunit/src/main/x/xunit/annotations/ParameterizedTest.x
@@ -43,7 +43,7 @@ annotation ParameterizedTest(Function<Tuple, Tuple> parameters, String group=Tes
         @Override
         Iterable<TestTemplateContext> getContexts(ExecutionContext context) {
             List<ParameterizedTestTemplateContext> templateContexts = new Array();
-            if (var o := context.invokeSingleResult(parameters)) {
+            if (var o := context.methodExecutor.invokeSingleResult(parameters, context)) {
                 if (o.is(Collection)) {
                     for (var arg : o) {
                         Argument[] args = createArguments(arg);

--- a/lib_xunit/src/main/x/xunit/annotations/ParameterizedTest.x
+++ b/lib_xunit/src/main/x/xunit/annotations/ParameterizedTest.x
@@ -43,7 +43,7 @@ annotation ParameterizedTest(Function<Tuple, Tuple> parameters, String group=Tes
         @Override
         Iterable<TestTemplateContext> getContexts(ExecutionContext context) {
             List<ParameterizedTestTemplateContext> templateContexts = new Array();
-            if (var o := context.methodExecutor.invokeSingleResult(parameters, context)) {
+            if (var o := executor.invokeSingleResult(parameters, context)) {
                 if (o.is(Collection)) {
                     for (var arg : o) {
                         Argument[] args = createArguments(arg);

--- a/lib_xunit/src/main/x/xunit/executor.x
+++ b/lib_xunit/src/main/x/xunit/executor.x
@@ -1,10 +1,10 @@
-import xunit.extensions.ParameterResolver;
+import extensions.ExecutionContext;
+import extensions.ParameterResolver;
 
 /**
- * A `MethodExecutor` can invoke methods and functions, using supplied `ParameterResolver`s
- * to bind any invocation parameters.
+ * The `executor` package contains classes and functions related to executing tests.
  */
-const MethodExecutor {
+package executor {
     /**
      * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources
      * to resolve parameters for the function.

--- a/lib_xunit/src/main/x/xunit/extensions/ExecutionContext.x
+++ b/lib_xunit/src/main/x/xunit/extensions/ExecutionContext.x
@@ -30,9 +30,9 @@ interface ExecutionContext {
     @RO ResourceRegistry registry;
 
     /**
-     * The current test fixture the test method will execute against.
+     * A reference to the current test fixture the test method will execute against.
      */
-    @RO Object? testFixture;
+    @RO Ref<Object>? testFixture;
 
     /**
      * Any `Exception thrown during execution of the test lifecycle.
@@ -40,26 +40,9 @@ interface ExecutionContext {
     @RO Exception? exception;
 
     /**
-     * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources to resolve
-     * parameters for the function.
-     *
-     * @param method the `MethodOrFunction` to invoke
-     *
-     * @return the result of invoking the function
+     * The `MethodExecutor` to use to execute methods and functions.
      */
-    Tuple invoke(MethodOrFunction method);
-
-    /**
-     * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources
-     * to resolve parameters for the function and return the single result returned by the
-     * invocation.
-     *
-     * @param method the `MethodOrFunction` to invoke
-     *
-     * @return `True` iff the invocation returned a result
-     * @return the single result of invoking the function
-     */
-    conditional Object invokeSingleResult(MethodOrFunction method);
+    @RO MethodExecutor methodExecutor;
 
     /**
      * Lookup a resource stored in this context.
@@ -72,5 +55,4 @@ interface ExecutionContext {
      * @return the requested resource
      */
     conditional Object lookup(Type type, String name, Options opts = Null);
-
 }

--- a/lib_xunit/src/main/x/xunit/extensions/ExecutionContext.x
+++ b/lib_xunit/src/main/x/xunit/extensions/ExecutionContext.x
@@ -40,11 +40,6 @@ interface ExecutionContext {
     @RO Exception? exception;
 
     /**
-     * The `MethodExecutor` to use to execute methods and functions.
-     */
-    @RO MethodExecutor methodExecutor;
-
-    /**
      * Lookup a resource stored in this context.
      *
      * @param type  the type of the resource to lookup

--- a/lib_xunit/src/main/x/xunit/extensions/MethodExecutor.x
+++ b/lib_xunit/src/main/x/xunit/extensions/MethodExecutor.x
@@ -6,22 +6,52 @@ import xunit.extensions.ParameterResolver;
  */
 const MethodExecutor {
     /**
-     * Invoke a `Function` using any registered `ParameterResolver` resources
+     * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources
      * to resolve parameters for the function.
      *
-     * @param fn         the function to invoke
-     * @param resolvers  the `ParameterResolver`s to use to resolve any function parameters
+     * @param method   the `Method` or `Function` to invoke
+     * @param context  the `ExecutionContext` for the current test
      *
      * @return the result of invoking the function
      */
-    Tuple invoke(Function<Tuple<>, Tuple<>> fn, EngineExecutionContext context) {
+    Tuple invoke(MethodOrFunction method, ExecutionContext context) {
+        if (method.is(Method)) {
+            Ref<Object>? testFixtureRef = context.testFixture;
+            assert testFixtureRef != Null;
+            Object testFixture = testFixtureRef.get();
+            assert testFixture != Null;
+            return invoke(method.as(Method), testFixture, context);
+         }
+        return invokeFunction(method.as(Function), context);
+    }
+
+    private Tuple invokeFunction(Function<Tuple<>, Tuple<>> fn, ExecutionContext context) {
         if (fn.params.size == 0) {
             return fn();
         }
         Map<Parameter, Object> params = ParameterResolver.ensureResolved(context, fn.params);
         Function fnInvoke = fn.bind(params);
         assert fnInvoke.params.size == 0 as $"Did not bind all parameters for {fn}";
-        return invoke(fnInvoke, context);
+        return fnInvoke.as(Function<Tuple<>, Tuple<>>)();
+    }
+
+    /**
+     * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources
+     * to resolve parameters for the function and return the single result returned by the
+     * invocation.
+     *
+     * @param method   the `MethodOrFunction` to invoke
+     * @param context  the `ExecutionContext` for the current test
+     *
+     * @return `True` iff the invocation returned a result
+     * @return the single result of invoking the function
+     */
+    conditional Object invokeSingleResult(MethodOrFunction method, ExecutionContext context) {
+        Tuple tuple = invoke(method, context);
+        if (tuple.size > 0) {
+            return True, tuple[0];
+         }
+        return False;
     }
 
     /**
@@ -35,7 +65,7 @@ const MethodExecutor {
      *
      * @return the result of invoking the function
      */
-    Tuple invoke(Method method, Object target, EngineExecutionContext context) {
+    Tuple invoke(Method method, Object target, ExecutionContext context) {
         Function<Tuple, Tuple> fn = method.bindTarget(target);
         return invoke(fn, context);
     }
@@ -53,10 +83,7 @@ const MethodExecutor {
      * @return `True` iff the invocation returned a result
      * @return the single result of invoking the function
      */
-    conditional Object invokeSingleResult(Method                 method,
-                                          Object                 target,
-                                          EngineExecutionContext context) {
-
+    conditional Object invokeSingleResult(Method method, Object target, ExecutionContext context) {
         Tuple tuple = invoke(method, target, context);
         if (tuple.size > 0) {
             return True, tuple[0];
@@ -75,8 +102,7 @@ const MethodExecutor {
      * @return `True` iff the invocation returned a result
      * @return the single result of invoking the function
      */
-    conditional Object invokeSingleResult(Function<Tuple, Tuple> fn,
-                                          EngineExecutionContext context) {
+    conditional Object invokeSingleResult(Function<Tuple, Tuple> fn, ExecutionContext context) {
 
         Tuple tuple = invoke(fn, context);
         if (tuple.size > 0) {

--- a/lib_xunit_engine/src/main/x/xunit_engine/DiscoveryConfiguration.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/DiscoveryConfiguration.x
@@ -148,10 +148,18 @@ const DiscoveryConfiguration {
 
             if (tests.is(List<String>)) {
                 for (String test : tests) {
-// ToDo JK: Fix why specifying a method seems to hang somewhere
-//                    assert:arg Selector[] testSelectors := discovery.selectors.forMethod(clz, test)
-//                            as $"Invalid test method specified {testClass}.{test}";
-//                    selectors.add(selector);
+                    if (Int idx := test.lastIndexOf('.')) {
+                        String testClass  = test[0..<idx];
+                        String testMethod = test[idx>..<test.size];
+                        if (Class clz := findClass(testModule, testClass)) {
+                            selectors.addAll(discovery.selectors.forMethod(clz, testMethod));
+                        } else {
+                            throw new IllegalArgument($"Invalid test class specified {test}");
+                        }
+                    } else {
+                        // method must be on the module
+                        selectors.addAll(discovery.selectors.forMethod(&testModule.class, test));
+                    }
                 }
             }
 

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/BaseExecutionLifecycle.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/BaseExecutionLifecycle.x
@@ -2,6 +2,8 @@ import extensions.ExtensionRegistry;
 
 import xunit.MethodOrFunction;
 
+import xunit.executor;
+
 /**
  * A base class for `ExecutionLifecycle` implementations.
  */
@@ -35,7 +37,7 @@ import xunit.MethodOrFunction;
 
         if (MethodOrFunction constructor := model.constructor.is(MethodOrFunction)) {
             // ToDo: call pre/post fixture constructor extensions
-            if (Object fixture := context.methodExecutor.invokeSingleResult(constructor, context)) {
+            if (Object fixture := executor.invokeSingleResult(constructor, context)) {
                 return fixture;
             }
         }

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/BaseExecutionLifecycle.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/BaseExecutionLifecycle.x
@@ -35,7 +35,7 @@ import xunit.MethodOrFunction;
 
         if (MethodOrFunction constructor := model.constructor.is(MethodOrFunction)) {
             // ToDo: call pre/post fixture constructor extensions
-            if (Object fixture := context.invokeSingleResult(constructor)) {
+            if (Object fixture := context.methodExecutor.invokeSingleResult(constructor, context)) {
                 return fixture;
             }
         }

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/ContainerExecutionLifecycle.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/ContainerExecutionLifecycle.x
@@ -55,7 +55,7 @@ const ContainerExecutionLifecycle<ModelType extends ContainerModel>(ModelType mo
         EngineExecutionContext beforeContext;
         if (Class testClass := model.testClass.is(TestFixture), testClass.lifecycle == Singleton) {
             Object fixture = ensureFixture(context, extensions, testClass);
-            beforeContext = context.asBuilder(model).withTestFixture(fixture).build();
+            beforeContext = context.asBuilder(model).withTestFixture(&fixture).build();
         } else {
             beforeContext = context;
         }

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/EngineExecutionContext.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/EngineExecutionContext.x
@@ -4,10 +4,13 @@ import xunit.MethodOrFunction;
 
 import xunit.extensions.ExecutionContext;
 
+import xunit.extensions.MethodExecutor;
+
 /**
  * Information about the current phase of execution of a test fixture.
  * A test fixture could be a test method, or a test container.
  */
+@Concurrent
 service EngineExecutionContext
         implements ExecutionContext {
     /**
@@ -31,66 +34,65 @@ service EngineExecutionContext
     /**
      * The `Model` to execute.
      */
-    Model model;
+    public/private Model model;
 
     /**
      * The `UniqueId` of the current test fixture.
      */
     @Override
-    UniqueId uniqueId.get() {
-        return model.uniqueId;
-     }
+    UniqueId uniqueId.get() = model.uniqueId;
 
     /**
      * The human readable name for the test.
      */
     @Override
-    String displayName;
+    public/private String displayName;
 
     /**
      * The `Class` associated to the current test fixture.
      */
     @Override
-    Class? testClass;
+    public/private Class? testClass;
 
     /**
      * The current test method.
      */
     @Override
-    MethodOrFunction? testMethod;
+    public/private MethodOrFunction? testMethod;
 
     /**
      * The current test fixture the test method will execute against.
      */
     @Override
-    Object? testFixture;
+    public/private Ref<Object>? testFixture;
 
     /**
      * Any `Exception thrown during execution of the test lifecycle.
      */
     @Override
-    Exception? exception;
+    public/private Exception? exception;
 
     /**
      * The `ResourceRegistry` containing resources registered for this execution.
      */
     @Override
-    ResourceRegistry registry;
+    public/private ResourceRegistry registry;
 
     /**
      * The `MethodExecutor` to use to execute tests.
      */
-    MethodExecutor methodExecutor;
+    @Override
+    public/private MethodExecutor methodExecutor;
 
     /**
      * The test `ExecutionListener`.
      */
-    ExecutionListener listener;
+    public/private ExecutionListener listener;
 
     /**
      * The current execution results.
      */
-    Result results = new Result(Successful, count=0);
+    public/private Result results = new Result(Successful, count=0);
 
     /**
      * Create a `Builder` from the specified `Model`.
@@ -112,42 +114,6 @@ service EngineExecutionContext
      * @param model  the `Model` to execute
      */
     Builder asBuilder(Model model) = new Builder(this, model);
-
-    /**
-     * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources
-     * to resolve parameters for the function.
-     *
-     * @param method the `MethodOrFunction` to invoke
-     *
-     * @return the result of invoking the function
-     */
-    @Override
-    Tuple invoke(MethodOrFunction method) {
-        if (method.is(Method)) {
-            assert testFixture != Null;
-            return methodExecutor.invoke(method.as(Method), testFixture, this);
-         }
-        return methodExecutor.invoke(method.as(Function), this);
-     }
-
-    /**
-     * Invoke a `MethodOrFunction` using any registered `ParameterResolver` resources
-     * to resolve parameters for the function and return the single result returned by the
-     * invocation.
-     *
-     * @param method the `MethodOrFunction` to invoke
-     *
-     * @return `True` iff the invocation returned a result
-     * @return the single result of invoking the function
-     */
-    @Override
-    conditional Object invokeSingleResult(MethodOrFunction method) {
-        Tuple tuple = invoke(method);
-        if (tuple.size > 0) {
-            return True, tuple[0];
-         }
-        return False;
-    }
 
     @Override
     conditional Object lookup(Type type, String name, Options opts = Null) {
@@ -250,7 +216,7 @@ service EngineExecutionContext
         /**
          * The current test fixture the test method will execute against.
          */
-        private Object? testFixture = Null;
+        private Ref<Object>? testFixture = Null;
 
         /**
          * Any `Exception`s thrown during execution of the test lifecycle.
@@ -292,7 +258,7 @@ service EngineExecutionContext
             return this;
         }
 
-        Builder withTestFixture(Object? testFixture) {
+        Builder withTestFixture(Ref<Object> testFixture) {
             this.testFixture = testFixture;
             return this;
         }

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/EngineExecutionContext.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/EngineExecutionContext.x
@@ -4,8 +4,6 @@ import xunit.MethodOrFunction;
 
 import xunit.extensions.ExecutionContext;
 
-import xunit.extensions.MethodExecutor;
-
 /**
  * Information about the current phase of execution of a test fixture.
  * A test fixture could be a test method, or a test container.
@@ -27,7 +25,6 @@ service EngineExecutionContext
         this.testFixture    = builder.testFixture;
         this.exception      = builder.exception;
         this.registry       = builder.registry;
-        this.methodExecutor = builder.methodExecutor;
         this.listener       = builder.listener;
     }
 
@@ -77,12 +74,6 @@ service EngineExecutionContext
      */
     @Override
     public/private ResourceRegistry registry;
-
-    /**
-     * The `MethodExecutor` to use to execute tests.
-     */
-    @Override
-    public/private MethodExecutor methodExecutor;
 
     /**
      * The test `ExecutionListener`.
@@ -162,7 +153,6 @@ service EngineExecutionContext
             this.displayName    = model.displayName;
             this.listener       = ExecutionListener.NoOp;
             this.registry       = new SimpleResourceRegistry();
-            this.methodExecutor = new MethodExecutor();
          }
 
         /**
@@ -178,7 +168,6 @@ service EngineExecutionContext
             this.testMethod     = ctx.testMethod;
             this.testFixture    = ctx.testFixture;
             this.exception      = ctx.exception;
-            this.methodExecutor = ctx.methodExecutor;
             this.listener       = ctx.listener;
             this.registry       = ctx.registry.copy();
          }
@@ -227,11 +216,6 @@ service EngineExecutionContext
          * The `ResourceRegistry` containing resources registered for this execution.
          */
         public/private ResourceRegistry registry;
-
-        /**
-         * The `MethodExecutor` to use to execute tests.
-         */
-        private MethodExecutor methodExecutor;
 
         /**
          * The `ExecutionListener`.

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/MethodExecutionLifecycle.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/MethodExecutionLifecycle.x
@@ -7,6 +7,8 @@ import xunit.SkipResult;
 import xunit.annotations.AfterEach.AfterEachFunction;
 import xunit.annotations.BeforeEach.BeforeEachFunction;
 
+import xunit.executor;
+
 import xunit.extensions.AfterEachCallback;
 import xunit.extensions.AfterTestInvocationCallback;
 import xunit.extensions.AroundTestCallback;
@@ -117,7 +119,7 @@ const MethodExecutionLifecycle<ModelType extends MethodModel>(ModelType model)
 
             if (collector.empty) {
                 // only run the test if there have been no errors
-                collector.executeVoid(() -> context.methodExecutor.invoke(model.testMethod, context));
+                collector.executeVoid(() -> executor.invoke(model.testMethod, context));
             }
         }
 

--- a/lib_xunit_engine/src/main/x/xunit_engine/executor/MethodExecutionLifecycle.x
+++ b/lib_xunit_engine/src/main/x/xunit_engine/executor/MethodExecutionLifecycle.x
@@ -41,7 +41,7 @@ const MethodExecutionLifecycle<ModelType extends MethodModel>(ModelType model)
 
         if (context.testFixture == Null) {
             Object fixture = ensureFixture(context, extensions, model.testClass);
-            builder.withTestFixture(fixture);
+            builder.withTestFixture(&fixture);
         }
         return super(builder.build(), extensions);
     }
@@ -117,7 +117,7 @@ const MethodExecutionLifecycle<ModelType extends MethodModel>(ModelType model)
 
             if (collector.empty) {
                 // only run the test if there have been no errors
-                collector.executeVoid(() -> context.invoke(model.testMethod));
+                collector.executeVoid(() -> context.methodExecutor.invoke(model.testMethod, context));
             }
         }
 


### PR DESCRIPTION
- Remove invoke methods from the ExecutionContext so that the context is not blocked during test invocation. Instead, the MethodExecutor is exposed as a property on the ExecutionContext.
- Annotate the EngineExecutionContext service with @Concurrent
- Fix the XUnit -t option to work for executing a single test method