### PR TITLE
Upgrade Gradle to 9.7.1; bump npms and other various dependabot fixes, but mostly related to the VSCode plugin and node. 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ slf4j = "2.0.18"
 download = "5.7.0"
 foojay-resolver = "1.0.0"
 gradle-portal-publish = "2.1.1"
-palantir-git-version = "5.0.0"
+palantir-git-version = "5.1.0"
 vanniktech-maven-publish = "0.37.0"
 
 # =============================================================================

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java
+++ b/javatools/src/main/java/org/xvm/tool/XtcProjectCreator.java
@@ -36,7 +36,7 @@ public class XtcProjectCreator {
      * IDE/CLI builds the bundled wrapper is the single source of truth, so this constant is rarely
      * hit; keep it roughly in sync with the repo wrapper anyway.
      */
-    public static final String DEFAULT_GRADLE_VERSION = "9.7.0";
+    public static final String DEFAULT_GRADLE_VERSION = "9.7.1";
 
     /**
      * Strict pattern for a resolvable XTC version coordinate written into a generated

--- a/lang/vscode-extension/package-lock.json
+++ b/lang/vscode-extension/package-lock.json
@@ -5641,13 +5641,14 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -6042,15 +6043,15 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },

--- a/lang/vscode-extension/package-lock.json
+++ b/lang/vscode-extension/package-lock.json
@@ -834,25 +834,39 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
                 "@humanwhocodes/retry": "^0.4.0"
             },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -1003,9 +1017,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1023,9 +1034,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1043,9 +1051,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1063,9 +1068,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1083,9 +1085,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1103,9 +1102,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1123,9 +1119,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1143,9 +1136,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1163,9 +1153,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1189,9 +1176,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1215,9 +1199,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1241,9 +1222,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1267,9 +1245,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1293,9 +1268,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1319,9 +1291,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1345,9 +1314,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3575,9 +3541,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
Mirrors #533 (the 9.7.0 upgrade): the Gradle version bump plus a minor plugin bump riding along, same as that PR did.

## 1. Gradle 9.7.0 → 9.7.1

- `gradle/wrapper/gradle-wrapper.properties` — distribution URL, produced by the recommended two-pass `./gradlew wrapper --gradle-version 9.7.1 && ./gradlew :wrapper`.
- `javatools/.../XtcProjectCreator.java` — `DEFAULT_GRADLE_VERSION` bumped to match; it is the fallback used when generating a wrapper from scratch and is documented as kept in sync with the repo wrapper.

Deliberately *not* changed, unlike #533:

- `gradle/wrapper/gradle-wrapper.jar` — byte-identical for this patch release (9.6.1 → 9.7.0 was a minor bump, which did change it).
- `build-logic/settings-plugins/build.gradle.kts` — the comment already reads "Gradle 9.7.x embeds Kotlin 2.4.0"; `./gradlew --version` on 9.7.1 confirms Kotlin 2.4.0, so it still holds.
- `version.properties` — `org.xtclang.plugin.minimum.gradle.version=9.2.0` is the *consumer* floor for applying the XTC plugin, intentionally lower and untouched by #533.

CI needs no change: `.github/actions/setup-xvm-project` derives the Gradle version from `gradle-wrapper.properties` rather than pinning it.

### What's in 9.7.1

A bug-fix-only patch (released 2026-08-19). The 9.x upgrade guide has **no** `changes_9.7.1` section — no new deprecations, no breaking changes, nothing for this build to adapt to. Six regressions in 9.7.0 were fixed; two land on surface area this repo actually uses:

- **`BaseExecSpec` streams no longer conforming to the API in 9.7.0** — `DockerCleanupTask` in `build-logic/common-plugins/src/main/kotlin/DockerTasks.kt` sets `standardOutput`/`errorOutput` on an `execOps.exec {}` spec and reads the captured buffer back on failure, so this is a real fix for us rather than a theoretical one.
- **"Click to see difference" formatting broken for failed unit tests** — restores useful assertion diffs in test failure output.

The other four don't apply: no `ant.taskdef` with an explicit classpath, no kapt, no `TransformAction`, and the `@Option` argument-order regression was specific to the Kotlin DSL, whereas this repo's `@Option` usages are all in Java plugin source (`XtcRunTask`, `XtcLauncherTask`).

## 2. vscode-extension lockfile: fast-uri + @humanfs/node

`lang/vscode-extension/package-lock.json`. Clears five Dependabot alerts — **#56-#59** (`fast-uri`, high ×4) and **#53** (`@humanfs/node`, moderate).

Both are transitive, but their parents' semver ranges already permitted the patched versions (`ajv` wants `fast-uri@^3.0.1`, `eslint` wants `@humanfs/node@^0.16.6`), so a lockfile refresh was sufficient — no parent upgrade, no API risk. Both are `dev: true` and never ship in the packaged `.vsix`.

- `fast-uri` 3.1.5 → 3.1.7
- `@humanfs/node` 0.16.7 → 0.16.8
- pulls `@humanfs/core` 0.19.1 → 0.19.2 and the new `@humanfs/types` 0.15.0

The diff also drops 16 `"libc"` blocks from optional `sharp` binaries. That is deliberate, not churn: `libc` is an npm 11 field, and this build pins Node 22.21.1 / npm **10.9.4** via `gradle-node-plugin`, which strips it on every `npmInstall`. The committed file previously carried npm-11-written metadata, so *any* local extension build dirtied the working tree; it now matches what the pinned toolchain actually emits and a repeat build leaves it untouched. The musl Docker image consumes the XDK dist zip and never runs npm, so nothing depends on that metadata.

Verified: `npm audit` clears both advisories, `:lang:vscode-extension:build` packages the vsix, `eslint` exits 0, and a second build produces no further lockfile change.

### Dependabot alerts left open, and why

The remaining 10 are all Gradle build-time tooling, none of it in shipped runtime code, and none currently actionable:

| Alerts | Package | Flagged version | Pulled by | Status |
|---|---|---|---|---|
| #17, #22, #24, #26, #28, #38 | jackson-core / databind | 2.14.2 | `com.github.node-gradle:gradle-node-plugin` | already on 7.1.0, the latest |
| #18, #30, #32 | logback-core | 1.3.16 | `com.pinterest.ktlint:ktlint-cli` | already on 1.8.0, the latest |
| #52 | kotlin-gradle-plugin | 2.4.0 | `org.gradle.kotlin:gradle-kotlin-dsl-plugins` (Gradle's embedded Kotlin DSL) | only patch is `2.4.20-Beta1`, a prerelease |

Worth noting these do **not** implicate our own declared versions: `lang-logback` resolves `logback-core:1.6.3` and the intellij-plugin graph resolves jackson `2.21.5`, both above every vulnerable range. The flagged copies are the plugins' private transitive pins.
